### PR TITLE
Avoid platform-specific shell commands

### DIFF
--- a/features/support/testing_dsl.rb
+++ b/features/support/testing_dsl.rb
@@ -324,7 +324,7 @@ module LicenseFinder
 
     class ProjectDir < SimpleDelegator # delegates to a Pathname
       def shell_out(command, allow_failures = false)
-        Shell.run("cd #{self} && #{command}", allow_failures)
+        Dir.chdir(self) { Shell.run(command, allow_failures) }
       end
 
       def add_to_file(filename, content)

--- a/lib/license_finder/package_manager.rb
+++ b/lib/license_finder/package_manager.rb
@@ -33,6 +33,10 @@ module LicenseFinder
         .tap { |is_active| logger.active self.class, is_active }
     end
 
+    def capture(command)
+      [`#{command}`, $?.success?]
+    end
+
     def current_packages_with_relations
       packages = current_packages
       packages.each do |parent|

--- a/lib/license_finder/package_managers/bower.rb
+++ b/lib/license_finder/package_managers/bower.rb
@@ -11,7 +11,9 @@ module LicenseFinder
     private
 
     def bower_output
-      output = `cd #{project_path} && bower list --json -l action`
+      command = 'bower list --json -l action'
+      output, success = Dir.chdir(project_path) { capture(command) }
+      raise "Command '#{command}' failed to execute: #{output}" unless success
 
       JSON(output)
         .fetch("dependencies", {})

--- a/lib/license_finder/package_managers/go_workspace.rb
+++ b/lib/license_finder/package_managers/go_workspace.rb
@@ -25,8 +25,11 @@ module LicenseFinder
     end
 
     def package_paths
-      imports = `cd #{project_path} && go list -f "{{.ImportPath}} " ./...`
-      imports.gsub(/\s{2,}/, ',').split(',').map { |path| path[1..-1] }
+      command = 'go list -f "{{.ImportPath}} " ./...'
+      output, success = Dir.chdir(project_path) { capture(command) }
+      raise "Command '#{command}' failed to execute: #{output}" unless success
+
+      output.gsub(/\s{2,}/, ',').split(',').map { |path| path[1..-1] }
     end
   end
 end

--- a/lib/license_finder/package_managers/gradle.rb
+++ b/lib/license_finder/package_managers/gradle.rb
@@ -9,7 +9,9 @@ module LicenseFinder
     end
 
     def current_packages
-      `cd #{project_path} && #{@command} downloadLicenses`
+      command = "#{@command} downloadLicenses"
+      output, success = Dir.chdir(project_path) { capture(command) }
+      raise "Command '#{command}' failed to execute: #{output}" unless success
 
       dependencies = GradleDependencyFinder.new(project_path).dependencies
       packages = dependencies.flat_map do |xml_file|

--- a/lib/license_finder/package_managers/maven.rb
+++ b/lib/license_finder/package_managers/maven.rb
@@ -3,7 +3,9 @@ require "xmlsimple"
 module LicenseFinder
   class Maven < PackageManager
     def current_packages
-      `cd #{project_path} && mvn license:download-licenses`
+      command = 'mvn license:download-licenses'
+      output, success = Dir.chdir(project_path) { capture(command) }
+      raise "Command '#{command}' failed to execute: #{output}" unless success
 
       xml = license_report.read
 

--- a/lib/license_finder/package_managers/npm.rb
+++ b/lib/license_finder/package_managers/npm.rb
@@ -42,8 +42,9 @@ module LicenseFinder
     end
 
     def npm_json
-      command = "cd #{project_path} && npm list --json --long"
-      output, success = capture(command)
+      command = 'npm list --json --long'
+      output, success = Dir.chdir(project_path) { capture(command) }
+
       if success
         json = JSON(output)
       else
@@ -53,16 +54,13 @@ module LicenseFinder
                  nil
                end
         if json
-          $stderr.puts "Command #{command} returned error but parsing succeeded."
+          $stderr.puts "Command '#{command}' returned an error but parsing succeeded."
         else
