### PR TITLE
conditionally invoke package manager only when a package manager is required and is installed

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,31 +26,10 @@ end
 
 desc "Check for non-Ruby development dependencies."
 task :check_dependencies do
-  dependencies = {
-    "mvn" => "Maven",
-    "npm" => "NPM",
-    "pip" => "Pip",
-    "gradle" => "Gradle",
-    "bower" => "Bower",
-    "rebar" => "Rebar",
-    "godep" => "Go"
-  }
-  dependencies["pod"] = "Cocoapods" if LicenseFinder::Platform.darwin?
+  require './lib/license_finder'
   satisfied = true
-  dependencies.each do |dependency, description|
-    printf "checking dev dependency for #{description} ... "
-    if LicenseFinder::Platform.windows?
-      `where #{dependency} 2>NUL`
-    else
-      `which #{dependency} 2>/dev/null`
-    end
-    status = $?
-    if status.success?
-      puts "OK"
-    else
-      puts "missing `#{dependency}`"
-      satisfied = false
-    end
+  LicenseFinder::PackageManager.package_managers.each do |package_manager|
+    satisfied = false unless package_manager.installed?(LicenseFinder::Logger.new(debug:true))
   end
   exit 1 unless satisfied
 end

--- a/lib/license_finder/logger.rb
+++ b/lib/license_finder/logger.rb
@@ -12,8 +12,22 @@ module LicenseFinder
     end
 
     class Base
+      def installed package_manager, is_installed
+        if String === is_installed
+          log package_manager, is_installed
+        elsif is_installed
+          log package_manager, Logger.green("is installed")
+        else
+          log package_manager, Logger.red("is not installed")
+        end
+      end
+
       def active package_manager, is_active
-        log package_manager, sprintf("%s active", (is_active ? "is" : "not"))
+        if is_active
+          log package_manager, Logger.green("is active")
+        else
+          log package_manager, "is not active"
+        end
       end
 
       def package package_manager, package
@@ -42,6 +56,18 @@ module LicenseFinder
       def log prefix, string
         raise NotImplementedError, "#log must be implemented"
       end
+    end
+
+    def self.green string
+      colorize 32, string
+    end
+
+    def self.red string
+      colorize 31, string
+    end
+
+    def self.colorize color_code, string
+      "\e[#{color_code}m#{string}\e[0m"
     end
 
     class Quiet < Base

--- a/lib/license_finder/package_managers/bower.rb
+++ b/lib/license_finder/package_managers/bower.rb
@@ -8,6 +8,10 @@ module LicenseFinder
       end
     end
 
+    def self.package_management_command
+      "bower"
+    end
+
     private
 
     def bower_output

--- a/lib/license_finder/package_managers/bundler.rb
+++ b/lib/license_finder/package_managers/bundler.rb
@@ -17,6 +17,10 @@ module LicenseFinder
       end
     end
 
+    def self.package_management_command
+      "bundler"
+    end
+
     private
 
     attr_reader :ignore_groups

--- a/lib/license_finder/package_managers/cocoa_pods.rb
+++ b/lib/license_finder/package_managers/cocoa_pods.rb
@@ -19,6 +19,10 @@ module LicenseFinder
       end
     end
 
+    def self.package_management_command
+      LicenseFinder::Platform.darwin? ? "pod" : nil
+    end
+
     private
 
     def package_path

--- a/lib/license_finder/package_managers/go_dep.rb
+++ b/lib/license_finder/package_managers/go_dep.rb
@@ -23,6 +23,10 @@ module LicenseFinder
       project_path.join('Godeps/Godeps.json')
     end
 
+    def self.package_management_command
+      "godep"
+    end
+
     private
 
     def install_prefix

--- a/lib/license_finder/package_managers/go_vendor.rb
+++ b/lib/license_finder/package_managers/go_vendor.rb
@@ -9,7 +9,15 @@ module LicenseFinder
     end
 
     def active?
-      !Dir[project_path.join("**/*.go")].empty? && package_path.exist?
+      return false unless self.class.installed?(@logger)
+
+      (has_go_files? && package_path.exist?).tap do |is_active|
+        logger.active self.class, is_active
+      end
+    end
+
+    def has_go_files?
+      !Dir[project_path.join("**/*.go")].empty?
     end
 
     def package_path

