### PR TITLE
Warn when a dependency has been specififed but not installed

### DIFF
--- a/lib/license_finder/package.rb
+++ b/lib/license_finder/package.rb
@@ -50,6 +50,7 @@ module LicenseFinder
       ## LICENSING
       @license_names_from_spec = options[:spec_licenses] || []
       @install_path = options[:install_path]
+      @missing = options[:missing] || false
       @decided_licenses = Set.new
     end
 
@@ -129,6 +130,10 @@ module LicenseFinder
 
     def default_license
       License.find_by_name nil
+    end
+
+    def missing?
+      @missing
     end
   end
 end

--- a/lib/license_finder/package_managers/bower_package.rb
+++ b/lib/license_finder/package_managers/bower_package.rb
@@ -2,16 +2,26 @@ module LicenseFinder
   class BowerPackage < Package
     def initialize(bower_module, options={})
       spec = bower_module.fetch("pkgMeta", Hash.new)
+      endpoint = bower_module.fetch("endpoint", Hash.new)
+
+      if spec.empty?
+        name = endpoint["name"]
+        version = endpoint["target"]
+      else
+        name = spec["name"]
+        version = spec["version"]
+      end
 
       super(
-        spec["name"],
-        spec["version"],
+        name,
+        version,
         options.merge(
           summary: spec["description"],
           description: spec["readme"],
           homepage: spec["homepage"],
           spec_licenses: Package.license_names_from_standard_spec(spec),
-          install_path: bower_module["canonicalDir"]
+          install_path: bower_module["canonicalDir"],
+          missing: bower_module["missing"]
         )
       )
     end

--- a/lib/license_finder/reports/csv_report.rb
+++ b/lib/license_finder/reports/csv_report.rb
@@ -4,6 +4,7 @@ module LicenseFinder
   class CsvReport < Report
     COMMA_SEP =  ","
     AVAILABLE_COLUMNS = %w[name version licenses approved summary description]
+    MISSING_DEPENDENCY_TEXT = "This package is not installed. Please install to determine licenses."
 
     def initialize(dependencies, options)
       super
@@ -35,7 +36,11 @@ module LicenseFinder
     end
 
     def format_licenses(dep)
-      dep.licenses.map(&:name).join(self.class::COMMA_SEP)
+      if dep.missing?
+        MISSING_DEPENDENCY_TEXT
+      else
+        dep.licenses.map(&:name).join(self.class::COMMA_SEP)
+      end
     end
 
     def format_approved(dep)

--- a/spec/lib/license_finder/package_managers/bower_package_spec.rb
+++ b/spec/lib/license_finder/package_managers/bower_package_spec.rb
@@ -27,6 +27,28 @@ module LicenseFinder
     its(:children) { should == [] } # TODO: get dependencies from dependencies and devDependencies, like NPM
     its(:install_path) { should eq "/path/to/thing" }
 
+
+    context "when package is NOT installed" do
+      subject do
+        described_class.new(
+          "missing" => true,
+          "endpoint" => {
+            "name" => "some_package_that_is_not_installed",
+            "target" => ">=3.0"
+          }
+        )
+      end
+
+      it "shows the name and version from the endpoint block" do
+        expect(subject.name).to eq("some_package_that_is_not_installed")
+        expect(subject.version).to eq(">=3.0")
+      end
+
+      it 'reports itself as missing' do
+        expect(subject).to be_missing
+      end
+    end
+
     describe '#license_names_from_spec' do
       let(:package1) { { "pkgMeta" => {"license" => "MIT"} } }
       let(:package2) { { "pkgMeta" => {"licenses" => [{"type" => "BSD"}]} } }

--- a/spec/lib/license_finder/reports/text_report_spec.rb
+++ b/spec/lib/license_finder/reports/text_report_spec.rb
@@ -27,6 +27,12 @@ module LicenseFinder
       it 'should generate a text report with the name, version and license of each dependency, sorted by name' do
         is_expected.to eq("gem_a, 1.0, MIT\ngem_b, 1.0, MIT\ngem_c, 2.0, \"MIT, BSD\"\n")
       end
+
+      it 'prints a warning message for packages that have not been installed' do
+        dep = Package.new('gem_d', '2.0', missing: true)
+        report = described_class.new([dep]).to_s
+        expect(report).to eq("gem_d, 2.0, \"This package is not installed. Please install to determine licenses.\"\n")
+      end
     end
   end
 end


### PR DESCRIPTION
Happens in Bower projects.  Fixes #83982776.
