### PR TITLE
removed ruby1.9.3 and jruby-19mode from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 rvm:
   - 2.1.0
   - 2.0.0
-  - 1.9.3
-  - jruby-19mode
   - ruby-head
   - jruby-head
 


### PR DESCRIPTION
bundler cannot install the required mime-types-data version on the rubies that have been removed in this PR.