### PR TITLE
dedup godep dependencies

### DIFF
--- a/spec/lib/license_finder/package_managers/go_dep_spec.rb
+++ b/spec/lib/license_finder/package_managers/go_dep_spec.rb
@@ -57,6 +57,35 @@ module LicenseFinder
         end
       end
 
+      context 'when there are duplicate dependencies' do
+        let(:content) do
+          '{
+	           "ImportPath": "github.com/foo/bar",
+	           "GoVersion": "go1.3",
+	           "Deps": [
+	           	{
+	           		"ImportPath": "github.com/foo/baz/sub1",
+	           		"Rev": "28838aae6e8158e3695cf90e2f0ed2498b68ee1d"
+	           	},
+	           	{
+	           		"ImportPath": "github.com/foo/baz/sub2",
+	           		"Rev": "28838aae6e8158e3695cf90e2f0ed2498b68ee1d"
+	           	},
+	           	{
+	           		"ImportPath": "github.com/foo/baz/sub3",
+	           		"Rev": "28838aae6e8158e3695cf90e2f0ed2498b68ee1d"
+	           	}
+            ]
+          }'
+        end
+
+        it 'should return one dependency only' do
+          packages = subject.current_packages
+          expect(packages.map(&:name)).to eq(['github.com/foo/baz'])
+          expect(packages.map(&:version)).to eq(['28838aa'])
+        end
+      end
+
       context 'when dependencies are not vendored' do
         before do
           ENV['GOPATH'] = '/fake/go/path'


### PR DESCRIPTION
This patch will dedup dependencies, for example
`github.com/foo/baz/sub1` and `github.com/foo/baz/sub2` will be reported
as `github.com/foo/baz` as long as they have the same sha.

Signed-off-by: John Shahid <jshahid@pivotal.io>