### PR TITLE
Local config file

### DIFF
--- a/lib/license_finder/package_managers/bundler.rb
+++ b/lib/license_finder/package_managers/bundler.rb
@@ -29,6 +29,7 @@ module LicenseFinder
 
         load 'bundler/rubygems_integration.rb'
         ENV['BUNDLE_GEMFILE'] = package_path.to_s
+        ::Bundler.setup
         @definition = ::Bundler::Definition.build(package_path, lockfile_path, nil)
 
         ENV['BUNDLE_GEMFILE'] = old_gemfile


### PR DESCRIPTION
Hi,

License finder would crash on our projects because they have a .bundle/config file that defined an alternative bundle_path. It took me many hours of looking through the bundler source code before I found out how I could get this to work.

As the code is now it will probably not work if you'd try to run it on multiple projects in the same process. I think I had that working in one of the between files but the required code was very ugly.

I spent too much time already for something that I should've done by hand in a few hours (indexing licenses of our projects) so I haven't written a spec for this. If you really want one before you merge the request I might find some time to do so, in the next weeks, but there's a good chance we'll have to pull in the super ugly hacky 'reset bundler state' code I reverted in this pr.

If you've got tips that'd be great as well ;)