### PR TITLE
Add support for approving particular versions of dependencies

### DIFF
--- a/lib/license_finder/cli/makes_decisions.rb
+++ b/lib/license_finder/cli/makes_decisions.rb
@@ -9,6 +9,7 @@ module LicenseFinder
         def auditable
           method_option :who, desc: "The person making this decision"
           method_option :why, desc: "The reason for making this decision"
+          method_option :version, desc: 'The version that will be approved'
         end
       end
 
@@ -18,6 +19,7 @@ module LicenseFinder
         @txn ||= {
           who: options[:who],
           why: options[:why],
+          versions: options[:version] ? [options[:version]] : [],
           when: Time.now.getutc
         }
       end

--- a/lib/license_finder/decision_applier.rb
+++ b/lib/license_finder/decision_applier.rb
@@ -42,8 +42,8 @@ module LicenseFinder
     def with_approval(package)
       if package.licenses.all? { |license| decisions.blacklisted?(license) }
         package.blacklisted!
-      elsif decisions.approved?(package.name)
-        package.approved_manually!(decisions.approval_of(package.name))
+      elsif decisions.approved?(package.name, package.version)
+        package.approved_manually!(decisions.approval_of(package.name, package.version))
       elsif package.licenses.any? { |license| decisions.whitelisted?(license) }
         package.whitelisted!
       end

--- a/lib/license_finder/decisions.rb
+++ b/lib/license_finder/decisions.rb
@@ -10,12 +10,20 @@ module LicenseFinder
       @licenses[name]
     end
 
-    def approval_of(name)
-      @approvals[name]
+    def approval_of(name, version=nil)
+      if version != nil
+        return @approvals[name] if !@approvals[name][:safe_versions].empty? && @approvals[name][:safe_versions].include?(version)
+      else
+        return @approvals[name] if @approvals[name][:safe_versions].empty?
+      end
     end
 
-    def approved?(name)
-      @approvals.has_key?(name)
+    def approved?(name, version=nil)
+      if version != nil
+        @approvals.has_key?(name) && !@approvals[name][:safe_versions].empty? && @approvals[name][:safe_versions].include?(version)
+      else
+        @approvals.has_key?(name)
+      end
     end
 
     def whitelisted?(lic)
@@ -38,9 +46,9 @@ module LicenseFinder
     # WRITE
     #######
 
-    TXN = Struct.new(:who, :why, :safe_when) do
+    TXN = Struct.new(:who, :why, :safe_when, :safe_versions) do
       def self.from_hash(txn)
-        new(txn[:who], txn[:why], txn[:when])
+        new(txn[:who], txn[:why], txn[:when], txn[:versions].nil? ? [] : txn[:versions])
       end
     end
 
@@ -81,7 +89,15 @@ module LicenseFinder
 
     def approve(name, txn = {})
       @decisions << [:approve, name, txn]
+
+      versions = []
+      if @approvals.has_key?(name)
+        versions = @approvals[name][:safe_versions]
+      end
+
       @approvals[name] = TXN.from_hash(txn)
+
+      @approvals[name][:safe_versions].concat(versions)
       self
     end
 

--- a/lib/license_finder/decisions.rb
+++ b/lib/license_finder/decisions.rb
@@ -11,16 +11,20 @@ module LicenseFinder
     end
 
     def approval_of(name, version=nil)
-      if version != nil
-        return @approvals[name] if !@approvals[name][:safe_versions].empty? && @approvals[name][:safe_versions].include?(version)
+      if !@approvals.has_key?(name)
+        nil
+      elsif version != nil
+        @approvals[name] if @approvals[name][:safe_versions].empty? || @approvals[name][:safe_versions].include?(version)
       else
-        return @approvals[name] if @approvals[name][:safe_versions].empty?
+        @approvals[name] if @approvals[name][:safe_versions].empty?
       end
     end
 
     def approved?(name, version=nil)
-      if version != nil
-        @approvals.has_key?(name) && !@approvals[name][:safe_versions].empty? && @approvals[name][:safe_versions].include?(version)
+      if !@approvals.has_key?(name)
+        nil
+      elsif version != nil
+        @approvals.has_key?(name) && @approvals[name][:safe_versions].empty? || @approvals[name][:safe_versions].include?(version)
       else
         @approvals.has_key?(name)
       end

--- a/spec/lib/license_finder/cli/approvals_spec.rb
+++ b/spec/lib/license_finder/cli/approvals_spec.rb
@@ -31,18 +31,20 @@ module LicenseFinder
           end
         end
 