-          raise "Command #{command} failed to execute: #{output}"
+          raise "Command '#{command}' failed to execute: #{output}"
         end
       end
-      json
-    end
 
-    def capture(command)
-      [`#{command}`, $?.success?]
+      json
     end
 
     def package_path

--- a/lib/license_finder/package_managers/rebar.rb
+++ b/lib/license_finder/package_managers/rebar.rb
@@ -21,18 +21,14 @@ module LicenseFinder
     private
 
     def rebar_ouput
-      command = "cd #{project_path} && #{@command} list-deps"
-      output, success = capture(command)
-      raise "Command #{command} failed to execute: #{output}" unless success
+      command = "#{@command} list-deps"
+      output, success = Dir.chdir(project_path) { capture(command) }
+      raise "Command '#{command}' failed to execute: #{output}" unless success
 
       output
         .each_line
         .reject { |line| line.start_with?("=") }
         .map { |line| line.split(" ") }
-    end
-
-    def capture(command)
-      [`#{command}`, $?.success?]
     end
 
     def package_path

--- a/spec/lib/license_finder/package_managers/bower_spec.rb
+++ b/spec/lib/license_finder/package_managers/bower_spec.rb
@@ -26,7 +26,9 @@ module LicenseFinder
             }
           }
         JSON
-        allow(subject).to receive('`').with('cd /fake/path && bower list --json -l action').and_return(json)
+
+        allow(Dir).to receive(:chdir).with(Pathname('/fake/path')) { |&block| block.call }
+        allow(subject).to receive(:capture).with('bower list --json -l action').and_return([json, true])
 
         expect(subject.current_packages.map { |p| [p.name, p.install_path] }).to eq [
           %w(dependency-library /path/to/thing), %w(another-dependency /path/to/thing2)

--- a/spec/lib/license_finder/package_managers/go_workspace_spec.rb
+++ b/spec/lib/license_finder/package_managers/go_workspace_spec.rb
@@ -19,7 +19,8 @@ module LicenseFinder
       }
 
       before do
-        allow_any_instance_of(Kernel).to receive('`').with('cd /Users/pivotal/workspace/loggregator && go list -f "{{.ImportPath}} " ./...').and_return(content.to_s)
+        allow(Dir).to receive(:chdir).with(Pathname('/Users/pivotal/workspace/loggregator')) { |&block| block.call }
+        allow(subject).to receive(:capture).with('go list -f "{{.ImportPath}} " ./...').and_return([content.to_s, true])
       end
 
       describe 'should return an array of go packages' do

--- a/spec/lib/license_finder/package_managers/gradle_spec.rb
+++ b/spec/lib/license_finder/package_managers/gradle_spec.rb
@@ -10,20 +10,22 @@ module LicenseFinder
 
     describe '#current_packages' do
       before do
-        allow(subject).to receive('`').with('cd /fake/path && gradle downloadLicenses')
+        allow(Dir).to receive(:chdir).with(Pathname('/fake/path')).and_return(['', true])
         dependencies = double(:subject_dependency_file, dependencies: content)
         expect(GradleDependencyFinder).to receive(:new).and_return(dependencies)
       end
 
       it 'uses custom subject command, if provided' do
-        subject = Gradle.new(gradle_command: 'subjectfoo', project_path: '/fake/path')
-        expect(subject).to receive('`').with('cd /fake/path && subjectfoo downloadLicenses')
+        subject = Gradle.new(gradle_command: 'subjectfoo', project_path: Pathname('/fake/path'))
+        expect(Dir).to receive(:chdir).with(Pathname('/fake/path')) { |&block| block.call }
+        expect(subject).to receive(:capture).with('subjectfoo downloadLicenses').and_return(['', true])
         subject.current_packages
       end
 
       it 'sets the working directory to project_path, if provided' do
