### PR TITLE
Don’t use readme as description for npm packages

### DIFF
--- a/lib/license_finder/package_managers/npm_package.rb
+++ b/lib/license_finder/package_managers/npm_package.rb
@@ -13,11 +13,11 @@ module LicenseFinder
     end
 
     def summary
-      node_module["description"]
+      nil
     end
 
     def description
-      node_module["readme"]
+      node_module["description"]
     end
 
     def homepage

--- a/spec/lib/license_finder/package_managers/npm_package_spec.rb
+++ b/spec/lib/license_finder/package_managers/npm_package_spec.rb
@@ -17,8 +17,8 @@ module LicenseFinder
 
     its(:name) { should == "jasmine-node" }
     its(:version) { should == "1.3.1" }
-    its(:summary) { should == "a description" }
-    its(:description) { should == "a readme" }
+    its(:summary) { should be_nil }
+    its(:description) { should == "a description" }
     its(:homepage) { should == "a homepage" }
     its(:groups) { should == [] }
     its(:children) { should == [] }


### PR DESCRIPTION
Using the full readme is way too verbose. Since node doesn’t have a convention of a short and a long description, we should just use the only description as the description and not have a summary. This makes the output vastly more readable.

cc @nertzy
