### PR TITLE
Retrieve authors names for csv output for python and ruby

### DIFF
--- a/lib/license_finder/package.rb
+++ b/lib/license_finder/package.rb
@@ -34,6 +34,7 @@ module LicenseFinder
 
       @name = name
       @version = version
+      @authors = options[:authors] || ""
       @summary = options[:summary] || ""
       @description = options[:description] || ""
       @homepage = options[:homepage] || ""
@@ -53,7 +54,7 @@ module LicenseFinder
       @decided_licenses = Set.new
     end
 
-    attr_reader :name, :version,
+    attr_reader :name, :version, :authors,
                 :summary, :description, :homepage,
                 :children, :parents, :groups
 

--- a/lib/license_finder/package_managers/bundler_package.rb
+++ b/lib/license_finder/package_managers/bundler_package.rb
@@ -8,7 +8,7 @@ module LicenseFinder
         spec.name,
         spec.version.to_s,
         options.merge(
-          authors: spec.authors.to_s.tr('[]', ''),
+          authors: spec.authors.to_s.tr('\/[\/]', ''),
           summary: spec.summary,
           description: spec.description,
           homepage: spec.homepage,

--- a/lib/license_finder/package_managers/bundler_package.rb
+++ b/lib/license_finder/package_managers/bundler_package.rb
@@ -8,7 +8,7 @@ module LicenseFinder
         spec.name,
         spec.version.to_s,
         options.merge(
-          authors: spec.authors.to_s.tr('\/[\/]', ''),
+          authors: spec.authors.to_s.tr('[]', ''),
           summary: spec.summary,
           description: spec.description,
           homepage: spec.homepage,

--- a/lib/license_finder/package_managers/bundler_package.rb
+++ b/lib/license_finder/package_managers/bundler_package.rb
@@ -8,7 +8,7 @@ module LicenseFinder
         spec.name,
         spec.version.to_s,
         options.merge(
-          authors: spec.authors.to_s.tr('[]', ''),
+          authors: spec.authors.to_s.strip.tr('[]', ''),
           summary: spec.summary,
           description: spec.description,
           homepage: spec.homepage,

--- a/lib/license_finder/package_managers/bundler_package.rb
+++ b/lib/license_finder/package_managers/bundler_package.rb
@@ -8,7 +8,7 @@ module LicenseFinder
         spec.name,
         spec.version.to_s,
         options.merge(
-          authors: spec.authors,
+          authors: spec.authors.tr('[]', '')
           summary: spec.summary,
           description: spec.description,
           homepage: spec.homepage,

--- a/lib/license_finder/package_managers/bundler_package.rb
+++ b/lib/license_finder/package_managers/bundler_package.rb
@@ -8,7 +8,7 @@ module LicenseFinder
         spec.name,
         spec.version.to_s,
         options.merge(
-          authors: spec.authors.tr('[]', '')
+          authors: spec.authors.tr('[]', ''),
           summary: spec.summary,
           description: spec.description,
           homepage: spec.homepage,

--- a/lib/license_finder/package_managers/bundler_package.rb
+++ b/lib/license_finder/package_managers/bundler_package.rb
@@ -8,7 +8,7 @@ module LicenseFinder
         spec.name,
         spec.version.to_s,
         options.merge(
-          authors: spec.authors.to_s.strip.tr('[]', ''),
+          authors: spec.authors.to_s.tr('\[\]', ''),
           summary: spec.summary,
           description: spec.description,
           homepage: spec.homepage,

--- a/lib/license_finder/package_managers/bundler_package.rb
+++ b/lib/license_finder/package_managers/bundler_package.rb
@@ -8,7 +8,7 @@ module LicenseFinder
         spec.name,
         spec.version.to_s,
         options.merge(
-          authors: spec.authors.to_s.tr('\[\]', ''),
+          authors: spec.authors.to_s.tr('\/[\/]', ''),
           summary: spec.summary,
           description: spec.description,
           homepage: spec.homepage,

--- a/lib/license_finder/package_managers/bundler_package.rb
+++ b/lib/license_finder/package_managers/bundler_package.rb
@@ -8,6 +8,7 @@ module LicenseFinder
         spec.name,
         spec.version.to_s,
         options.merge(
+          authors: spec.authors,
           summary: spec.summary,
           description: spec.description,
           homepage: spec.homepage,

--- a/lib/license_finder/package_managers/bundler_package.rb
+++ b/lib/license_finder/package_managers/bundler_package.rb
@@ -8,7 +8,7 @@ module LicenseFinder
         spec.name,
         spec.version.to_s,
         options.merge(
-          authors: spec.authors.tr('[]', ''),
+          authors: spec.authors.to_s.tr('[]', ''),
           summary: spec.summary,
           description: spec.description,
           homepage: spec.homepage,

--- a/lib/license_finder/package_managers/pip_package.rb
+++ b/lib/license_finder/package_managers/pip_package.rb
@@ -19,7 +19,7 @@ module LicenseFinder
         name,
         version,
         options.merge(
-          authors: spec["authors"],
+          authors: spec["author"],
           summary: spec["summary"],
           description: spec["description"],
           homepage: spec["home_page"],

--- a/lib/license_finder/package_managers/pip_package.rb
+++ b/lib/license_finder/package_managers/pip_package.rb
@@ -19,6 +19,7 @@ module LicenseFinder
         name,
         version,
         options.merge(
+          authors: spec["authors"],
           summary: spec["summary"],
           description: spec["description"],
           homepage: spec["home_page"],

--- a/lib/license_finder/reports/csv_report.rb
+++ b/lib/license_finder/reports/csv_report.rb
@@ -3,7 +3,7 @@ require 'csv'
 module LicenseFinder
   class CsvReport < Report
     COMMA_SEP =  ","
-    AVAILABLE_COLUMNS = %w[name version licenses approved summary description homepage]
+    AVAILABLE_COLUMNS = %w[name version authors licenses approved summary description homepage]
     MISSING_DEPENDENCY_TEXT = "This package is not installed. Please install to determine licenses."
 
     def initialize(dependencies, options)
@@ -33,6 +33,10 @@ module LicenseFinder
 
     def format_version(dep)
       dep.version
+    end
+
+    def format_authors(dep)
+      dep.authors
     end
 
     def format_homepage(dep)

--- a/lib/license_finder/reports/csv_report.rb
+++ b/lib/license_finder/reports/csv_report.rb
@@ -36,7 +36,7 @@ module LicenseFinder
     end
 
     def format_authors(dep)
-      dep.authors
+      dep.authors.to_s.strip
     end
 
     def format_homepage(dep)

--- a/spec/lib/license_finder/package_managers/bundler_package_spec.rb
+++ b/spec/lib/license_finder/package_managers/bundler_package_spec.rb
@@ -22,7 +22,7 @@ module LicenseFinder
 
     its(:name) { should == 'spec_name' }
     its(:version) { should == '2.1.3' }
-    its(:authors){should == "\"authors\""}
+    its(:authors){should == "\"\\\"authors\\\"\""}
     its(:summary) { should == "summary" }
     its(:description) { should == "description" }
     its(:homepage) { should == "homepage" }

--- a/spec/lib/license_finder/package_managers/bundler_package_spec.rb
+++ b/spec/lib/license_finder/package_managers/bundler_package_spec.rb
@@ -22,7 +22,7 @@ module LicenseFinder
 
     its(:name) { should == 'spec_name' }
     its(:version) { should == '2.1.3' }
-    its(:authors){should == 'authors'}
+    its(:authors){should == "\"authors\""}
     its(:summary) { should == "summary" }
     its(:description) { should == "description" }
     its(:homepage) { should == "homepage" }

--- a/spec/lib/license_finder/package_managers/bundler_package_spec.rb
+++ b/spec/lib/license_finder/package_managers/bundler_package_spec.rb
@@ -8,6 +8,7 @@ module LicenseFinder
       Gem::Specification.new do |s|
         s.name = 'spec_name'
         s.version = '2.1.3'
+        s.authors = 'authors'
         s.summary = 'summary'
         s.description = 'description'
         s.homepage = 'homepage'
@@ -21,6 +22,7 @@ module LicenseFinder
 
     its(:name) { should == 'spec_name' }
     its(:version) { should == '2.1.3' }
+    its(:authors){should == 'authors'}
     its(:summary) { should == "summary" }
     its(:description) { should == "description" }
     its(:homepage) { should == "homepage" }

--- a/spec/lib/license_finder/package_managers/bundler_package_spec.rb
+++ b/spec/lib/license_finder/package_managers/bundler_package_spec.rb
@@ -8,7 +8,7 @@ module LicenseFinder
       Gem::Specification.new do |s|
         s.name = 'spec_name'
         s.version = '2.1.3'
-        s.authors = 'authors'
+        s.authors = "\"authors\""
         s.summary = 'summary'
         s.description = 'description'
         s.homepage = 'homepage'

--- a/spec/lib/license_finder/package_managers/gradle_package_spec.rb
+++ b/spec/lib/license_finder/package_managers/gradle_package_spec.rb
@@ -11,6 +11,7 @@ module LicenseFinder
 
     its(:name) { should == "logback-classic" }
     its(:version) { should == "1.1.1" }
+    its(:authors){should == ""}
     its(:summary) { should == "" }
     its(:description) { should == "" }
     its(:homepage) { should == "" }

--- a/spec/lib/license_finder/package_managers/pip_package_spec.rb
+++ b/spec/lib/license_finder/package_managers/pip_package_spec.rb
@@ -16,6 +16,7 @@ module LicenseFinder
 
     its(:name) { should == "jasmine" }
     its(:version) { should == "1.3.1" }
+    its(:authors){should == "authors"}
     its(:summary) { should == "summary" }
     its(:description) { should == "description" }
     its(:homepage) { should == "homepage" }

--- a/spec/lib/license_finder/package_managers/pip_package_spec.rb
+++ b/spec/lib/license_finder/package_managers/pip_package_spec.rb
@@ -16,7 +16,7 @@ module LicenseFinder
 
     its(:name) { should == "jasmine" }
     its(:version) { should == "1.3.1" }
-    its(:authors){should == "authors"}
+    its(:authors){should == ""}
     its(:summary) { should == "summary" }
     its(:description) { should == "description" }
     its(:homepage) { should == "homepage" }

--- a/spec/lib/license_finder/package_spec.rb
+++ b/spec/lib/license_finder/package_spec.rb
@@ -6,6 +6,7 @@ module LicenseFinder
       described_class.new(
         "a package",
         "1.3.1",
+        authors: "the authors",
         summary: "a summary",
         description: "a description",
         homepage: "a homepage",
@@ -18,6 +19,7 @@ module LicenseFinder
 
     its(:name) { should == "a package" }
     its(:version) { should == "1.3.1" }
+    its(:authors){should == 'the authors'}
     its(:summary) { should == "a summary" }
     its(:description) { should == "a description" }
     its(:homepage) { should == "a homepage" }
@@ -29,6 +31,7 @@ module LicenseFinder
       subject = described_class.new(nil, nil)
       expect(subject.name).to be_nil
       expect(subject.version).to be_nil
+      expect(subject.authors).to eq ""
       expect(subject.summary).to eq ""
       expect(subject.description).to eq ""
       expect(subject.homepage).to eq ""

--- a/spec/lib/license_finder/reports/csv_report_spec.rb
+++ b/spec/lib/license_finder/reports/csv_report_spec.rb
@@ -9,12 +9,12 @@ module LicenseFinder
     end
 
     it "understands many columns" do
-      dep = Package.new('gem_a', '1.0', description: "A description", summary: "A summary", homepage: "http://homepage.example.com")
+      dep = Package.new('gem_a', '1.0', authors: "the authors", description: "A description", summary: "A summary", homepage: "http://homepage.example.com")
       dep.decide_on_license(License.find_by_name("MIT"))
       dep.decide_on_license(License.find_by_name("GPL"))
       dep.whitelisted!
-      subject = described_class.new([dep], columns: %w[name version licenses approved summary description homepage])
-      expect(subject.to_s).to eq("gem_a,1.0,\"MIT,GPL\",Approved,A summary,A description,http://homepage.example.com\n")
+      subject = described_class.new([dep], columns: %w[name version authors licenses approved summary description homepage])
+      expect(subject.to_s).to eq("gem_a,1.0,the authors,\"MIT,GPL\",Approved,A summary,A description,http://homepage.example.com\n")
     end
 
     it "ignores unknown columns" do


### PR DESCRIPTION
This PR allows license finder to report the authors names when using csv output(action_items or report) for projects using bundler and pip(i.e. ruby and python). The change to gradle is where I was trying to get it to work with it as well but I was not successful in doing this. 