### PR TITLE
Forbid approval of dependencies with exclusively blacklisted licenses

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,6 +1,8 @@
 === 2.0.2 / unreleased
 
   * Show requires/required-by relationships for pip projects
+  * Licenses can be blacklisted.  Dependencies which only have licenses in the
+    blacklist will not be approved, even if someone tries.
 
 === 2.0.1 / 2015-03-02
 

--- a/README.md
+++ b/README.md
@@ -255,6 +255,15 @@ since it is a common dependency whose version changes from machine to
 machine.  Adding it to the `ignored_dependencies` would prevent it
 (and its oscillating versions) from appearing in reports.
 
+### Blacklisting Licenses
+
+Some projects will have a list of licenses that cannot be used.  You can add
+these licenses to the blacklist `license_finder blacklist add`.  Any dependency
+that has exclusively blacklisted licenses will always appear in the action
+items, even if someone attempts to manually approve or whitelist it.  However,
+if a dependency has even one license outside of the blacklist, it can still be
+manually approved or whitelisted.
+
 
 ## Configuration
 

--- a/features/features/configure/blacklist_licenses_spec.rb
+++ b/features/features/configure/blacklist_licenses_spec.rb
@@ -1,0 +1,30 @@
+require 'feature_helper'
+
+describe "Blacklisted licenses" do
+  # As a lawyer
+  # I want to blacklist certain licenses
+  # So that any dependencies with only these licenses cannot be approved
+
+  let(:developer) { LicenseFinder::TestingDSL::User.new }
+  let(:lawyer) { LicenseFinder::TestingDSL::User.new }
+
+  before do
+    developer.create_empty_project
+    lawyer.execute_command 'license_finder blacklist add BSD'
+    developer.execute_command 'license_finder dependencies add blacklisted_dep BSD'
+  end
+
+  specify "prevent packages from being approved" do
+    developer.execute_command 'license_finder approval add blacklisted_dep'
+
+    lawyer.run_license_finder
+    expect(lawyer).to be_seeing 'blacklisted_dep'
+  end
+
+  specify "override the whitelist" do
+    developer.execute_command 'license_finder whitelist add BSD'
+
+    lawyer.run_license_finder
+    expect(lawyer).to be_seeing 'blacklisted_dep'
+  end
+end

--- a/lib/license_finder/cli.rb
+++ b/lib/license_finder/cli.rb
@@ -9,6 +9,7 @@ require 'license_finder/cli/base'
 require 'license_finder/cli/makes_decisions'
 
 require 'license_finder/cli/whitelist'
+require 'license_finder/cli/blacklist'
 require 'license_finder/cli/dependencies'
 require 'license_finder/cli/licenses'
 require 'license_finder/cli/approvals'

--- a/lib/license_finder/cli/blacklist.rb
+++ b/lib/license_finder/cli/blacklist.rb
@@ -1,0 +1,30 @@
+module LicenseFinder
+  module CLI
+    class Blacklist < Base
+      extend Subcommand
+      include MakesDecisions
+
+      desc "list", "List all the blacklisted licenses"
+      def list
+        say "Blacklisted Licenses:", :blue
+        say_each(decisions.blacklisted) { |license| license.name }
+      end
+
+      auditable
+      desc "add LICENSE...", "Add one or more licenses to the blacklist"
+      def add(*licenses)
+        assert_some licenses
+        modifying { licenses.each { |l| decisions.blacklist(l, txn) } }
+        say "Added #{licenses.join(", ")} to the license blacklist"
+      end
+
+      auditable
+      desc "remove LICENSE...", "Remove one or more licenses from the blacklist"
+      def remove(*licenses)
+        assert_some licenses
+        modifying { licenses.each { |l| decisions.unblacklist(l, txn) } }
+        say "Removed #{licenses.join(", ")} from the license blacklist"
+      end
+    end
+  end
+end

