### PR TITLE
Allow `groups` as an available column for CSV

### DIFF
--- a/lib/license_finder/reports/csv_report.rb
+++ b/lib/license_finder/reports/csv_report.rb
@@ -3,7 +3,7 @@ require 'csv'
 module LicenseFinder
   class CsvReport < Report
     COMMA_SEP =  ","
-    AVAILABLE_COLUMNS = %w[name version authors licenses approved summary description homepage install_path package_manager]
+    AVAILABLE_COLUMNS = %w[name version authors licenses approved summary description homepage install_path package_manager groups]
     MISSING_DEPENDENCY_TEXT = "This package is not installed. Please install to determine licenses."
 
     def initialize(dependencies, options)
@@ -69,6 +69,10 @@ module LicenseFinder
 
     def format_package_manager(dep)
       dep.package_manager
+    end
+
+    def format_groups(dep)
+      dep.groups.join(",")
     end
   end
 end

--- a/spec/lib/license_finder/reports/csv_report_spec.rb
+++ b/spec/lib/license_finder/reports/csv_report_spec.rb
@@ -40,5 +40,23 @@ module LicenseFinder
       subject = described_class.new([dep], columns: %w[subproject_paths])
       expect(subject.to_s).to eq("\n")
     end
+
+    context "when no groups are specified" do
+      let( :dep ) { Package.new('gem_a', '1.0') }
+      subject { described_class.new([dep], columns: %w[name version groups]) }
+
+      it 'supports a groups column' do
+        expect(subject.to_s).to eq("gem_a,1.0,\"\"\n")
+      end
+    end
+
+    context "when some groups are specified" do
+      let( :dep ) { Package.new('gem_a', '1.0', groups: %w[development production]) }
+      subject { described_class.new([dep], columns: %w[name version groups]) }
+
+      it 'supports a groups column' do
+        expect(subject.to_s).to eq("gem_a,1.0,\"development,production\"\n")
+      end
+    end
   end
 end


### PR DESCRIPTION
This change adds `groups` to the `AVAILABLE_COLUMNS` for `--format csv`.

Background
----------

It is useful to know the "groups" in which a dependency exists because
license restrictions may apply differently for different uses
(e.g. AGPL ramifications for SaaS on local development versus running on
a production server).