### PR TITLE
Allow more licenses to match on text

### DIFF
--- a/lib/license_finder/license/text.rb
+++ b/lib/license_finder/license/text.rb
@@ -8,6 +8,7 @@ module LicenseFinder
       def self.normalize_punctuation(text)
         text.gsub(SPACES, ' ')
             .gsub(QUOTES, '"')
+            .strip
       end
 
       def self.compile_to_regex(text)

--- a/spec/lib/license_finder/license_spec.rb
+++ b/spec/lib/license_finder/license_spec.rb
@@ -119,6 +119,12 @@ module LicenseFinder
           shall not be held "responsible" for `anything`.
         FILE
       end
+
+      it "should match even if whitespace at beginning and end don't match" do
+        template = License::Template.new("\nThe license text")
+        license = make_license(matcher: License::Matcher.from_template(template))
+        license.should be_matches_text "The license text\n"
+      end
     end
 
     it "should default pretty_name to short_name" do


### PR DESCRIPTION
By not caring whether the license file has extra whitespace at the beginning or end.
