### PR TITLE
Stop looking at bundled dependencies for node.js

### DIFF
--- a/lib/license_finder/package_managers/npm.rb
+++ b/lib/license_finder/package_managers/npm.rb
@@ -2,7 +2,7 @@ require 'json'
 
 module LicenseFinder
   class NPM
-    DEPENDENCY_GROUPS = ["dependencies", "devDependencies", "bundleDependencies", "bundledDependencies"]
+    DEPENDENCY_GROUPS = ["dependencies", "devDependencies"]
 
     def self.current_packages
       json = npm_json

--- a/spec/lib/license_finder/package_managers/npm_spec.rb
+++ b/spec/lib/license_finder/package_managers/npm_spec.rb
@@ -33,24 +33,6 @@ module LicenseFinder
                 "path": "/path/to/thing3"
               }
             },
-            "bundledDependencies": {
-              "dependency4.js": {
-                "name": "dep4js",
-                "version": "4.2",
-                "description": "description4",
-                "readme": "readme4",
-                "path": "/path/to/thing4"
-              }
-            },
-            "bundleDependencies": {
-              "dependency5.js": {
-                "name": "dep5js",
-                "version": "4.2",
-                "description": "description5",
-                "readme": "readme5",
-                "path": "/path/to/thing5"
-              }
-            },
             "notADependency": {
               "dependency6.js": {
                 "name": "dep6js",
@@ -66,7 +48,7 @@ module LicenseFinder
 
         current_packages = NPM.current_packages
 
-        expect(current_packages.map(&:name)).to eq(["depjs", "dep2js", "dep3js", "dep5js", "dep4js"])
+        expect(current_packages.map(&:name)).to eq(["depjs", "dep2js", "dep3js"])
         expect(current_packages.first).to be_a(Package)
         expect(current_packages.first.name).to eq("depjs")
       end


### PR DESCRIPTION
This feature never worked, and probably never could. The `bundleDependencies` and `bundledDependencies` keys in npm’s JSON output don't have the metadata we need to collect licenses; they are just arrays of package names. 

These names are not a way to point to and install third-party dependencies, and thus there's no way to know what their licenses are. It seems that developers use this feature in combination with `dependencies` to mark some dependencies as being fully included in the npm package archive. See http://stackoverflow.com/a/25044361

Actual output from `npm info --json --long` would look like this:

``` javascript
     bundleDependencies:
      [ 'nopt',
        'npmlog',
        'request',
        'semver',
        'tar',
        'tar-pack',
        'mkdirp',
        'rc',
        'rimraf' ],
```

cc @nertzy 
