### PR TITLE
Run gradle with `--console plain`

### DIFF
--- a/lib/license_finder/configuration.rb
+++ b/lib/license_finder/configuration.rb
@@ -31,7 +31,8 @@ module LicenseFinder
           gradle = 'gradle'
         end
 
-        File.exist?(wrapper) ? wrapper : gradle
+        executable = File.exist?(wrapper) ? wrapper : gradle
+        "#{executable} --console plain"
       )
     end
 

--- a/lib/license_finder/package_managers/gradle.rb
+++ b/lib/license_finder/package_managers/gradle.rb
@@ -5,7 +5,7 @@ module LicenseFinder
   class Gradle < PackageManager
     def initialize(options={})
       super
-      @command = options[:gradle_command] || 'gradle'
+      @command = options[:gradle_command] || 'gradle --console plain'
       @include_groups = options[:gradle_include_groups]
     end
 

--- a/spec/lib/license_finder/configuration_spec.rb
+++ b/spec/lib/license_finder/configuration_spec.rb
@@ -53,7 +53,7 @@ module LicenseFinder
           {gradle_command: nil},
           {"gradle_command" => nil}
         )
-        expect(subject.gradle_command).to eq "gradle"
+        expect(subject.gradle_command).to eq "gradle --console plain"
       end
     end
 

--- a/spec/lib/license_finder/package_managers/gradle_spec.rb
+++ b/spec/lib/license_finder/package_managers/gradle_spec.rb
@@ -27,9 +27,10 @@ module LicenseFinder
       it 'sets the working directory to project_path, if provided' do
         subject = Gradle.new(project_path: Pathname('/Users/foo/bar'))
         expect(Dir).to receive(:chdir).with(Pathname('/Users/foo/bar')) { |&block| block.call }
-        expect(subject).to receive(:capture).with('gradle downloadLicenses').and_return(['', true])
+        expect(subject).to receive(:capture).with('gradle --console plain downloadLicenses').and_return(['', true])
         subject.current_packages
       end
+
 
       context 'when dependencies are found' do
         let(:content) do


### PR DESCRIPTION
Without this option gradle will try to use termcaps which doesn't work
on CI.

Signed-off-by: Amin Jamali <ajamali@pivotal.io>