### PR TITLE
remove devDependencies from the search list

### DIFF
--- a/lib/license_finder/npm.rb
+++ b/lib/license_finder/npm.rb
@@ -4,7 +4,7 @@ require 'license_finder/package'
 module LicenseFinder
   class NPM
 
-    DEPENDENCY_GROUPS = ["dependencies", "devDependencies", "bundleDependencies", "bundledDependencies"]
+    DEPENDENCY_GROUPS = ["dependencies", "bundleDependencies", "bundledDependencies"]
 
     def self.current_modules
       return @modules if @modules


### PR DESCRIPTION
`npm list --long --json` does not return the same details as the regular dependencies block. The truncated information causes license_finder to crash. see pivotal/LicenseFinder#65
