### PR TITLE
Nuget should pick the vendored directory

### DIFF
--- a/lib/license_finder/package_managers/nuget.rb
+++ b/lib/license_finder/package_managers/nuget.rb
@@ -4,7 +4,13 @@ require 'zip'
 module LicenseFinder
   class Nuget < PackageManager
     def package_path
-      project_path.join('.nuget')
+      path = project_path.join("**/*.nupkg")
+      nuget_dir = Dir[path].map{|pkg| File.dirname(pkg)}.uniq
+      if nuget_dir.length == 0
+        project_path.join(".nuget")
+      else
+        nuget_dir.first
+      end
     end
 
     def assemblies

--- a/spec/lib/license_finder/package_managers/nuget_spec.rb
+++ b/spec/lib/license_finder/package_managers/nuget_spec.rb
@@ -36,6 +36,23 @@ module LicenseFinder
           expect(nuget.assemblies.map(&:name)).to include('.nuget')
         end
       end
+
+    end
+
+    describe "#package_path" do
+      include FakeFS::SpecHelpers
+
+      context 'when .nupkg files exist, but are not in .nuget directory' do
+        before do
+          FileUtils.mkdir_p 'app/vendor'
+          FileUtils.touch 'app/vendor/package.nupkg'
+        end
+
+        it "returns vendored director" do
+          nuget = Nuget.new project_path: Pathname.new("app")
+          expect(nuget.package_path).to eq('/app/vendor')
+        end
+      end
     end
 
     describe "#current_packages" do


### PR DESCRIPTION
project_path should return the directory containing the vendored .nupkg packages

Signed-off-by: Amin Jamali <ajamali@pivotal.io>