### PR TITLE
reduce map & reject calls when applying decisions

### DIFF
--- a/lib/license_finder/decision_applier.rb
+++ b/lib/license_finder/decision_applier.rb
@@ -21,10 +21,11 @@ module LicenseFinder
 
     def apply_decisions(system_packages)
       all_packages = decisions.packages + system_packages
-      all_packages
-        .map { |package| with_decided_licenses(package) }
-        .map { |package| with_approval(package) }
-        .reject { |package| ignored?(package) }
+      all_packages.each_with_object([]) do |_pkg, packages|
+        pkg = with_decided_licenses(_pkg)
+        package = with_approval(pkg)
+        packages << package unless ignored?(package)
+      end
     end
 
     def ignored?(package)

--- a/lib/license_finder/decision_applier.rb
+++ b/lib/license_finder/decision_applier.rb
@@ -20,11 +20,14 @@ module LicenseFinder
     attr_reader :decisions
 
     def apply_decisions(system_packages)
-      all_packages = decisions.packages + system_packages
-      all_packages.each_with_object([]) do |_pkg, packages|
-        pkg = with_decided_licenses(_pkg)
-        package = with_approval(pkg)
-        packages << package unless ignored?(package)
+      [].tap do |packages|
+        all_packages = decisions.packages + system_packages
+        all_packages.each do |_pkg|
+          pkg = with_decided_licenses(_pkg)
+          package = with_approval(pkg)
+          next if ignored?(package)
+          packages << package
+        end
       end
     end
 


### PR DESCRIPTION
The `apply_decisions` method could be faster. The current layout IMO isn't readable enough to accept the compromise on speed. With this PR I'm offering a faster way to process the decisions on concerned packages. Instead of 3 new arrays, only 1 new array is created and instead of iterating over the packages array thrice, only one iteration is required. The effect in speed can be quickly checked by executing the `spec/lib/license_finder/decision_applier_spec.rb` test file.