### PR TITLE
Return a Pathname object from nuget package manager

### DIFF
--- a/lib/license_finder/package_managers/nuget.rb
+++ b/lib/license_finder/package_managers/nuget.rb
@@ -9,7 +9,7 @@ module LicenseFinder
       if nuget_dir.length == 0
         project_path.join(".nuget")
       else
-        nuget_dir.first
+        Pathname(nuget_dir.first)
       end
     end
 

--- a/spec/lib/license_finder/package_managers/nuget_spec.rb
+++ b/spec/lib/license_finder/package_managers/nuget_spec.rb
@@ -50,7 +50,7 @@ module LicenseFinder
 
         it "returns vendored director" do
           nuget = Nuget.new project_path: Pathname.new("app")
-          expect(nuget.package_path).to eq('/app/vendor')
+          expect(nuget.package_path).to eq Pathname('/app/vendor')
         end
       end
     end


### PR DESCRIPTION
PackageManager:active? expects package_path to return a Pathname object
which wasn't the case in nuget.

Related to #225

Signed-off-by: John Shahid <jshahid@pivotal.io>