### PR TITLE
Go-Workspace filter for non-standard packages

### DIFF
--- a/spec/lib/license_finder/package_managers/go_workspace_spec.rb
+++ b/spec/lib/license_finder/package_managers/go_workspace_spec.rb
@@ -35,6 +35,7 @@ module LicenseFinder
       let(:go_list_output) {
         <<HERE
 encoding/json
+gopkg.in/yaml.v2
 github.com/onsi/ginkgo
 HERE
       }
@@ -54,8 +55,9 @@ HERE
       it 'returns the skip the standard libs and return lines of the output' do
         allow(subject).to receive(:capture).with('go list -f \'{{join .Deps "\n"}}\' ./...').and_return([go_list_output, true])
         packages = subject.send(:go_list)
-        expect(packages.count).to eq(1)
-        expect(packages.first).to eq('github.com/onsi/ginkgo')
+        expect(packages.count).to eq(2)
+        expect(packages).to include 'github.com/onsi/ginkgo'
+        expect(packages).to include 'gopkg.in/yaml.v2'
       end
 
       it 'sets gopath to the envrc path' do


### PR DESCRIPTION
Instead of counting forward slashes in namespace, go-workspace looks
for packages whose namespaces include the pattern `*.*`

Signed-off-by: Amin Jamali <ajamali@pivotal.io>