--- a/lib/license_finder/package_managers/go_workspace.rb
+++ b/lib/license_finder/package_managers/go_workspace.rb
@@ -31,9 +31,12 @@ module LicenseFinder
     end
 
     def active?
-      go_dep = LicenseFinder::GoDep.new({project_path: Pathname(project_path), logger: logger})
-      return if go_dep.package_path.exist?
-      active = !! (envrc_path && ENVRC_REGEXP.match(IO.read(envrc_path)))
+      return false unless self.class.installed?(logger)
+
+      godep = LicenseFinder::GoDep.new({project_path: Pathname(project_path)})
+      # go workspace is only active if GoDep wasn't. There are some projects
+      # that will use the .envrc and have a Godep folder as well.
+      active = !! (!godep.active? && envrc_path && ENVRC_REGEXP.match(IO.read(envrc_path)))
       active.tap { |is_active| logger.active self.class, is_active }
     end
 

--- a/lib/license_finder/package_managers/gradle.rb
+++ b/lib/license_finder/package_managers/gradle.rb
@@ -26,6 +26,10 @@ module LicenseFinder
       packages.uniq
     end
 
+    def self.package_management_command
+      "gradle"
+    end
+
     private
 
     def package_path

--- a/lib/license_finder/package_managers/maven.rb
+++ b/lib/license_finder/package_managers/maven.rb
@@ -20,6 +20,10 @@ module LicenseFinder
       end
     end
 
+    def self.package_management_command
+      "mvn"
+    end
+
     private
 
     def license_report

--- a/lib/license_finder/package_managers/npm.rb
+++ b/lib/license_finder/package_managers/npm.rb
@@ -22,6 +22,10 @@ module LicenseFinder
       packages.values
     end
 
+    def self.package_management_command
+      "npm"
+    end
+
     private
 
     def direct_dependencies

--- a/lib/license_finder/package_managers/pip.rb
+++ b/lib/license_finder/package_managers/pip.rb
@@ -16,6 +16,10 @@ module LicenseFinder
       end
     end
 
+    def self.package_management_command
+      "pip"
+    end
+
     private
 
     def package_path

--- a/lib/license_finder/package_managers/rebar.rb
+++ b/lib/license_finder/package_managers/rebar.rb
@@ -18,6 +18,10 @@ module LicenseFinder
       end
     end
 
+    def self.package_management_command
+      "rebar"
+    end
+
     private
 
     def rebar_ouput

--- a/license_finder.gemspec
+++ b/license_finder.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |s|
   s.add_dependency "thor"
   s.add_dependency "httparty"
   s.add_dependency "xml-simple"
+  s.add_dependency "colorize"
 
   s.add_development_dependency "capybara", "~> 2.0.0"
   s.add_development_dependency "cocoapods", "0.34.0" if LicenseFinder::Platform.darwin?

--- a/spec/fixtures/all_pms/.envrc
+++ b/spec/fixtures/all_pms/.envrc
@@ -1,0 +1,1 @@
+GOPATH=$PWD

--- a/spec/lib/license_finder/package_manager_spec.rb
+++ b/spec/lib/license_finder/package_manager_spec.rb
@@ -18,5 +18,45 @@ module LicenseFinder
         ])
       end
     end
+
+    describe "#package_management_command" do
+      it "defaults to nil" do
+        expect(LicenseFinder::PackageManager.package_management_command).to be_nil
+      end
+    end
+
+    describe ".installed?" do
+      context "package_management_command is nil" do
+        before do
+          allow(LicenseFinder::PackageManager).to receive(:package_management_command).and_return(nil)
+        end
+
+        it "returns true" do
+          expect(LicenseFinder::PackageManager.installed?).to be_truthy
+        end
+      end
+
+      context "package_management_command exists" do
+        before do
+          allow(LicenseFinder::PackageManager).to receive(:package_management_command).and_return("foobar")
+          allow(LicenseFinder::PackageManager).to receive(:command_exists?).with("foobar").and_return(true)
+        end
+
+        it "returns true" do
+          expect(LicenseFinder::PackageManager.installed?).to be_truthy
+        end
+      end
+
+      context "package_management_command does not exist" do
+        before do
+          allow(LicenseFinder::PackageManager).to receive(:package_management_command).and_return("foobar")
+          allow(LicenseFinder::PackageManager).to receive(:command_exists?).with("foobar").and_return(false)
+        end
+
+        it "returns false" do
+          expect(LicenseFinder::PackageManager.installed?).to be_falsey
+        end
+      end
+    end
   end
 end

