### PR TITLE
support npm dependency groups

### DIFF
--- a/lib/license_finder/package_managers/npm.rb
+++ b/lib/license_finder/package_managers/npm.rb
@@ -5,18 +5,41 @@ module LicenseFinder
     DEPENDENCY_GROUPS = ["dependencies", "devDependencies"]
 
     def current_packages
-      json = npm_json
-      dependencies = DEPENDENCY_GROUPS
-        .map { |g| (json[g] || {}).values }
-        .flatten(1)
-        .reject{ |d| d.is_a?(String) }
-
-      pkgs = {} # name => spec
-      dependencies.each { |d| recursive_dependencies(d, pkgs) }
-      pkgs.values.map { |d| NpmPackage.new(d, logger: logger) }
+      packages = {}
+      direct_dependencies.each do |dep|
+        group_name = dep[:group]
+        walk_dependency_tree(dep[:name]) do |dependency|
+          package_id = dependency["name"]
+          packages[package_id] ||= NpmPackage.new(dependency, logger: logger)
+          packages[package_id].groups << group_name unless packages[package_id].groups.include?(group_name)
+        end
+      end
+      packages.values
     end
 
     private
+
+    def direct_dependencies
+      package_json = JSON.parse(File.read(package_path))
+      DEPENDENCY_GROUPS.map do |group|
+        package_json.fetch(group, {}).keys.map do |dependency|
+          {
+            group: group,
+            name: dependency
+          }
+        end
+      end.flatten
+    end
+
+    def walk_dependency_tree(dependency, &block)
+      @json ||= npm_json
+      deps = @json.fetch("dependencies", {}).reject { |_,d| d.is_a?(String) }
+      current_dep = deps[dependency]
+      block.call(current_dep) if current_dep
+      recursive_dependencies(current_dep) do |d|
+        block.call(d)
+      end
+    end
 
     def npm_json
       command = "npm list --json --long"
@@ -46,16 +69,13 @@ module LicenseFinder
       project_path.join('package.json')
     end
 
-    # node_module can be empty hash if it is included elsewhere
-    def recursive_dependencies(node_module, memo)
-      key = node_module['name']
-      memo[key] ||= {}
-      memo[key].merge!(node_module)
+    def recursive_dependencies(node_module, &block)
+      return unless node_module # node_module can be empty hash if it is included elsewhere
+      block.call(node_module)
       node_module.fetch('dependencies', {}).each do |dep_key, data|
         data['name'] ||= dep_key
-        recursive_dependencies(data, memo)
+        recursive_dependencies(data, &block)
       end
-      memo
     end
   end
 end

--- a/license_finder.gemspec
+++ b/license_finder.gemspec
@@ -51,6 +51,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "capybara", "~> 2.0.0"
   s.add_development_dependency "webmock", "~> 1.13"
   s.add_development_dependency "cocoapods" if LicenseFinder::Platform.darwin?
+  s.add_development_dependency "fakefs"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/spec/lib/license_finder/package_managers/npm_spec.rb
+++ b/spec/lib/license_finder/package_managers/npm_spec.rb
@@ -1,54 +1,68 @@
 require 'spec_helper'
+require 'fakefs/spec_helpers'
 
 module LicenseFinder
   describe NPM do
-    let(:npm) { NPM.new }
+    let(:root) { "/fake-node-project" }
+    let(:npm) { NPM.new project_path: Pathname.new(root) }
     it_behaves_like "a PackageManager"
 
-    describe '.current_packages' do
-      before { NPM.instance_variable_set(:@modules, nil) }
+    let(:package_json) do
+      {
+        dependencies: {
+          "dependency.js" => "1.3.3.7",
+          "dependency2.js" => "4.2"
+        },
+        devDependencies: {
+          "dependency3.js" => "4.2"
+        }
+      }.to_json
+    end
 