--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -53,6 +53,7 @@ module LicenseFinder
       subcommand "ignored_groups", IgnoredGroups, "Exclude test and development dependencies from action items and reports"
       subcommand "ignored_dependencies", IgnoredDependencies, "Exclude individual dependencies from action items and reports"
       subcommand "whitelist", Whitelist, "Automatically approve any dependency that has a whitelisted license"
+      subcommand "blacklist", Blacklist, "Forbid approval of any dependency whose licenses are all blacklisted"
       subcommand "project_name", ProjectName, "Set the project name, for display in reports"
 
       private

--- a/lib/license_finder/decision_applier.rb
+++ b/lib/license_finder/decision_applier.rb
@@ -37,7 +37,9 @@ module LicenseFinder
     end
 
     def with_approval(package)
-      if decisions.approved?(package.name)
+      if package.licenses.all? { |license| decisions.blacklisted?(license) }
+        # do not approve; could mark package.blacklisted! if needed for reports
+      elsif decisions.approved?(package.name)
         package.approved_manually!(decisions.approval_of(package.name))
       elsif package.licenses.any? { |license| decisions.whitelisted?(license) }
         package.whitelisted!

--- a/lib/license_finder/decisions.rb
+++ b/lib/license_finder/decisions.rb
@@ -4,7 +4,7 @@ module LicenseFinder
     # READ
     ######
 
-    attr_reader :packages, :whitelisted, :ignored, :ignored_groups, :project_name
+    attr_reader :packages, :whitelisted, :blacklisted, :ignored, :ignored_groups, :project_name
 
     def licenses_of(name)
       @licenses[name]
@@ -20,6 +20,10 @@ module LicenseFinder
 
     def whitelisted?(lic)
       @whitelisted.include?(lic)
+    end
+
+    def blacklisted?(lic)
+      @blacklisted.include?(lic)
     end
 
     def ignored?(name)
@@ -46,6 +50,7 @@ module LicenseFinder
       @licenses = Hash.new { |h, k| h[k] = Set.new }
       @approvals = {}
       @whitelisted = Set.new
+      @blacklisted = Set.new
       @ignored = Set.new
       @ignored_groups = Set.new
     end
@@ -95,6 +100,18 @@ module LicenseFinder
     def unwhitelist(lic, txn = {})
       @decisions << [:unwhitelist, lic, txn]
       @whitelisted.delete(License.find_by_name(lic))
+      self
+    end
+
+    def blacklist(lic, txn = {})
+      @decisions << [:blacklist, lic, txn]
+      @blacklisted << License.find_by_name(lic)
+      self
+    end
+
+    def unblacklist(lic, txn = {})
+      @decisions << [:unblacklist, lic, txn]
+      @blacklisted.delete(License.find_by_name(lic))
       self
     end
 

--- a/spec/lib/license_finder/cli/blacklist_spec.rb
+++ b/spec/lib/license_finder/cli/blacklist_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+
+module LicenseFinder
+  module CLI
+    describe Blacklist do
+      let(:decisions) { Decisions.new }
+
+      before do
+        allow(Decisions).to receive(:saved!) { decisions }
+      end
+
+      describe "list" do
+        it "shows the blacklist of licenses" do
+          decisions.blacklist("MIT")
+
+          expect(capture_stdout { subject.list }).to match /MIT/
+        end
+      end
+
+      describe "add" do
+        it "adds the specified license to the blacklist" do
+          silence_stdout do
+            subject.add("test")
+          end
+          expect(subject.decisions.blacklisted).to eq [License.find_by_name("test")].to_set
+        end
+
+        it "adds multiple licenses to the blacklist" do
+          silence_stdout do
+            subject.add("test", "rest")
+          end
+          expect(subject.decisions.blacklisted).to eq [
+            License.find_by_name("test"),
+            License.find_by_name("rest")
+          ].to_set
+        end
+      end
+
+      describe "remove" do
+        it "removes the specified license from the blacklist" do
+          silence_stdout do
+            subject.add("test")
+            subject.remove("test")
+          end
+          expect(subject.decisions.blacklisted).to be_empty
+        end
+
+        it "removes multiple licenses from the blacklist" do
+          silence_stdout do
+            subject.add("test", "rest")
+            subject.remove("test", "rest")
+          end
+          expect(subject.decisions.blacklisted).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/license_finder/decision_applier_spec.rb
+++ b/spec/lib/license_finder/decision_applier_spec.rb
@@ -60,6 +60,42 @@ module LicenseFinder
         expect(dep).to be_approved
         expect(dep).to be_whitelisted
       end
