### PR TITLE
includes packages.config inside .nuget directories

### DIFF
--- a/lib/license_finder/package_managers/nuget.rb
+++ b/lib/license_finder/package_managers/nuget.rb
@@ -8,7 +8,7 @@ module LicenseFinder
     end
 
     def assemblies
-      Dir[project_path.join("**", "packages.config")].map do |d|
+      Dir.glob(project_path.join("**", "packages.config"), File::FNM_DOTMATCH).map do |d|
         path = Pathname.new(d).dirname
         name = path.basename.to_s
         Assembly.new path, name

--- a/spec/lib/license_finder/package_managers/nuget_spec.rb
+++ b/spec/lib/license_finder/package_managers/nuget_spec.rb
@@ -24,6 +24,18 @@ module LicenseFinder
         nuget = Nuget.new project_path: Pathname.new("app")
         expect(nuget.assemblies.map(&:name)).to match_array ['Assembly1', 'Assembly1.Tests', 'Assembly2']
       end
+
+      context 'when packages.config is in .nuget directory' do
+        before do
+          FileUtils.mkdir_p 'app/.nuget'
+          FileUtils.touch 'app/.nuget/packages.config'
+        end
+
+        it "finds dependencies all subdirectories containing a packages.config" do
+          nuget = Nuget.new project_path: Pathname.new("app")
+          expect(nuget.assemblies.map(&:name)).to include('.nuget')
+        end
+      end
     end
 
     describe "#current_packages" do


### PR DESCRIPTION
prior to this change we missed a few packages.config because Dir[]
doesn't include dot directories.

Signed-off-by: Amin Jamali <ajamali@pivotal.io>