### PR TITLE
Restrict output to distributions mentioned in requirements.txt

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,6 +1,11 @@
 === 2.0.2 / unreleased
 
+* Bugfixes
+
   * Show requires/required-by relationships for pip projects
+  * For pip projects, limit output to the distributions mentioned in
+    requirements.txt, or their dependencies, instead of all installed
+    distributions, which may include distributions from other projects. #119
 
 === 2.0.1 / 2015-03-02
 

--- a/bin/license_finder_pip.py
+++ b/bin/license_finder_pip.py
@@ -1,18 +1,22 @@
 #!/usr/bin/env python
 
 import json
-from pip.utils import get_installed_distributions
+from pip.req import parse_requirements
+from pip.download import PipSession
+from pip._vendor import pkg_resources
 
-packages = []
+requirements = [req.req for req
+                in parse_requirements('requirements.txt', session=PipSession())]
 
-for dist in get_installed_distributions():
-    packages.append(
-        {
-            "name": dist.project_name,
-            "version": dist.version,
-            "location": dist.location,
-            "dependencies": map(lambda dependency: dependency.project_name, dist.requires())
+transform = lambda dist: {
+        'name': dist.project_name,
+        'version': dist.version,
+        'location': dist.location,
+        'dependencies': map(lambda dependency: dependency.project_name,
+                            dist.requires()),
         }
-    )
+
+packages = [transform(dist) for dist
+            in pkg_resources.working_set.resolve(requirements)]
 
 print json.dumps(packages)


### PR DESCRIPTION
For pip projects, this change limits `license_finder` output to the distributions mentioned in `requirements.txt`, or their dependencies.  This is an improvement over listing all installed distributions, which may include distributions from other projects.

Fixes #119.  I'd like a review from someone who knows the Python ecosystem better than I do.