+
+      it "forbids approval of packages with only blacklisted license" do
+        decisions = Decisions.new.
+          add_package("manual", nil).
+          license("manual", "ABC").
+          whitelist("ABC").
+          approve("manual").
+          blacklist("ABC")
+        decision_applier = described_class.new(decisions: decisions, packages: [])
+        dep = decision_applier.acknowledged.last
+        expect(dep).not_to be_approved
+      end
+
+      it "allows approval of packages if not all licenses are blacklisted" do
+        decisions = Decisions.new.
+          add_package("manual", nil).
+          license("manual", "ABC").
+          license("manual", "DEF").
+          whitelist("ABC").
+          blacklist("DEF")
+        decision_applier = described_class.new(decisions: decisions, packages: [])
+        dep = decision_applier.acknowledged.last
+        expect(dep).to be_approved
+        expect(dep).to be_whitelisted
+
+        decisions = Decisions.new.
+          add_package("manual", nil).
+          license("manual", "ABC").
+          license("manual", "DEF").
+          approve("manual").
+          blacklist("DEF")
+        decision_applier = described_class.new(decisions: decisions, packages: [])
+        dep = decision_applier.acknowledged.last
+        expect(dep).to be_approved
+        expect(dep).to be_approved_manually
+      end
     end
   end
 end

--- a/spec/lib/license_finder/decision_applier_spec.rb
+++ b/spec/lib/license_finder/decision_applier_spec.rb
@@ -62,35 +62,35 @@ module LicenseFinder
       end
 
       it "forbids approval of packages with only blacklisted license" do
-        decisions = Decisions.new.
-          add_package("manual", nil).
-          license("manual", "ABC").
-          whitelist("ABC").
-          approve("manual").
-          blacklist("ABC")
+        decisions = Decisions.new
+          .add_package("manual", nil)
+          .license("manual", "ABC")
+          .whitelist("ABC")
+          .approve("manual")
+          .blacklist("ABC")
         decision_applier = described_class.new(decisions: decisions, packages: [])
         dep = decision_applier.acknowledged.last
         expect(dep).not_to be_approved
       end
 
       it "allows approval of packages if not all licenses are blacklisted" do
-        decisions = Decisions.new.
-          add_package("manual", nil).
-          license("manual", "ABC").
-          license("manual", "DEF").
-          whitelist("ABC").
-          blacklist("DEF")
+        decisions = Decisions.new
+          .add_package("manual", nil)
+          .license("manual", "ABC")
+          .license("manual", "DEF")
+          .whitelist("ABC")
+          .blacklist("DEF")
         decision_applier = described_class.new(decisions: decisions, packages: [])
         dep = decision_applier.acknowledged.last
         expect(dep).to be_approved
         expect(dep).to be_whitelisted
 
-        decisions = Decisions.new.
-          add_package("manual", nil).
-          license("manual", "ABC").
-          license("manual", "DEF").
-          approve("manual").
-          blacklist("DEF")
+        decisions = Decisions.new
+          .add_package("manual", nil)
+          .license("manual", "ABC")
+          .license("manual", "DEF")
+          .approve("manual")
+          .blacklist("DEF")
         decision_applier = described_class.new(decisions: decisions, packages: [])
         dep = decision_applier.acknowledged.last
         expect(dep).to be_approved

--- a/spec/lib/license_finder/decisions_spec.rb
+++ b/spec/lib/license_finder/decisions_spec.rb
@@ -177,24 +177,24 @@ module LicenseFinder
 
     describe ".unblacklist" do
       it "will not report the given license as blacklisted" do
