### PR TITLE
Adding output to rake task for CI

### DIFF
--- a/lib/tasks/license_finder.rake
+++ b/lib/tasks/license_finder.rake
@@ -14,9 +14,16 @@ namespace :license do
     puts "Dependencies that need approval:"
     puts LicenseFinder::Finder.new.action_items
   end
-  
+
   desc 'All gems approved for use'
   task 'action_items:ok' => :generate_dependencies do
-    exit 1 unless LicenseFinder::Finder.new.action_items.size == 0
+    found = LicenseFinder::Finder.new.action_items
+    if found.size > 0
+      puts "Dependencies that need approval:"
+      puts found
+    else
+      puts "All gems are approved for use"
+    end
+    exit 1 unless found.size == 0
   end
 end


### PR DESCRIPTION
Right now you just get a failure with no feedback in CI in the console output. This pull request adds in some text output that you already see in rake license:action_items. 
