### PR TITLE
Fixes a bug when multiple go packages share the same prefix

### DIFF
--- a/lib/license_finder/package_managers/go_workspace.rb
+++ b/lib/license_finder/package_managers/go_workspace.rb
@@ -13,7 +13,7 @@ module LicenseFinder
       go_list_packages = go_list
       git_modules.map do |submodule|
         import_path = go_list_packages.select { |gp|
-          submodule.install_path =~ /#{repo_name(gp)}/
+          submodule.install_path =~ /#{repo_name(gp)}$/
         }.first
         if import_path then
           GoPackage.from_dependency({

--- a/spec/lib/license_finder/package_managers/go_workspace_spec.rb
+++ b/spec/lib/license_finder/package_managers/go_workspace_spec.rb
@@ -153,6 +153,25 @@ HERE
             expect(packages.map(&:name)).to eq(['bitbucket.org/kardianos/osext'])
           end
         end
+
+        context 'when only the subpackage is being used' do
+          let(:git_modules_output) {
+            [GoWorkspace::Submodule.new("/Users/pivotal/workspace/loggregator/vendor/src/github.com/onsi/foo", "e762c377b10053a8b"),
+             GoWorkspace::Submodule.new("/Users/pivotal/workspace/loggregator/vendor/src/github.com/onsi/foobar", "b8a35001b773c267e")]
+          }
+
+          let(:go_list_output) {
+            [
+             "github.com/onsi/foo",
+             "github.com/onsi/foobar",
+            ]
+          }
+
+          it 'returns the top level repo name as the import path' do
+            packages = subject.current_packages
+            expect(packages.map(&:name)).to eq(['github.com/onsi/foo', 'github.com/onsi/foobar'])
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Prior to this fix if a go project had two dependencies such as
`github.com/pivotal/foo' and `github.com/pivotal/foobar', LF would
return only `github.com/pivotal/foo'