-        decisions = subject.
-          blacklist("MIT").
-          unblacklist("MIT")
+        decisions = subject
+          .blacklist("MIT")
+          .unblacklist("MIT")
         expect(decisions).not_to be_blacklisted(License.find_by_name("MIT"))
       end
 
       it "is cumulative" do
-        decisions = subject.
-          blacklist("MIT").
-          unblacklist("MIT").
-          blacklist("MIT")
+        decisions = subject
+          .blacklist("MIT")
+          .unblacklist("MIT")
+          .blacklist("MIT")
         expect(decisions).to be_blacklisted(License.find_by_name("MIT"))
       end
 
       it "adapts names" do
-        decisions = subject.
-          blacklist("MIT").
-          unblacklist("Expat")
+        decisions = subject
+          .blacklist("MIT")
+          .unblacklist("Expat")
         expect(decisions).not_to be_blacklisted(License.find_by_name("MIT"))
       end
     end
@@ -346,9 +346,9 @@ module LicenseFinder
 
       it "can restore un-blacklists" do
         decisions = roundtrip(
-          subject.
-          blacklist("MIT").
-          unblacklist("MIT")
+          subject
+            .blacklist("MIT")
+            .unblacklist("MIT")
         )
         expect(decisions).not_to be_blacklisted(License.find_by_name("MIT"))
       end

--- a/spec/lib/license_finder/decisions_spec.rb
+++ b/spec/lib/license_finder/decisions_spec.rb
@@ -158,6 +158,47 @@ module LicenseFinder
       end
     end
 
+    describe ".blacklist" do
+      it "will report the given license as blacklisted" do
+        decisions = subject.blacklist("MIT")
+        expect(decisions).to be_blacklisted(License.find_by_name("MIT"))
+      end
+
+      it "adapts names" do
+        decisions = subject.blacklist("Expat")
+        expect(decisions).to be_blacklisted(License.find_by_name("MIT"))
+      end
+
+      it "adds to list" do
+        decisions = subject.blacklist("MIT")
+        expect(decisions.blacklisted).to eq(Set.new([License.find_by_name("MIT")]))
+      end
+    end
+
+    describe ".unblacklist" do
+      it "will not report the given license as blacklisted" do
+        decisions = subject.
+          blacklist("MIT").
+          unblacklist("MIT")
+        expect(decisions).not_to be_blacklisted(License.find_by_name("MIT"))
+      end
+
+      it "is cumulative" do
+        decisions = subject.
+          blacklist("MIT").
+          unblacklist("MIT").
+          blacklist("MIT")
+        expect(decisions).to be_blacklisted(License.find_by_name("MIT"))
+      end
+
+      it "adapts names" do
+        decisions = subject.
+          blacklist("MIT").
+          unblacklist("Expat")
+        expect(decisions).not_to be_blacklisted(License.find_by_name("MIT"))
+      end
+    end
+
     describe ".ignore" do
       it "will report ignored dependencies" do
         decisions = subject.ignore("dep")
@@ -294,6 +335,22 @@ module LicenseFinder
             .unwhitelist("MIT")
         )
         expect(decisions).not_to be_whitelisted(License.find_by_name("MIT"))
+      end
+
+      it "can restore blacklists" do
+        decisions = roundtrip(
+          subject.blacklist("MIT")
+        )
+        expect(decisions).to be_blacklisted(License.find_by_name("MIT"))
+      end
+
+      it "can restore un-blacklists" do
+        decisions = roundtrip(
+          subject.
+          blacklist("MIT").
+          unblacklist("MIT")
+        )
+        expect(decisions).not_to be_blacklisted(License.find_by_name("MIT"))
       end
 
       it "can restore ignorals" do


### PR DESCRIPTION
This doesn't do anything to highlight blacklisted packages.  Instead it just refuses to show them as approved, regardless of the whitelist or manual approvals.  Easy enough to change if that's important.

A lot of this code is an almost exact copy of the whitelist code.  Would love feedback about how to improve that.

[#84478498]