### PR TITLE
Use '&&' instead of ';' when chaining shell commands.

### DIFF
--- a/lib/license_finder/package_managers/bower.rb
+++ b/lib/license_finder/package_managers/bower.rb
@@ -11,7 +11,7 @@ module LicenseFinder
     private
 
     def bower_output
-      output = `cd #{project_path}; bower list --json -l action`
+      output = `cd #{project_path} && bower list --json -l action`
 
       JSON(output)
         .fetch("dependencies", {})

--- a/lib/license_finder/package_managers/go_workspace.rb
+++ b/lib/license_finder/package_managers/go_workspace.rb
@@ -21,7 +21,7 @@ module LicenseFinder
     private
 
     def go_output
-      cmd_text = `cd #{project_path}; go list -f "{{.ImportPath}} " ./...`
+      cmd_text = `cd #{project_path} && go list -f "{{.ImportPath}} " ./...`
       paths = cmd_text.gsub(/\s{2,}/, ",").split(",")
       paths.map do |path|
         {

--- a/lib/license_finder/package_managers/gradle.rb
+++ b/lib/license_finder/package_managers/gradle.rb
@@ -9,7 +9,7 @@ module LicenseFinder
     end
 
     def current_packages
-      `cd #{project_path}; #{@command} downloadLicenses`
+      `cd #{project_path} && #{@command} downloadLicenses`
 
       packages = []
       dependencies = GradleDependencyFinder.new(project_path).dependencies

--- a/lib/license_finder/package_managers/maven.rb
+++ b/lib/license_finder/package_managers/maven.rb
@@ -3,7 +3,7 @@ require "xmlsimple"
 module LicenseFinder
   class Maven < PackageManager
     def current_packages
-      `cd #{project_path}; mvn license:download-licenses`
+      `cd #{project_path} && mvn license:download-licenses`
 
       xml = license_report.read
 

--- a/lib/license_finder/package_managers/npm.rb
+++ b/lib/license_finder/package_managers/npm.rb
@@ -42,7 +42,7 @@ module LicenseFinder
     end
 
     def npm_json
-      command = "cd #{project_path}; npm list --json --long"
+      command = "cd #{project_path} && npm list --json --long"
       output, success = capture(command)
       if success
         json = JSON(output)

--- a/lib/license_finder/package_managers/rebar.rb
+++ b/lib/license_finder/package_managers/rebar.rb
@@ -21,7 +21,7 @@ module LicenseFinder
     private
 
     def rebar_ouput
-      command = "cd #{project_path}; #{@command} list-deps"
+      command = "cd #{project_path} && #{@command} list-deps"
       output, success = capture(command)
       raise "Command #{command} failed to execute: #{output}" unless success
 

--- a/spec/lib/license_finder/package_managers/bower_spec.rb
+++ b/spec/lib/license_finder/package_managers/bower_spec.rb
@@ -26,7 +26,7 @@ module LicenseFinder
             }
           }
         JSON
-        allow(subject).to receive('`').with('cd /fake/path; bower list --json -l action').and_return(json)
+        allow(subject).to receive('`').with('cd /fake/path && bower list --json -l action').and_return(json)
 
         expect(subject.current_packages.map { |p| [p.name, p.install_path] }).to eq [
           %w(dependency-library /path/to/thing), %w(another-dependency /path/to/thing2)

--- a/spec/lib/license_finder/package_managers/go_workspace_spec.rb
+++ b/spec/lib/license_finder/package_managers/go_workspace_spec.rb
@@ -19,7 +19,7 @@ module LicenseFinder
       }
 
       before do
-        allow_any_instance_of(Kernel).to receive('`').with('cd /Users/pivotal/workspace/loggregator; go list -f "{{.ImportPath}} " ./...').and_return(content.to_s)
+        allow_any_instance_of(Kernel).to receive('`').with('cd /Users/pivotal/workspace/loggregator && go list -f "{{.ImportPath}} " ./...').and_return(content.to_s)
       end
 
       describe 'should return an array of go packages' do

--- a/spec/lib/license_finder/package_managers/gradle_spec.rb
+++ b/spec/lib/license_finder/package_managers/gradle_spec.rb
@@ -10,20 +10,20 @@ module LicenseFinder
 
     describe '#current_packages' do
       before do
-        allow(subject).to receive('`').with('cd /fake/path; gradle downloadLicenses')
+        allow(subject).to receive('`').with('cd /fake/path && gradle downloadLicenses')
         dependencies = double(:subject_dependency_file, dependencies: content)
         expect(GradleDependencyFinder).to receive(:new).and_return(dependencies)
       end
 
       it 'uses custom subject command, if provided' do
         subject = Gradle.new(gradle_command: 'subjectfoo', project_path: '/fake/path')
-        expect(subject).to receive('`').with('cd /fake/path; subjectfoo downloadLicenses')
+        expect(subject).to receive('`').with('cd /fake/path && subjectfoo downloadLicenses')
         subject.current_packages
       end
 
       it 'sets the working directory to project_path, if provided' do
         subject = Gradle.new(project_path: '/Users/foo/bar')
-        expect(subject).to receive('`').with('cd /Users/foo/bar; gradle downloadLicenses')
+        expect(subject).to receive('`').with('cd /Users/foo/bar && gradle downloadLicenses')
         subject.current_packages
       end
 

--- a/spec/lib/license_finder/package_managers/maven_spec.rb
+++ b/spec/lib/license_finder/package_managers/maven_spec.rb
@@ -19,7 +19,7 @@ module LicenseFinder
 
     describe '.current_packages' do
       before do
-        allow(subject).to receive('`').with('cd /fake/path; mvn license:download-licenses')
+        allow(subject).to receive('`').with('cd /fake/path && mvn license:download-licenses')
       end
 
       def stub_license_report(deps)

--- a/spec/lib/license_finder/package_managers/npm_spec.rb
+++ b/spec/lib/license_finder/package_managers/npm_spec.rb
@@ -115,7 +115,7 @@ module LicenseFinder
             }
           }
         JSON
-        allow(npm).to receive(:capture).with('cd /fake-node-project; npm list --json --long').and_return([json, true])
+        allow(npm).to receive(:capture).with('cd /fake-node-project && npm list --json --long').and_return([json, true])
 
         current_packages = npm.current_packages
 

--- a/spec/lib/license_finder/package_managers/rebar_spec.rb
+++ b/spec/lib/license_finder/package_managers/rebar_spec.rb
@@ -14,7 +14,7 @@ jiffy TAG 0.9.0 https://github.com/davisp/jiffy.git
 
     describe '.current_packages' do
       it 'lists all the current packages' do
-        allow(subject).to receive(:capture).with('cd /fake/path; rebar list-deps').and_return([output, true])
+        allow(subject).to receive(:capture).with('cd /fake/path && rebar list-deps').and_return([output, true])
 
         current_packages = subject.current_packages
 


### PR DESCRIPTION
Closes #158.