### PR TITLE
Fix platform checks to return booleans

### DIFF
--- a/lib/license_finder/platform.rb
+++ b/lib/license_finder/platform.rb
@@ -1,11 +1,11 @@
 module LicenseFinder
   module Platform
     def self.darwin?
-      RUBY_PLATFORM =~ /darwin/
+      !(RUBY_PLATFORM =~ /darwin/).nil?
     end
 
     def self.windows?
-      RUBY_PLATFORM =~ /mswin|cygwin|mingw/
+      !(RUBY_PLATFORM =~ /mswin|cygwin|mingw/).nil?
     end
   end
 end


### PR DESCRIPTION
Otherwise the offset of the match, if any, or nil would be returned.