### PR TITLE
Improve tables.rb readability

### DIFF
--- a/lib/license_finder/tables.rb
+++ b/lib/license_finder/tables.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'sequel'
 require LicenseFinder::Platform.sqlite_load_path
 


### PR DESCRIPTION
Remove excessive namespacing of constants in tables.rb by nesting code inside a module declaration.
