### PR TITLE
Looks like `rubyzip' is runtime dependency but is declared as development

### DIFF
--- a/license_finder.gemspec
+++ b/license_finder.gemspec
@@ -42,11 +42,11 @@ Gem::Specification.new do |s|
   s.add_dependency "thor"
   s.add_dependency "httparty"
   s.add_dependency "xml-simple"
+  s.add_dependency "rubyzip"
 
   s.add_development_dependency "capybara", "~> 2.0.0"
   s.add_development_dependency "cocoapods", "0.34.0" if LicenseFinder::Platform.darwin?
   s.add_development_dependency "fakefs", "~> 0.6.7"
-  s.add_development_dependency "rubyzip"
   s.add_development_dependency "pry"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 3"


### PR DESCRIPTION
Signed-off-by: James Wen <jrw2175@columbia.edu>