### PR TITLE
Flag maven-include-groups adds group to maven depenency information

### DIFF
--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -23,6 +23,7 @@ module LicenseFinder
       class_option :go_full_version, desc: "Whether dependency version should include full version. Only meaningful if used with a Go project. Defaults to false."
       class_option :gradle_include_groups, desc: "Whether dependency name should include group id. Only meaningful if used with a Java/gradle project. Defaults to false."
       class_option :gradle_command, desc: "Command to use when fetching gradle packages. Only meaningful if used with a Java/gradle project. Defaults to 'gradlew' / 'gradlew.bat' if the wrapper is present, otherwise to 'gradle'."
+      class_option :maven_include_groups, desc: "Whether dependency name should include group id. Only meaningful if used with a Java/maven project. Defaults to false."
       class_option :rebar_command, desc: "Command to use when fetching rebar packages. Only meaningful if used with a Erlang/rebar project. Defaults to 'rebar'."
       class_option :rebar_deps_dir, desc: "Path to rebar dependencies directory. Only meaningful if used with a Erlang/rebar project. Defaults to 'deps'."
       class_option :subprojects, type: :array, desc: "Generate a single report for multiple sub-projects. Ex: --subprojects='path/to/project1', 'path/to/project2'"

--- a/lib/license_finder/configuration.rb
+++ b/lib/license_finder/configuration.rb
@@ -44,6 +44,10 @@ module LicenseFinder
       get(:gradle_include_groups)
     end
 
+    def maven_include_groups
+      get(:maven_include_groups)
+    end
+
     def rebar_command
       get(:rebar_command) || 'rebar'
     end

--- a/lib/license_finder/core.rb
+++ b/lib/license_finder/core.rb
@@ -67,6 +67,7 @@ module LicenseFinder
         go_full_version: config.go_full_version,
         gradle_command: config.gradle_command,
         gradle_include_groups: config.gradle_include_groups,
+        maven_include_groups: config.maven_include_groups,
         rebar_command: config.rebar_command,
         rebar_deps_dir: config.rebar_deps_dir,
       )

--- a/lib/license_finder/package_managers/maven.rb
+++ b/lib/license_finder/package_managers/maven.rb
@@ -2,6 +2,11 @@ require "xmlsimple"
 
 module LicenseFinder
   class Maven < PackageManager
+    def initialize(options={})
+      super
+      @include_groups = options[:maven_include_groups]
+    end
+
     def current_packages
       command = 'mvn license:download-licenses'
       output, success = Dir.chdir(project_path) { capture(command) }
@@ -16,7 +21,7 @@ module LicenseFinder
       dependencies = XmlSimple.xml_in(xml, options)["dependencies"]
 
       dependencies.map do |dep|
-        MavenPackage.new(dep, logger: logger)
+        MavenPackage.new(dep, logger: logger, include_groups: @include_groups)
       end
     end
 

--- a/lib/license_finder/package_managers/maven_package.rb
+++ b/lib/license_finder/package_managers/maven_package.rb
@@ -1,8 +1,13 @@
 module LicenseFinder
   class MavenPackage < Package
     def initialize(spec, options={})
+      name = spec['artifactId']
+      if options[:include_groups]
+        name = "#{spec['groupId']}:#{name}"
+      end
+
       super(
-        spec["artifactId"],
+        name,
         spec["version"],
         options.merge(
           spec_licenses: Array(spec["licenses"]).map { |l| l["name"] }

--- a/spec/lib/license_finder/core_spec.rb
+++ b/spec/lib/license_finder/core_spec.rb
@@ -30,6 +30,7 @@ module LicenseFinder
           go_full_version: nil,
           gradle_command: configuration.gradle_command,
           gradle_include_groups: nil,
+          maven_include_groups: nil,
           rebar_command: configuration.rebar_command,
           rebar_deps_dir: configuration.rebar_deps_dir
         }

--- a/spec/lib/license_finder/package_managers/maven_package_spec.rb
+++ b/spec/lib/license_finder/package_managers/maven_package_spec.rb
@@ -2,11 +2,16 @@ require 'spec_helper'
 
 module LicenseFinder
   describe MavenPackage do
+    let(:options) { {} }
     subject do
       described_class.new(
-        "artifactId" => "hamcrest-core",
-        "version" => "4.11",
-        "licenses" => [{ "name" => "MIT" }]
+        {
+          "groupId" => "org.hamcrest",
+          "artifactId" => "hamcrest-core",
+          "version" => "4.11",
+          "licenses" => [{ "name" => "MIT" }],
+        },
+        options
       )
     end
 
@@ -30,6 +35,14 @@ module LicenseFinder
 
         it "is empty" do
           expect(subject.license_names_from_spec).to be_empty
+        end
+      end
+
+      context 'when include_groups is set to true' do
+        let(:options) { {include_groups: true} }
+
+        it 'includes the group id in the name' do
+          expect(subject.name).to eq("org.hamcrest:hamcrest-core")
         end
       end
 

--- a/spec/lib/license_finder/package_managers/maven_spec.rb
+++ b/spec/lib/license_finder/package_managers/maven_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 module LicenseFinder
   describe Maven do
-    subject { Maven.new(project_path: Pathname('/fake/path')) }
+    let(:options) { {} }
+
+    subject { Maven.new(options.merge(project_path: Pathname('/fake/path'))) }
 
     it_behaves_like "a PackageManager"
 
@@ -31,10 +33,12 @@ module LicenseFinder
       it 'lists all the current packages' do
         stub_license_report("
           <dependency>
+           <groupId>org.otherorg</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>
           </dependency>
           <dependency>
+            <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
             <version>1.3</version>
            </dependency>
@@ -44,6 +48,30 @@ module LicenseFinder
           ["junit", "4.11"],
           ["hamcrest-core", "1.3"]
         ]
+      end
+
+      context 'when maven group ids option is enabled' do
+        let(:options) { { maven_include_groups: true } }
+
+        it 'lists all the current packages' do
+          stub_license_report("
+          <dependency>
+           <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+          </dependency>
+          <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.3</version>
+           </dependency>
+                              ")
+
+          expect(subject.current_packages.map { |p| [p.name, p.version] }).to eq [
+            ["junit:junit", "4.11"],
+            ["org.hamcrest:hamcrest-core", "1.3"]
+          ]
+        end
       end
 
       it "handles multiple licenses" do


### PR DESCRIPTION
- Very similar to gradle_include_groups flag

Signed-off-by: Gabriel Ramirez gabriel.e.ramirez@gmail.com