-        it "sets approver and approval message" do
+        it "sets approver, approval message, and approval version" do
           subject.options = {
             who: "Julian",
-            why: "We really need this"
+            why: "We really need this",
+            version: '1.0.0.RELEASE'
           }
           silence_stdout do
             subject.add("foo")
           end
 
-          approval = subject.decisions.approval_of("foo")
+          approval = subject.decisions.approval_of("foo", '1.0.0.RELEASE')
           expect(approval.who).to eq "Julian"
           expect(approval.why).to eq "We really need this"
+          expect(approval.safe_versions).to eq ['1.0.0.RELEASE']
         end
       end
 

--- a/spec/lib/license_finder/cli/dependencies_spec.rb
+++ b/spec/lib/license_finder/cli/dependencies_spec.rb
@@ -39,6 +39,17 @@ module LicenseFinder
           expect(approval.who).to eq "Julian"
           expect(approval.why).to eq "We really need this"
         end
+
+        it 'has an --approve option to approve the added dependency & version combination' do
+          subject.options = { approve: true, who: "Julian", why: "We really need this", version: '1.0.0.RELEASE' }
+          silence_stdout do
+            subject.add("js_dep", "MIT")
+          end
+          approval = subject.decisions.approval_of("js_dep", '1.0.0.RELEASE')
+          expect(approval.who).to eq "Julian"
+          expect(approval.why).to eq "We really need this"
+          expect(approval.safe_versions).to eq ['1.0.0.RELEASE']
+        end
       end
 
       describe "remove" do

--- a/spec/lib/license_finder/decision_applier_spec.rb
+++ b/spec/lib/license_finder/decision_applier_spec.rb
@@ -147,6 +147,24 @@ module LicenseFinder
         expect(dep).to be_approved
         expect(dep).to be_approved_manually
       end
+
+      it 'returns an approval if the requested package has been approved, but no version was specified' do
+        decisions = Decisions.new
+                        .add_package('spring-boot', '1.3.0.RELEASE')
+                        .approve('spring-boot', versions: [], who: 'Approver', why: 'Because')
+        decision_applier = described_class.new(decisions: decisions, packages: [])
+        dep = decision_applier.acknowledged.last
+        expect(dep).to be_approved
+        expect(dep).to be_approved_manually
+      end
+
+      it 'does not return an approval if no dependencies have been approved' do
+        decisions = Decisions.new
+                        .add_package('spring-boot', '1.3.0.RELEASE')
+        decision_applier = described_class.new(decisions: decisions, packages: [])
+        dep = decision_applier.acknowledged.last
+        expect(dep).to_not be_approved
+      end
     end
 
     describe '#unapproved' do

--- a/spec/lib/license_finder/decision_applier_spec.rb
+++ b/spec/lib/license_finder/decision_applier_spec.rb
@@ -119,6 +119,34 @@ module LicenseFinder
         expect(dep).to be_approved
         expect(dep).to be_approved_manually
       end
+
+      it 'does not return an approval for a package without a version if all approvals have an explicit version' do
+        decisions = Decisions.new
+                        .add_package('spring-boot', nil)
+                        .approve('spring-boot', versions: ['1.3.0.RELEASE'], who: 'Approver', why: 'Because')
+        decision_applier = described_class.new(decisions: decisions, packages: [])
+        dep = decision_applier.acknowledged.last
+        expect(dep).to_not be_approved
+      end
+
+      it 'does not return an approval if the package has the wrong version' do
+        decisions = Decisions.new
+                        .add_package('spring-boot', '1.3.1.RELEASE')
+                        .approve('spring-boot', versions: ['1.3.0.RELEASE'], who: 'Approver', why: 'Because')
+        decision_applier = described_class.new(decisions: decisions, packages: [])
+        dep = decision_applier.acknowledged.last
+        expect(dep).to_not be_approved
+      end
+
+      it 'returns an approval if the requested package has an approved version' do
+        decisions = Decisions.new
+                        .add_package('spring-boot', '1.3.0.RELEASE')
+                        .approve('spring-boot', versions: ['1.3.0.RELEASE'], who: 'Approver', why: 'Because')
+        decision_applier = described_class.new(decisions: decisions, packages: [])
+        dep = decision_applier.acknowledged.last
+        expect(dep).to be_approved
+        expect(dep).to be_approved_manually
+      end
     end
 
     describe '#unapproved' do


### PR DESCRIPTION
Resolves #183 - you can now approve dependencies on a version-by-version basis. Might need more work to make it clear when a dependency is approved for a specific version, but you're using an earlier/later version, which is not approved.