### PR TITLE
Properly initialize whitelist and ignore_groups if no config/license_finder.yml is found

### DIFF
--- a/lib/license_finder/finder.rb
+++ b/lib/license_finder/finder.rb
@@ -3,11 +3,15 @@ module LicenseFinder
 
     attr_reader :whitelist, :ignore_groups
     def initialize
-      if File.exists?('./config/license_finder.yml')
-        config = YAML.load(File.open('./config/license_finder.yml').readlines.join)
-        @whitelist = config['whitelist'] || []
-        @ignore_groups = config['ignore_groups'] ? config['ignore_groups'].map{|g| g.to_sym} : []
+      config = case 
+        when File.exists?('./config/license_finder.yml')
+          YAML.load(File.open('./config/license_finder.yml').readlines.join)
+        else
+          {'whitelist' => [], 'ignore_groups' => []}
       end
+      
+      @whitelist = config['whitelist']
+      @ignore_groups = config['ignore_groups'].map{|g| g.to_sym}
     end
 
     def from_bundler

--- a/spec/finder_spec.rb
+++ b/spec/finder_spec.rb
@@ -1,6 +1,14 @@
 require 'spec_helper'
 
 describe LicenseFinder::Finder do
+
+  it "should properly initialize whitelist and ignore_groups" do
+    stub(File).exists?('./config/license_finder.yml') {false}
+    finder = LicenseFinder::Finder.new
+    finder.whitelist.should_not be_nil
+    finder.ignore_groups.should_not be_nil
+  end
+
   it "should generate a yml file and txt file" do
     stub(File).exists?('./config/license_finder.yml') {false}
     stub(File).exists?('./dependencies.yml') {false}


### PR DESCRIPTION
When no config/license_finder.yml file exists, LicenseFinder will crash when running from the supplied rake task. This commit provides a failing test for that condition, and a fix that properly initializes those instance variables.
