### PR TITLE
Switch to using git submodules for go projects with .envrc file

### DIFF
--- a/spec/lib/license_finder/package_managers/go_workspace_spec.rb
+++ b/spec/lib/license_finder/package_managers/go_workspace_spec.rb
@@ -8,6 +8,7 @@ module LicenseFinder
     describe '#current_packages' do
       let(:content) {
         '_/Users/pivotal/workspace/loggregator/src/bitbucket.org/kardianos/osext
+         _/Users/pivotal/workspace/loggregator/src/bitbucket.org/kardianos/osext/something
          _/Users/pivotal/workspace/loggregator/src/deaagent
          _/Users/pivotal/workspace/loggregator/src/deaagent/deaagent
          _/Users/pivotal/workspace/loggregator/src/deaagent/domain
@@ -18,9 +19,14 @@ module LicenseFinder
          _/Users/pivotal/workspace/loggregator/src/doppler/groupedsinks/sink_wrapper'
       }
 
+      let(:git_modules) {
+        "b8a35001b773c267e src/bitbucket.org/kardianos/osext (heads/master)"
+      }
+
       before do
         allow(Dir).to receive(:chdir).with(Pathname('/Users/pivotal/workspace/loggregator')) { |&block| block.call }
         allow(subject).to receive(:capture).with('go list -f "{{.ImportPath}} " ./...').and_return([content.to_s, true])
+        allow(subject).to receive(:capture).with('git submodule status').and_return([git_modules, true])
       end
 
       describe 'should return an array of go packages' do
@@ -28,41 +34,57 @@ module LicenseFinder
           packages = subject.current_packages
           first_package = packages.first
           expect(first_package.name).to eq 'bitbucket.org/kardianos/osext'
-          expect(first_package.version).to eq 'unknown'
+          expect(first_package.version).to eq 'b8a3500'
           expect(first_package.install_path).to eq '/Users/pivotal/workspace/loggregator/src/bitbucket.org/kardianos/osext'
         end
-      end
-    end
 
-    describe '#package_path' do
-      it 'returns the package_path' do
-        expect(subject.package_path).to eq Pathname('/Users/pivotal/workspace/loggregator/.envrc')
-      end
-    end
+        it 'should filter the subpackages' do
+          packages = subject.current_packages
+          packages = packages.select { |p| p.name.include?("bitbucket.org") }
+          expect(packages.count).to eq(1)
+        end
 
-    describe '#active?' do
-      let(:envrc)   { '/Users/pivotal/workspace/loggregator/.envrc' }
+        context 'if git submodule status fails' do
+          before do
+            allow(subject).to receive(:capture).with('git submodule status').and_return(['', false])
+          end
 
-      it 'returns true when .envrc contains GOPATH' do
-        allow(FileTest).to receive(:exist?).with(envrc).and_return(true)
-        allow(IO).to receive(:read).with(Pathname(envrc)).and_return('export GOPATH=/foo/bar')
-        expect(subject.active?).to eq(true)
-      end
-
-      it 'returns false when .envrc does not contain GOPATH' do
-        allow(FileTest).to receive(:exist?).with(envrc).and_return(true)
-        allow(IO).to receive(:read).with(Pathname(envrc)).and_return('this is not an envrc file')
-        expect(subject.active?).to eq(false)
+          it 'should raise an exception' do
+            expect { subject.current_packages }.to raise_exception(/git submodule status failed/)
+          end
+        end
       end
 
-      it 'returns false when .envrc does not exist' do
-        allow(FileTest).to receive(:exist?).with(envrc).and_return(false)
-        expect(subject.active?).to eq(false)
+      describe '#package_path' do
+        it 'returns the package_path' do
+          expect(subject.package_path).to eq Pathname('/Users/pivotal/workspace/loggregator/.envrc')
+        end
       end
 
-      it 'logs the active state' do
-        expect(logger).to receive(:active)
-        subject.active?
+      describe '#active?' do
+        let(:envrc)   { '/Users/pivotal/workspace/loggregator/.envrc' }
+
+        it 'returns true when .envrc contains GOPATH' do
+          allow(FileTest).to receive(:exist?).with(envrc).and_return(true)
+          allow(IO).to receive(:read).with(Pathname(envrc)).and_return('export GOPATH=/foo/bar')
+          expect(subject.active?).to eq(true)
+        end
+
+        it 'returns false when .envrc does not contain GOPATH' do
+          allow(FileTest).to receive(:exist?).with(envrc).and_return(true)
+          allow(IO).to receive(:read).with(Pathname(envrc)).and_return('this is not an envrc file')
+          expect(subject.active?).to eq(false)
+        end
+
+        it 'returns false when .envrc does not exist' do
+          allow(FileTest).to receive(:exist?).with(envrc).and_return(false)
+          expect(subject.active?).to eq(false)
+        end
+
+        it 'logs the active state' do
+          expect(logger).to receive(:active)
+          subject.active?
+        end
       end
     end
   end


### PR DESCRIPTION
Previously `go list` was used to list the projects in the current
directory. This is unecessary since most projects that use .envrc
submodule their dependencies. Also, `go list` will report the project
in interest (as well as its dependencies) which is uneeded.

Signed-off-by: John Shahid <jshahid@pivotal.io>