### PR TITLE
Speed up tests again.

### DIFF
--- a/spec/lib/license_finder/cli_spec.rb
+++ b/spec/lib/license_finder/cli_spec.rb
@@ -57,7 +57,7 @@ module LicenseFinder
         it "adds the specified license to the whitelist" do
           config.whitelist.should_receive(:push).with("test")
           config.should_receive(:save)
-          Reporter.should_receive(:write_reports)
+          expect(DependencyManager).to receive(:sync_with_package_managers)
 
           silence_stdout do
             subject.add("test")
@@ -68,7 +68,7 @@ module LicenseFinder
           config.whitelist.should_receive(:push).with("test")
           config.whitelist.should_receive(:push).with("rest")
           config.should_receive(:save)
-          Reporter.should_receive(:write_reports)
+          expect(DependencyManager).to receive(:sync_with_package_managers)
 
           silence_stdout do
             subject.add("test", "rest")
@@ -80,7 +80,7 @@ module LicenseFinder
         it "removes the specified license from the whitelist" do
           config.should_receive(:save)
           config.whitelist.should_receive(:delete).with("test")
-          Reporter.should_receive(:write_reports)
+          expect(DependencyManager).to receive(:sync_with_package_managers)
 
           silence_stdout do
 
@@ -92,7 +92,7 @@ module LicenseFinder
           config.should_receive(:save)
           config.whitelist.should_receive(:delete).with("test")
           config.whitelist.should_receive(:delete).with("rest")
-          Reporter.should_receive(:write_reports)
+          expect(DependencyManager).to receive(:sync_with_package_managers)
 
           silence_stdout do
             subject.remove("test", "rest")
@@ -108,7 +108,7 @@ module LicenseFinder
         it "sets the project name" do
           config.should_receive(:save)
           config.project_name.should_not eq("new_project_name")
-          Reporter.should_receive(:write_reports)
+          expect(DependencyManager).to receive(:sync_with_package_managers)
 
           silence_stdout do
             subject.set("new_project_name")
@@ -134,7 +134,7 @@ module LicenseFinder
         it "adds the specified group to the ignored groups list" do
           config.ignore_groups.should_receive(:push).with("test")
           config.should_receive(:save)
-          Reporter.should_receive(:write_reports)
+          expect(DependencyManager).to receive(:sync_with_package_managers)
 
           silence_stdout do
             subject.add("test")
@@ -146,7 +146,7 @@ module LicenseFinder
         it "removes the specified group from the ignored groups list" do
           config.ignore_groups.should_receive(:delete).with("test")
           config.should_receive(:save)
-          Reporter.should_receive(:write_reports)
+          expect(DependencyManager).to receive(:sync_with_package_managers)
 
           silence_stdout do
             subject.remove("test")
@@ -178,7 +178,7 @@ module LicenseFinder
         it "adds the specified group to the ignored groups list" do
           config.ignore_dependencies.should_receive(:push).with("test")
           config.should_receive(:save)
-          Reporter.should_receive(:write_reports)
+          expect(DependencyManager).to receive(:sync_with_package_managers)
 
           silence_stdout do
             subject.add("test")
@@ -190,7 +190,7 @@ module LicenseFinder
         it "removes the specified group from the ignored groups list" do
           config.ignore_dependencies.should_receive(:delete).with("test")
           config.should_receive(:save)
-          Reporter.should_receive(:write_reports)
+          expect(DependencyManager).to receive(:sync_with_package_managers)
 
           silence_stdout do
             subject.remove("test")


### PR DESCRIPTION
This is a better testing pattern anyway - only stubbing direct dependencies, not dependencies' dependencies.
