### PR TITLE
When an NPM package misdeclared its "licenses" as a Hash, deal with it.

### DIFF
--- a/lib/license_finder/package.rb
+++ b/lib/license_finder/package.rb
@@ -8,6 +8,7 @@ module LicenseFinder
   class Package
     def self.license_names_from_standard_spec(spec)
       licenses = spec["licenses"] || [spec["license"]].compact
+      licenses = [licenses] unless licenses.is_a?(Array)
       licenses.map do |license|
         if license.is_a? Hash
           license["type"]

--- a/spec/lib/license_finder/package_managers/npm_package_spec.rb
+++ b/spec/lib/license_finder/package_managers/npm_package_spec.rb
@@ -32,12 +32,14 @@ module LicenseFinder
       let(:node_module2) { {"licenses" => [{"type" => "BSD"}], "path" => "/some/path"} }
       let(:node_module3) { {"license" => {"type" => "PSF"}, "path" => "/some/path"} }
       let(:node_module4) { {"licenses" => ["MIT"], "path" => "/some/path"} }
+      let(:misdeclared_node_module) { {"licenses" => {"type" => "MIT"}} }
 
       it 'finds the license for both license structures' do
         NpmPackage.new(node_module1).license.name.should eq("MIT")
         NpmPackage.new(node_module2).license.name.should eq("BSD")
         NpmPackage.new(node_module3).license.name.should eq("Python Software Foundation License")
         NpmPackage.new(node_module4).license.name.should eq("MIT")
+        NpmPackage.new(misdeclared_node_module).license.name.should eq("MIT")
       end
 
       context "regardless of whether there are licenses in files" do


### PR DESCRIPTION
When an NPM package misdeclared its "licenses" as a Hash (and not an array of hashes), deal with it. :sunglasses:

For example, see grunt-concurrent v0.5.0.

Fixes #108.