--- a/spec/lib/license_finder/package_managers/go_vendor_spec.rb
+++ b/spec/lib/license_finder/package_managers/go_vendor_spec.rb
@@ -5,10 +5,24 @@ module LicenseFinder
   describe GoVendor do
     include FakeFS::SpecHelpers
 
-    let(:project_path) { '/app' }
-    let(:options) { {} }
     let(:logger) { double(:logger, active: nil) }
     subject { GoVendor.new(options.merge(project_path: Pathname(project_path), logger: logger)) }
+
+    before do
+      allow(logger).to receive(:installed)
+      allow(logger).to receive(:active)
+    end
+
+    context 'package manager' do
+      before do
+        FileUtils.mkdir_p File.join(fixture_path('all_pms'), 'vendor')
+      end
+
+      it_behaves_like "a PackageManager"
+    end
+
+    let(:project_path) { '/app' }
+    let(:options) { {} }
 
     context 'when there are go files' do
       before do

--- a/spec/lib/license_finder/package_managers/go_workspace_spec.rb
+++ b/spec/lib/license_finder/package_managers/go_workspace_spec.rb
@@ -7,6 +7,19 @@ module LicenseFinder
     let(:project_path) { '/Users/pivotal/workspace/loggregator'}
     subject { GoWorkspace.new(options.merge(project_path: Pathname(project_path), logger: logger)) }
 
+    before do
+      allow(logger).to receive(:installed)
+      allow(logger).to receive(:active)
+    end
+
+    context 'package manager' do
+      before do
+        allow_any_instance_of(GoDep).to receive(:active?).and_return(false)
+      end
+
+      it_behaves_like "a PackageManager"
+    end
+
     describe '#go_list' do
 
       let(:go_list_output) {

--- a/spec/support/shared_examples_for_package_manager.rb
+++ b/spec/support/shared_examples_for_package_manager.rb
@@ -20,6 +20,7 @@ module LicenseFinder
       context 'package manager is installed' do
         before do
           allow(described_class).to receive(:installed?).and_return(true)
+          allow_any_instance_of(described_class).to receive(:has_go_files?).and_return(true)
         end
 
         it 'is true when package manager file exists' do

--- a/spec/support/shared_examples_for_package_manager.rb
+++ b/spec/support/shared_examples_for_package_manager.rb
@@ -8,6 +8,7 @@ module LicenseFinder
     context "logging" do
       it "logs when it checks for active-ness" do
         logger = double(:logger)
+        expect(logger).to receive(:installed)
         expect(logger).to receive(:active)
 
         subject = described_class.new logger: logger, project_path: all_pms
@@ -16,13 +17,34 @@ module LicenseFinder
     end
 
     describe '.active?' do
-      it 'is true when package manager file exists' do
-        expect(described_class.new(project_path: all_pms)).to be_active
+      context 'package manager is installed' do
+        before do
+          allow(described_class).to receive(:installed?).and_return(true)
+        end
+
+        it 'is true when package manager file exists' do
+          expect(described_class.new(project_path: all_pms)).to be_active
+        end
+
+        it 'is false without a package manager file' do
+          no_pms = fixture_path("not/a/path")
+          expect(described_class.new(project_path: no_pms)).to_not be_active
+        end
       end
 
-      it 'is false without a package manager file' do
-        no_pms = fixture_path("not/a/path")
-        expect(described_class.new(project_path: no_pms)).to_not be_active
+      context 'package manager is not installed' do
+        before do
+          allow(described_class).to receive(:installed?).and_return(false)
+        end
+
+        it 'is false when package manager file exists' do
+          expect(described_class.new(project_path: all_pms)).to_not be_active
+        end
+
+        it 'is false without a package manager file' do
+          no_pms = fixture_path("not/a/path")
+          expect(described_class.new(project_path: no_pms)).to_not be_active
+        end
       end
     end
   end


### PR DESCRIPTION
LicenseFinder currently melts down if a package manager file (e.g., Gemfile) exists but the related package manager (e.g., `bundler`) is not installed.

This commit makes "detection of package manager installation" a first-class thing that gets logged along with `#active?` status, and will skip package managers at runtime if they're not installed.

Note that `rake check_dependencies` still exits with a non-zero status if anything isn't installed.
