### PR TITLE
Add an option to view the full SHA for Go projects

### DIFF
--- a/lib/license_finder/cli/base.rb
+++ b/lib/license_finder/cli/base.rb
@@ -28,6 +28,7 @@ module LicenseFinder
         extract_options(
           :project_path,
           :decisions_file,
+          :go_full_version,
           :gradle_command,
           :rebar_command,
           :rebar_deps_dir,

--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -20,6 +20,7 @@ module LicenseFinder
       class_option :format, desc: "The desired output format.", default: 'text', enum: FORMATS.keys
       class_option :columns, type: :array, desc: "For CSV reports, which columns to print. Pick from: #{CsvReport::AVAILABLE_COLUMNS}", default: %w[name version licenses]
       class_option :save, desc: "Save report to a file. Default: 'license_report.csv' in project root.", lazy_default: "license_report"
+      class_option :go_full_version, desc: "Whether dependency version should include full version. Only meaningful if used with a Go project. Defaults to false."
       class_option :gradle_command, desc: "Command to use when fetching gradle packages. Only meaningful if used with a Java/gradle project. Defaults to 'gradlew' / 'gradlew.bat' if the wrapper is present, otherwise to 'gradle'."
       class_option :rebar_command, desc: "Command to use when fetching rebar packages. Only meaningful if used with a Erlang/rebar project. Defaults to 'rebar'."
       class_option :rebar_deps_dir, desc: "Path to rebar dependencies directory. Only meaningful if used with a Erlang/rebar project. Defaults to 'deps'."

--- a/lib/license_finder/configuration.rb
+++ b/lib/license_finder/configuration.rb
@@ -35,6 +35,10 @@ module LicenseFinder
       )
     end
 
+    def go_full_version
+      get(:go_full_version)
+    end
+
     def rebar_command
       get(:rebar_command) || 'rebar'
     end

--- a/lib/license_finder/core.rb
+++ b/lib/license_finder/core.rb
@@ -64,6 +64,7 @@ module LicenseFinder
         logger: logger,
         project_path: config.project_path,
         ignore_groups: decisions.ignored_groups,
+        go_full_version: config.go_full_version,
         gradle_command: config.gradle_command,
         rebar_command: config.rebar_command,
         rebar_deps_dir: config.rebar_deps_dir,

--- a/lib/license_finder/package_managers/go_dep.rb
+++ b/lib/license_finder/package_managers/go_dep.rb
@@ -2,9 +2,15 @@ require 'json'
 
 module LicenseFinder
   class GoDep < PackageManager
+
+    def initialize(options={})
+      super
+      @full_version = options[:go_full_version]
+    end
+
     def current_packages
       json = JSON.parse(package_path.read)
-      json['Deps'].map { |dep| GoPackage.from_dependency(dep, install_prefix) }
+      json['Deps'].map { |dep| GoPackage.from_dependency(dep, install_prefix, @full_version) }
     end
 
     def package_path

--- a/lib/license_finder/package_managers/go_package.rb
+++ b/lib/license_finder/package_managers/go_package.rb
@@ -4,9 +4,9 @@ module LicenseFinder
       LicenseFinder::Package.new(name, 'unknown', {install_path: install_path(path)})
     end
 
-    def self.from_dependency(hash, prefix)
+    def self.from_dependency(hash, prefix,full_version)
       name = hash['ImportPath']
-      version = hash['Rev'][0..6]
+      version = full_version ? hash['Rev'] : hash['Rev'][0..6]
       LicenseFinder::Package.new(name, version, {install_path: install_path(prefix.join(name))})
     end
 

--- a/lib/license_finder/package_managers/go_workspace.rb
+++ b/lib/license_finder/package_managers/go_workspace.rb
@@ -4,10 +4,15 @@ module LicenseFinder
   class GoWorkspace < PackageManager
     Submodule = Struct.new :path, :revision
 
+    def initialize(options={})
+      super
+      @full_version = options[:go_full_version]
+    end
+
     def current_packages
       submodules.map do |submodule|
         import_path = Pathname.new(submodule.path).relative_path_from(project_src)
-        GoPackage.from_dependency({'ImportPath' => import_path.to_s, 'Rev' => submodule.revision}, project_src)
+        GoPackage.from_dependency({'ImportPath' => import_path.to_s, 'Rev' => submodule.revision}, project_src, @full_version)
       end
     end
 

--- a/spec/lib/license_finder/core_spec.rb
+++ b/spec/lib/license_finder/core_spec.rb
@@ -27,6 +27,7 @@ module LicenseFinder
           logger: logger,
           project_path: configuration.project_path,
           ignore_groups: Set.new,
+          go_full_version: nil,
           gradle_command: configuration.gradle_command,
           rebar_command: configuration.rebar_command,
           rebar_deps_dir: configuration.rebar_deps_dir

--- a/spec/lib/license_finder/package_managers/go_dep_spec.rb
+++ b/spec/lib/license_finder/package_managers/go_dep_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 module LicenseFinder
   describe GoDep do
-    subject { GoDep.new(project_path: Pathname('/fake/path')) }
+    let(:options) { {} }
+    subject { GoDep.new(options.merge(project_path: Pathname('/fake/path'))) }
+
 
     it_behaves_like 'a PackageManager'
 
@@ -43,6 +45,15 @@ module LicenseFinder
           packages = subject.current_packages
           expect(packages[0].install_path).to eq('/fake/path/Godeps/_workspace/src/github.com/pivotal/foo')
           expect(packages[1].install_path).to eq('/fake/path/Godeps/_workspace/src/github.com/pivotal/bar')
+        end
+
+        context 'when requesting the full version' do
+          let(:options) { { go_full_version:true } }
+          it 'list the dependencies with full version' do
+            expect(subject.current_packages.map(&:version)).to eq [
+              "61164e49940b423ba1f12ddbdf01632ac793e5e9",
+              "3245708abcdef234589450649872346783298736"]
+          end
         end
       end
 

--- a/spec/lib/license_finder/package_managers/go_workspace_spec.rb
+++ b/spec/lib/license_finder/package_managers/go_workspace_spec.rb
@@ -2,8 +2,9 @@ require 'spec_helper'
 
 module LicenseFinder
   describe GoWorkspace do
+    let(:options) { {} }
     let(:logger) { double(:logger, active: nil) }
-    subject { GoWorkspace.new(project_path: Pathname('/Users/pivotal/workspace/loggregator'), logger: logger) }
+    subject { GoWorkspace.new(options.merge(project_path: Pathname('/Users/pivotal/workspace/loggregator'), logger: logger)) }
 
     describe '#current_packages' do
       let(:content) {
@@ -51,6 +52,13 @@ module LicenseFinder
 
           it 'should raise an exception' do
             expect { subject.current_packages }.to raise_exception(/git submodule status failed/)
+          end
+        end
+
+        context 'when requesting the full version' do
+          let(:options) { { go_full_version:true } }
+          it 'list the dependencies with full version' do
+            expect(subject.current_packages.map(&:version)).to eq ["b8a35001b773c267e"]
           end
         end
       end


### PR DESCRIPTION
Given a Go project (GoDep/Go workspace) we should be able to emit the full
SHA/version of a dependency.

A/C: I should be able to pass `--go_full_version` and get the full SHA.