### PR TITLE
Allow dependencies file directory to be configured

### DIFF
--- a/files/license_finder.yml
+++ b/files/license_finder.yml
@@ -1,7 +1,8 @@
---- 
-whitelist: 
+---
+whitelist:
 #- MIT
 #- Apache 2.0
 ignore_groups:
 #- test
 #- development
+dependencies_file_dir: './'

--- a/lib/license_finder/finder.rb
+++ b/lib/license_finder/finder.rb
@@ -7,7 +7,20 @@ module LicenseFinder
         config = YAML.load(File.open('./config/license_finder.yml').readlines.join)
         @whitelist = config['whitelist'] || []
         @ignore_groups = config['ignore_groups'] ? config['ignore_groups'].map{|g| g.to_sym} : []
+        @dependencies_dir = config['dependencies_file_dir']
       end
+    end
+
+    def dependencies_dir
+      @dependencies_dir || './'
+    end
+
+    def dependencies_yaml
+      File.join(dependencies_dir, 'dependencies.yml')
+    end
+
+    def dependencies_text
+      File.join(dependencies_dir, 'dependencies.txt')
     end
 
     def from_bundler
@@ -18,10 +31,10 @@ module LicenseFinder
     def write_files
       new_list = generate_list
 
-      File.open('./dependencies.yml', 'w+') do |f|
+      File.open(dependencies_yaml, 'w+') do |f|
         f.puts new_list.to_yaml
       end
-      File.open('./dependencies.txt', 'w+') do |f|
+      File.open(dependencies_text, 'w+') do |f|
         f.puts new_list.to_s
       end
 
@@ -36,8 +49,8 @@ module LicenseFinder
     def generate_list
       bundler_list = DependencyList.from_bundler(whitelist, ignore_groups)
 
-      if (File.exists?('./dependencies.yml'))
-        yml = File.open('./dependencies.yml').readlines.join
+      if (File.exists?(dependencies_yaml))
+        yml = File.open(dependencies_yaml).readlines.join
         existing_list = DependencyList.from_yaml(yml)
         existing_list.merge(bundler_list)
       else

--- a/spec/finder_spec.rb
+++ b/spec/finder_spec.rb
@@ -41,4 +41,13 @@ describe LicenseFinder::Finder do
     stub(File).open('./config/license_finder.yml').stub!.readlines.stub!.join {"--- \nwhitelist: \n- MIT\n- Apache\nignore_groups: \n- test\n- development\n"}
     LicenseFinder::Finder.new.ignore_groups.should == [:test, :development]
   end
+
+  it 'should allow the dependencies file directory to be configured' do
+    stub(File).exists?('./config/license_finder.yml') {true}
+    stub(File).open('./config/license_finder.yml').stub!.readlines.stub!.join {"--- \nwhitelist: \n- MIT\n- Apache\nignore_groups: \n- test\n- development\ndependencies_file_dir: './elsewhere'\n"}
+    finder = LicenseFinder::Finder.new
+    finder.dependencies_dir.should == './elsewhere'
+    finder.dependencies_yaml.should == './elsewhere/dependencies.yml'
+    finder.dependencies_text.should == './elsewhere/dependencies.txt'
+  end
 end


### PR DESCRIPTION
Allow projects to configure the location where dependencies.txt
and dependencies.yml are written using the dependencies_file_dir
config variable.
