### PR TITLE
Consolidate slow HtmlReport specs to speed up test suite

### DIFF
--- a/spec/lib/license_finder/reports/html_report_spec.rb
+++ b/spec/lib/license_finder/reports/html_report_spec.rb
@@ -15,11 +15,8 @@ module LicenseFinder
       context "when the dependency is manually approved" do
         before { dependency.approve! "the-approver", "the-approval-note" }
 
-        it "should add an approved class to dependency's container" do
+        it "should show approved dependencies without action items" do
           should have_selector ".approved"
-        end
-
-        it "does not list the dependency in the action items" do
           should_not have_selector ".action-items"
         end
 
@@ -35,11 +32,8 @@ module LicenseFinder
       context "when the dependency is whitelisted" do
         before { dependency.stub(whitelisted?: true) }
 
-        it "should add an approved class to dependency's container" do
+        it "should show approved dependencies without action items" do
           should have_selector ".approved"
-        end
-
-        it "does not list the dependency in the action items" do
           should_not have_selector ".action-items"
         end
 
@@ -55,56 +49,32 @@ module LicenseFinder
           dependency.manual_approval = nil
         }
 
-        it "should not add an approved class to he dependency's container" do
+        it "should show unapproved dependencies with action items" do
           should have_selector ".unapproved"
-        end
-
-        it "lists the dependency in the action items" do
           should have_selector ".action-items li"
         end
       end
 
-      context "when the gem has at least one bundler group" do
-        before { dependency.stub(bundler_groups: [double(name: "group")]) }
-        it "should show the bundler group(s) in parens" do
-          should have_text "(group)"
-        end
-      end
-
-      context "when the gem has no bundler groups" do
-        before { dependency.stub(bundler_groups: []) }
-
-        it "should not show any parens or bundler group info" do
-          should_not have_text "()"
+      context "when the gem has many relationships" do
+        before do
+          dependency.stub(bundler_groups: [double(name: "foo group")],
+                          parents: [double(name: "foo parent")],
+                          children: [double(name: "foo child")])
         end
 
-      end
-
-      context "when the gem has at least one parent" do
-        before { dependency.stub(parents: [double(:name => "foo parent")]) }
-        it "should include a parents section" do
+        it "should show the relationships" do
+          should have_text "(foo group)"
           should have_text "Parents"
           should have_text "foo parent"
-        end
-      end
-
-      context "when the gem has no parents" do
-        it "should not include any parents section in the output" do
-          should_not have_text "Parents"
-        end
-      end
-
-      context "when the gem has at least one child" do
-        before { dependency.stub(children: [double(:name => "foo child")]) }
-
-        it "should include a Children section" do
           should have_text "Children"
           should have_text "foo child"
         end
       end
 
-      context "when the gem has no children" do
-        it "should not include any Children section in the output" do
+      context "when the gem has no relationships" do
+        it "should not show any relationships" do
+          should_not have_text "()"
+          should_not have_text "Parents"
           should_not have_text "Children"
         end
       end


### PR DESCRIPTION
Nokogiri tests are slow, so run more assertions per Nokogiri parse.
