### PR TITLE
add short name for apache license according to spdx license list

### DIFF
--- a/lib/license_finder/license/apache2.rb
+++ b/lib/license_finder/license/apache2.rb
@@ -1,5 +1,5 @@
 class LicenseFinder::License::Apache2 < LicenseFinder::License::Base
-  self.alternative_names = ["Apache 2.0", "Apache2"]
+  self.alternative_names = ["Apache 2.0", "Apache2", "Apache-2.0"]
   self.license_url       = "http://www.apache.org/licenses/LICENSE-2.0.txt"
 
   def self.pretty_name


### PR DESCRIPTION
http://spdx.org/licenses/ is a list of commonly found open source
software licenses for the purposes of being able to easily and
efficiently identify such licenses in an Software Package Data
Exchange (rpm, deb).

Please add this identifier so that we can easily use it when packaging software for linux.
