### PR TITLE
Fix Sequel loader to escape paths with spaces in them

### DIFF
--- a/lib/license_finder/tables.rb
+++ b/lib/license_finder/tables.rb
@@ -2,7 +2,6 @@ require 'rubygems'
 require 'sequel'
 require LicenseFinder::Platform.sqlite_load_path
 
-#DB = Sequel.connect(URI.escape("#{LicenseFinder::Platform.sqlite_adapter}://#{LicenseFinder.config.database_path}"))
-DB = Sequel.connect("#{LicenseFinder::Platform.sqlite_adapter}://#{LicenseFinder.config.database_path}")
+DB = Sequel.connect(URI.escape("#{LicenseFinder::Platform.sqlite_adapter}://#{LicenseFinder.config.database_path}"))
 Sequel.extension :migration, :core_extensions
 Sequel::Migrator.run(DB, LicenseFinder::ROOT_PATH.join('../db/migrate'))


### PR DESCRIPTION
When the working directory to the source has a space in it, the URI sent to Sequel is not properly escaped causing the `require` call to raise an error:

```
$ bundle exec license_finder
/Users/jeremywadsack/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/uri/common.rb:176:in `split': bad URI(is not URI?): sqlite:///Users/jeremywadsack/Source/License Finder/doc/dependencies.db (URI::InvalidURIError)
    from /Users/jeremywadsack/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/uri/common.rb:211:in `parse'
    from /Users/jeremywadsack/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/uri/common.rb:747:in `parse'
    from /Users/jeremywadsack/.rvm/gems/ruby-1.9.3-p194@licensefinder/gems/sequel-3.46.0/lib/sequel/database/connecting.rb:52:in `connect'
    from /Users/jeremywadsack/.rvm/gems/ruby-1.9.3-p194@licensefinder/gems/sequel-3.46.0/lib/sequel/core.rb:147:in `connect'
    from /Users/jeremywadsack/Source/License Finder/lib/license_finder/tables.rb:5:in `<top (required)>'
    from /Users/jeremywadsack/Source/License Finder/lib/license_finder.rb:45:in `require'
    from /Users/jeremywadsack/Source/License Finder/lib/license_finder.rb:45:in `<top (required)>'
    from /Users/jeremywadsack/Source/License Finder/bin/license_finder:3:in `require'
    from /Users/jeremywadsack/Source/License Finder/bin/license_finder:3:in `<top (required)>'
    from /Users/jeremywadsack/.rvm/gems/ruby-1.9.3-p194@licensefinder/bin/license_finder:23:in `load'
    from /Users/jeremywadsack/.rvm/gems/ruby-1.9.3-p194@licensefinder/bin/license_finder:23:in `<main>'
```

This pull request fixes the issue. I tried to spec this, but couldn't come up with a way to test the require statement. I'm sure that's just a pattern I need to learn.