-      it 'fetches data from npm' do
-        json = <<-JSON
+    let(:dependency_json) do
+      <<-JSON
           {
             "dependencies": {
               "dependency.js": {
-                "name": "depjs",
+                "name": "dependency.js",
                 "version": "1.3.3.7",
                 "description": "description",
                 "readme": "readme",
                 "path": "/path/to/thing",
                 "dependencies": {
                   "dependency1-1.js": {
-                    "name": "dep1-1js"
+                    "name": "dependency1-1.js"
                   }
                 }
               },
               "dependency2.js": {
-                "name": "dep2js",
+                "name": "dependency2.js",
                 "version": "4.2",
                 "description": "description2",
                 "readme": "readme2",
                 "path": "/path/to/thing2",
                 "dependencies": {
                   "dependency2-1.js": {
-                    "name": "dep2-1js",
+                    "name": "dependency2-1.js",
                     "dependencies": {
                       "dependency1-1.js": {
-                        "name": "dep1-1js"
+                        "name": "dependency1-1.js"
                       }
                     }
                   }
                 }
-              }
-            },
-            "devDependencies": {
+              },
               "dependency3.js": {
-                "name": "dep3js",
+                "name": "dependency3.js",
                 "version": "4.2",
                 "description": "description3",
                 "readme": "readme3",
-                "path": "/path/to/thing3"
+                "path": "/path/to/thing3",
+                "dependencies": {
+                  "dependency1-1.js": {
+                    "name": "dependency1-1.js"
+                  }
+                }
               }
             },
             "notADependency": {
@@ -61,12 +75,31 @@ module LicenseFinder
               }
             }
           }
-        JSON
-        allow(npm).to receive(:capture).with(/npm/).and_return([json, true])
+      JSON
+    end
 
+    describe '.current_packages' do
+      include FakeFS::SpecHelpers
+      before do
+        NPM.instance_variable_set(:@modules, nil)
+        FileUtils.mkdir_p(root)
+        File.write(File.join(root, "package.json"), package_json)
+        allow(npm).to receive(:capture).with(/npm/).and_return([dependency_json, true])
+      end
+
+      it 'fetches data from npm' do
         current_packages = npm.current_packages
 
-        expect(current_packages.map(&:name)).to eq(["depjs", "dep1-1js", "dep2js", "dep2-1js", "dep3js"])
+        expect(current_packages.map(&:name)).to eq(["dependency.js", "dependency1-1.js", "dependency2.js", "dependency2-1.js", "dependency3.js"])
+      end
+
+      it "finds the groups for dependencies" do
+        current_packages = npm.current_packages
+        expect(current_packages.find { |p| p.name == "dependency.js" }.groups).to eq(["dependencies"])
+        expect(current_packages.find { |p| p.name == "dependency1-1.js" }.groups).to eq(["dependencies", "devDependencies"])
+        expect(current_packages.find { |p| p.name == "dependency2.js" }.groups).to eq(["dependencies"])
+        expect(current_packages.find { |p| p.name == "dependency2-1.js" }.groups).to eq(["dependencies"])
+        expect(current_packages.find { |p| p.name == "dependency3.js" }.groups).to eq(["devDependencies"])
       end
 
       it "does not support name version string" do

--- a/spec/lib/license_finder/package_managers/npm_spec.rb
+++ b/spec/lib/license_finder/package_managers/npm_spec.rb
@@ -61,6 +61,9 @@ module LicenseFinder
                 "dependencies": {
                   "dependency1-1.js": {
                     "name": "dependency1-1.js"
+                  },
+                 "dependency3-1.js": {
+                    "name": "dependency3-1.js"
                   }
                 }
               }
@@ -90,7 +93,7 @@ module LicenseFinder
       it 'fetches data from npm' do
         current_packages = npm.current_packages
 
-        expect(current_packages.map(&:name)).to eq(["dependency.js", "dependency1-1.js", "dependency2.js", "dependency2-1.js", "dependency3.js"])
+        expect(current_packages.map(&:name)).to eq(["dependency.js", "dependency1-1.js", "dependency2.js", "dependency2-1.js", "dependency3.js",  "dependency3-1.js"])
       end
 
       it "finds the groups for dependencies" do
@@ -100,6 +103,7 @@ module LicenseFinder
         expect(current_packages.find { |p| p.name == "dependency2.js" }.groups).to eq(["dependencies"])
         expect(current_packages.find { |p| p.name == "dependency2-1.js" }.groups).to eq(["dependencies"])
         expect(current_packages.find { |p| p.name == "dependency3.js" }.groups).to eq(["devDependencies"])
+        expect(current_packages.find { |p| p.name == "dependency3-1.js" }.groups).to eq(["devDependencies"])
       end
 
       it "does not support name version string" do


### PR DESCRIPTION
Responding to issue #113. I favor using NPM's own terms of `dependencies` and `devDependencies` rather than mapping these to other terms.