-        subject = Gradle.new(project_path: '/Users/foo/bar')
-        expect(subject).to receive('`').with('cd /Users/foo/bar && gradle downloadLicenses')
+        subject = Gradle.new(project_path: Pathname('/Users/foo/bar'))
+        expect(Dir).to receive(:chdir).with(Pathname('/Users/foo/bar')) { |&block| block.call }
+        expect(subject).to receive(:capture).with('gradle downloadLicenses').and_return(['', true])
         subject.current_packages
       end
 

--- a/spec/lib/license_finder/package_managers/maven_spec.rb
+++ b/spec/lib/license_finder/package_managers/maven_spec.rb
@@ -19,7 +19,8 @@ module LicenseFinder
 
     describe '.current_packages' do
       before do
-        allow(subject).to receive('`').with('cd /fake/path && mvn license:download-licenses')
+        allow(Dir).to receive(:chdir).with(Pathname('/fake/path')) { |&block| block.call }
+        allow(subject).to receive(:capture).with('mvn license:download-licenses').and_return(['', true])
       end
 
       def stub_license_report(deps)

--- a/spec/lib/license_finder/package_managers/npm_spec.rb
+++ b/spec/lib/license_finder/package_managers/npm_spec.rb
@@ -115,10 +115,11 @@ module LicenseFinder
             }
           }
         JSON
-        allow(npm).to receive(:capture).with('cd /fake-node-project && npm list --json --long').and_return([json, true])
+
+        allow(Dir).to receive(:chdir).with(Pathname('/fake-node-project')) { |&block| block.call }
+        allow(npm).to receive(:capture).with('npm list --json --long').and_return([json, true])
 
         current_packages = npm.current_packages
-
         expect(current_packages.map(&:name)).to eq([])
       end
 

--- a/spec/lib/license_finder/package_managers/rebar_spec.rb
+++ b/spec/lib/license_finder/package_managers/rebar_spec.rb
@@ -13,37 +13,36 @@ jiffy TAG 0.9.0 https://github.com/davisp/jiffy.git
     CMDOUTPUT
 
     describe '.current_packages' do
+      before do
+        allow(Dir).to receive(:chdir).with(Pathname('/fake/path')) { |&block| block.call }
+      end
+
       it 'lists all the current packages' do
-        allow(subject).to receive(:capture).with('cd /fake/path && rebar list-deps').and_return([output, true])
+        allow(subject).to receive(:capture).with('rebar list-deps').and_return([output, true])
 
         current_packages = subject.current_packages
-
         expect(current_packages.map(&:name)).to eq(["uuid", "jiffy"])
         expect(current_packages.map(&:install_path)).to eq([Pathname("deps/uuid"), Pathname("deps/jiffy")])
       end
 
       it "fails when command fails" do
-        allow(subject).to receive(:capture).with(/rebar/).and_return('Some error', false).once
+        allow(subject).to receive(:capture).with(/rebar/).and_return(['Some error', false]).once
         expect { subject.current_packages }.to raise_error(RuntimeError)
       end
 
       it "uses custom rebar command, if provided" do
-        rebar = Rebar.new(rebar_command: "rebarfoo")
-
+        rebar = Rebar.new(rebar_command: "rebarfoo", project_path: Pathname('/fake/path'))
         allow(rebar).to receive(:capture).with(/rebarfoo/).and_return([output, true])
 
         current_packages = rebar.current_packages
-
         expect(current_packages.map(&:name)).to eq(["uuid", "jiffy"])
       end
 
       it "uses custom rebar_deps_dir, if provided" do
-        rebar = Rebar.new(rebar_deps_dir: "foo")
-
+        rebar = Rebar.new(rebar_deps_dir: "foo", project_path: Pathname('/fake/path'))
         allow(rebar).to receive(:capture).with(/rebar/).and_return([output, true])
 
         current_packages = rebar.current_packages
-
         expect(current_packages.map(&:install_path)).to eq([Pathname("foo/uuid"), Pathname("foo/jiffy")])
       end
     end


### PR DESCRIPTION
Avoid the use of "cd" and "&&" in both package managers and tests, as they are platform-specific.