### PR TITLE
[fixes #83982776] Improve reporting output for dependencies that have no...

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ Dependencies that need approval:
 highline, 1.6.14, ruby
 json, 1.7.5, ruby
 mime-types, 1.19, ruby
-rails, 3.2.8, other
-rdoc, 3.12, other
+rails, 3.2.8, unknown
+rdoc, 3.12, unknown
 rubyzip, 0.9.9, ruby
-xml-simple, 1.1.1, other
+xml-simple, 1.1.1, unknown
 ```
 
 ### Files and Reports
@@ -139,7 +139,7 @@ project name at the top of the report can be set in
 
 ### Setting Licenses
 
-When `license_finder` reports that a dependency's license is 'other',
+When `license_finder` reports that a dependency's license is 'unknown',
 you should manually research what the actual license is.  When you
 have established the real license, you can record it with:
 

--- a/db/migrate/201412151140_add_missing_to_dependencies.rb
+++ b/db/migrate/201412151140_add_missing_to_dependencies.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:dependencies) do
+      add_column :missing, TrueClass
+    end
+  end
+end

--- a/features/step_definitions/manually_assigned_license_steps.rb
+++ b/features/step_definitions/manually_assigned_license_steps.rb
@@ -1,8 +1,8 @@
 Given(/^I have an app that depends on a few gems without known licenses$/) do
   @user = ::DSL::User.new
   @user.create_ruby_app
-  @user.create_and_depend_on_gem 'other_gem', version: '1.0', license: 'other'
-  @user.create_and_depend_on_gem 'control_gem', version: '1.0', license: 'other'
+  @user.create_and_depend_on_gem 'other_gem', version: '1.0', license: 'unknown'
+  @user.create_and_depend_on_gem 'control_gem', version: '1.0', license: 'unknown'
 end
 
 When(/^I set one gem's license to MIT from the command line$/) do
@@ -16,7 +16,7 @@ Then(/^I should see that gem's license set to MIT$/) do
 end
 
 Then(/^I should see other gems have not changed their licenses$/) do
-  expect(@user).to be_seeing 'control_gem, 1.0, other'
+  expect(@user).to be_seeing 'control_gem, 1.0, unknown'
 end
 
 Given(/^I have an app that depends on a manually licensed gem$/) do

--- a/features/step_definitions/shared_steps.rb
+++ b/features/step_definitions/shared_steps.rb
@@ -16,7 +16,7 @@ When(/^I run license_finder$/) do
 end
 
 When(/^I whitelist everything I can think of$/) do
-  whitelist = ["MIT","other","New BSD","Apache 2.0","Ruby"]
+  whitelist = ["MIT","unknown","New BSD","Apache 2.0","Ruby"]
   whitelist += ["BSD","Apache-2","Apache"] # for JRuby
   @user.configure_license_finder_whitelist whitelist
   @user.execute_command "license_finder --quiet"

--- a/lib/license_finder/license.rb
+++ b/lib/license_finder/license.rb
@@ -6,7 +6,7 @@ module LicenseFinder
       end
 
       def find_by_name(name)
-        name ||= "other"
+        name ||= "unknown"
         all.detect { |l| l.matches_name? name } || Definitions.build_unrecognized(name, LicenseFinder.config.whitelist)
       end
 

--- a/lib/license_finder/package.rb
+++ b/lib/license_finder/package.rb
@@ -74,5 +74,10 @@ module LicenseFinder
     def install_path
       nil
     end
+
+    def missing
+      false
+    end
+
   end
 end

--- a/lib/license_finder/package_managers/bower_package.rb
+++ b/lib/license_finder/package_managers/bower_package.rb
@@ -4,14 +4,23 @@ module LicenseFinder
       super options
       @bower_module = bower_module
       @module_metadata = bower_module.fetch("pkgMeta", Hash.new)
+      @module_endpoint = bower_module.fetch("endpoint", Hash.new)
     end
 
     def name
-      module_metadata.fetch("name", nil)
+      if module_metadata.empty?
+        module_endpoint.fetch("name", nil)
+      else
+        module_metadata.fetch("name", nil)
+      end
     end
 
     def version
-      module_metadata.fetch("version", nil)
+      if module_metadata.empty?
+        module_endpoint.fetch("target", nil)
+      else
+        module_metadata.fetch("version", nil)
+      end
     end
 
     def summary
@@ -26,6 +35,10 @@ module LicenseFinder
       module_metadata.fetch("homepage", nil)
     end
 
+    def missing
+      bower_module.fetch("missing", nil)
+    end
+
     def children
       [] # no way to determine child deps from bower (maybe?)
     end
@@ -38,6 +51,7 @@ module LicenseFinder
 
     attr_reader :bower_module
     attr_reader :module_metadata
+    attr_reader :module_endpoint
 
     def install_path
       bower_module["canonicalDir"]

--- a/lib/license_finder/package_saver.rb
+++ b/lib/license_finder/package_saver.rb
@@ -3,7 +3,7 @@ require 'forwardable'
 module LicenseFinder
   class PackageSaver
     extend Forwardable
-    def_delegators :package, :licenses, :children, :groups, :summary, :description, :version, :homepage
+    def_delegators :package, :licenses, :children, :groups, :summary, :description, :version, :homepage, :missing
 
     attr_reader :dependency, :package
 
@@ -26,6 +26,7 @@ module LicenseFinder
       dependency.bundler_group_names = groups.map(&:to_s)
       dependency.children_names = children
       dependency.set_licenses licenses
+      dependency.missing = missing
 
       # Only save *changed* dependencies. This ensures re-running
       # `license_finder` won't always update the DB, and therefore won't always

--- a/lib/license_finder/reports/text_report.rb
+++ b/lib/license_finder/reports/text_report.rb
@@ -4,12 +4,13 @@ module LicenseFinder
   class TextReport < DependencyReport
     def to_s
       CSV.generate(col_sep: ", ") do |csv|
+        missing_dependency_text = "This package is not installed. Please install to determine licenses."
         sorted_dependencies.each do |s|
-          csv << [
-            s.name,
-            s.version,
-            s.licenses.map(&:name).join(', ')
-          ]
+            csv << [
+                s.name,
+                s.version,
+                s.missing ? missing_dependency_text : s.licenses.map(&:name).join(', ')
+            ]
         end
       end
     end

--- a/spec/lib/license_finder/dependency_manager_spec.rb
+++ b/spec/lib/license_finder/dependency_manager_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module LicenseFinder
   describe DependencyManager do
-    let(:config) { Configuration.new('whitelist' => ['MIT', 'other']) }
+    let(:config) { Configuration.new('whitelist' => ['MIT', 'unknown']) }
     let(:dependency_manager) { DependencyManager.new }
 
     before do

--- a/spec/lib/license_finder/license_spec.rb
+++ b/spec/lib/license_finder/license_spec.rb
@@ -15,8 +15,8 @@ module LicenseFinder
       end
 
       context "making the default license" do
-        it "set the name to 'other'" do
-          expect(License.find_by_name(nil).name).to eq("other")
+        it "set the name to 'unknown'" do
+          expect(License.find_by_name(nil).name).to eq("unknown")
         end
 
         it "does not equal other uses of the default license" do
@@ -29,7 +29,7 @@ module LicenseFinder
           end
 
           it "does not blow up" do
-            expect(License.find_by_name(nil).name).to eq("other")
+            expect(License.find_by_name(nil).name).to eq("unknown")
           end
         end
       end

--- a/spec/lib/license_finder/package_managers/bundler_package_spec.rb
+++ b/spec/lib/license_finder/package_managers/bundler_package_spec.rb
@@ -66,11 +66,11 @@ module LicenseFinder
           expect(subject.licenses.first.name).to eq "MIT"
         end
 
-        it "returns 'other' if there are no licenses in files" do
+        it "returns 'unknown' if there are no licenses in files" do
           stub_license_files []
 
           expect(subject.licenses.length).to eq 1
-          expect(subject.licenses.first.name).to eq "other"
+          expect(subject.licenses.first.name).to eq "unknown"
         end
 
         it "returns 'multiple licenses' if there are many licenses in files" do

--- a/spec/lib/license_finder/package_managers/cocoa_pods_package_spec.rb
+++ b/spec/lib/license_finder/package_managers/cocoa_pods_package_spec.rb
@@ -29,17 +29,17 @@ module LicenseFinder
           expect(subject.licenses.first.name).to eq "LicenseName"
         end
 
-        it "returns other if the license can't be found by text" do
+        it "returns unknown if the license can't be found by text" do
           allow(License).to receive(:find_by_text).with(license_text).and_return(nil)
 
           expect(subject.licenses.length).to eq 1
-          expect(subject.licenses.first.name).to eq "other"
+          expect(subject.licenses.first.name).to eq "unknown"
         end
       end
 
-      it "returns other when there's no license" do
+      it "returns unknown when there's no license" do
         expect(subject.licenses.length).to eq 1
-        expect(subject.licenses.first.name).to eq "other"
+        expect(subject.licenses.first.name).to eq "unknown"
       end
     end
   end

--- a/spec/lib/license_finder/package_managers/gradle_package_spec.rb
+++ b/spec/lib/license_finder/package_managers/gradle_package_spec.rb
@@ -57,9 +57,9 @@ module LicenseFinder
           )
         end
 
-        it "returns 'other' otherwise" do
+        it "returns 'unknown' otherwise" do
           expect(subject.licenses.length).to eq 1
-          expect(subject.licenses.first.name).to eq "other"
+          expect(subject.licenses.first.name).to eq "unknown"
         end
       end
     end

--- a/spec/lib/license_finder/package_managers/maven_package_spec.rb
+++ b/spec/lib/license_finder/package_managers/maven_package_spec.rb
@@ -63,9 +63,9 @@ module LicenseFinder
           )
         end
 
-        it "returns 'other' otherwise" do
+        it "returns 'unknown' otherwise" do
           expect(subject.licenses.length).to eq 1
-          expect(subject.licenses.first.name).to eq "other"
+          expect(subject.licenses.first.name).to eq "unknown"
         end
       end
     end

--- a/spec/lib/license_finder/package_managers/npm_package_spec.rb
+++ b/spec/lib/license_finder/package_managers/npm_package_spec.rb
@@ -85,14 +85,14 @@ module LicenseFinder
           expect(subject.licenses.first.name).to eq "MIT"
         end
 
-        it "returns 'other' if there are no licenses in files" do
+        it "returns 'unknown' if there are no licenses in files" do
           stub_license_files []
 
           expect(subject.licenses.length).to eq 1
-          expect(subject.licenses.first.name).to eq "other"
+          expect(subject.licenses.first.name).to eq "unknown"
         end
 
-        it "returns 'other' if there are many licenses in files" do
+        it "returns 'unknown' if there are many licenses in files" do
           stub_license_files([
             double(:first_file, license: License.find_by_name('First Detected License'), path: "/"),
             double(:second_file, license: License.find_by_name('Second Detected License'), path: "/")

--- a/spec/lib/license_finder/package_managers/pip_package_spec.rb
+++ b/spec/lib/license_finder/package_managers/pip_package_spec.rb
@@ -105,10 +105,10 @@ module LicenseFinder
           expect(subject.licenses.first.name).to eq('License from file')
         end
 
-        it 'returns other if no license can be found' do
+        it 'returns unknown if no license can be found' do
           stub_license_files []
           expect(subject.licenses.length).to eq 1
-          expect(subject.licenses.first.name).to eq('other')
+          expect(subject.licenses.first.name).to eq('unknown')
         end
       end
     end

--- a/spec/lib/license_finder/package_saver_spec.rb
+++ b/spec/lib/license_finder/package_saver_spec.rb
@@ -12,7 +12,8 @@ module LicenseFinder
         description: 'description',
         name: 'spec_name',
         version: '1.2.3',
-        homepage: 'http://example.com'
+        homepage: 'http://example.com',
+        missing: false,
       )
     end
 

--- a/spec/lib/license_finder/reports/markdown_report_spec.rb
+++ b/spec/lib/license_finder/reports/markdown_report_spec.rb
@@ -7,7 +7,7 @@ module LicenseFinder
         Dependency.new(
           'name' => 'gem_a',
           'version' => '1.0',
-          'licenses' => [License.find_by_name('other')].to_set
+          'licenses' => [License.find_by_name('unknown')].to_set
         )
       end
 
@@ -39,7 +39,7 @@ module LicenseFinder
 
       it "should display a summary" do
         is_expected.to match "## Summary"
-        is_expected.to match /\s+\* 1 other/
+        is_expected.to match /\s+\* 1 unknown/
         is_expected.to match /\s+\* 1 BSD/
       end
 

--- a/spec/lib/license_finder/reports/text_report_spec.rb
+++ b/spec/lib/license_finder/reports/text_report_spec.rb
@@ -27,10 +27,24 @@ module LicenseFinder
         )
       end
 
-      subject { TextReport.new([dep3, dep2, dep1]).to_s }
+      let(:dep4) do
+        Dependency.new(
+            'name' => 'gem_d',
+            'version' => '2.0',
+            'licenses' => [License.find_by_name(nil)].to_set,
+            'missing' => true
+        )
+      end
 
       it 'should generate a text report with the name, version and license of each dependency, sorted by name' do
-        is_expected.to eq("gem_a, 1.0, MIT\ngem_b, 1.0, MIT\ngem_c, 2.0, \"MIT, BSD\"\n")
+        report = TextReport.new([dep3, dep2, dep1] ).to_s
+        expect(report).to eq("gem_a, 1.0, MIT\ngem_b, 1.0, MIT\ngem_c, 2.0, \"MIT, BSD\"\n")
+      end
+
+      it 'prints a warning message for packages that have not been installed' do
+        report = TextReport.new([dep3, dep4] ).to_s
+        expect(report).to eq("gem_c, 2.0, \"MIT, BSD\"\ngem_d, 2.0, \"This package is not installed. Please install to determine licenses.\"\n")
+
       end
     end
   end

--- a/spec/lib/license_finder/yml_to_sql_spec.rb
+++ b/spec/lib/license_finder/yml_to_sql_spec.rb
@@ -109,7 +109,7 @@ module LicenseFinder
         child_attrs = {
           'name' => 'child1_name',
           'version' => '0.0.1',
-          'license' => 'other'
+          'license' => 'unknown'
         }
         described_class.convert_all([legacy_attributes, child_attrs])
 


### PR DESCRIPTION
...t been installed.  Rename 'other' to 'unknown' for packages for which we cannot determine the license.