### PR TITLE
Uses license_url as the license of nuget packages

### DIFF
--- a/license_finder.gemspec
+++ b/license_finder.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "capybara", "~> 2.0.0"
   s.add_development_dependency "cocoapods", "0.34.0" if LicenseFinder::Platform.darwin?
   s.add_development_dependency "fakefs", "~> 0.6.7"
+  s.add_development_dependency "rubyzip"
   s.add_development_dependency "pry"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 3"


### PR DESCRIPTION
Most nuget packages set a url to their licenses in the nuspec file which
is located inside the nupkg zip file. Note, this will only work if the
nupkgs are checked in the repo.

Signed-off-by: John Shahid <jshahid@pivotal.io>