### PR TITLE
Allow license finder to take the project path.

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,3 +1,9 @@
+=== 2.1.0 / unreleased
+
+* Features
+
+  * Allow project path to be set in a command line option
+
 === 2.0.3 / 2015-03-18
 
 * Bugfixes

--- a/features/features/configure/set_project_path_spec.rb
+++ b/features/features/configure/set_project_path_spec.rb
@@ -1,0 +1,17 @@
+require 'feature_helper'
+
+describe "Project path" do
+  # As a developer
+  # I want to set a project path
+  # So that I can run license finder in a different Bundle environment to the project.
+
+  let(:developer) { LicenseFinder::TestingDSL::User.new }
+
+  specify "can be overridden on the command line" do
+    project = developer.create_ruby_app
+    gem = developer.create_gem 'mitlicensed_dep', license: 'MIT', version: '1.2.3'
+    project.depend_on gem
+    developer.execute_command_outside_project("license_finder --quiet --project_path #{project.project_dir}")
+    expect(developer).to be_seeing 'mitlicensed_dep, 1.2.3, MIT'
+  end
+end

--- a/features/support/testing_dsl.rb
+++ b/features/support/testing_dsl.rb
@@ -19,7 +19,11 @@ module LicenseFinder::TestingDSL
     end
 
     def execute_command(command)
-      @output, @exit_code = Paths.project.shell_out(command, true)
+      execute_command_in_path(command, Paths.project)
+    end
+
+    def execute_command_outside_project(command)
+      execute_command_in_path(command, Paths.root)
     end
 
     def seeing?(content)
@@ -41,6 +45,12 @@ module LicenseFinder::TestingDSL
     def view_html
       execute_command 'license_finder report --format html'
       HtmlReport.from_string(@output)
+    end
+
+    private
+
+    def execute_command_in_path(command, path)
+      @output, @exit_code = path.shell_out(command, true)
     end
   end
 
@@ -66,8 +76,6 @@ module LicenseFinder::TestingDSL
 
     def install
     end
-
-    private
 
     def project_dir
       Paths.project
@@ -262,7 +270,7 @@ module LicenseFinder::TestingDSL
 
     def root
       # where license_finder is installed
-      Pathname.new(__FILE__).dirname.join("..", "..").realpath
+      ProjectDir.new(Pathname.new(__FILE__).dirname.join("..", "..").realpath)
     end
 
     def fixtures

--- a/lib/license_finder/cli/base.rb
+++ b/lib/license_finder/cli/base.rb
@@ -3,6 +3,7 @@ require 'thor'
 module LicenseFinder
   module CLI
     class Base < Thor
+      class_option :project_path, desc: "Path to the project. Defaults to current working directory."
       class_option :decisions_file, desc: "Where decisions are saved. Defaults to doc/dependency_decisions.yml."
 
       no_commands do
@@ -18,9 +19,8 @@ module LicenseFinder
       end
 
       def license_finder_config
-        result = extract_options(:decisions_file, :gradle_command, :rebar_command, :rebar_deps_dir)
+        result = extract_options(:project_path, :decisions_file, :gradle_command, :rebar_command, :rebar_deps_dir)
         result[:logger] = logger_config
-        result[:project_path] = Pathname.pwd
         result
       end
 


### PR DESCRIPTION
I want to run license finder with bundler. However the Gemfile containing license_finder is different to the Gemfile I want to run license_finder on. The proposed solution is to allow license_finder to accept a command line argument to say where the project directory is. This is to be used as:
```
bundle exec license_finder --project_path path/to/project
```