### PR TITLE
Nuget package manager does not recursively look for .nupkg files

### DIFF
--- a/lib/license_finder/package_managers/nuget.rb
+++ b/lib/license_finder/package_managers/nuget.rb
@@ -4,7 +4,7 @@ require 'zip'
 module LicenseFinder
   class Nuget < PackageManager
     def package_path
-      path = project_path.join("**/*.nupkg")
+      path = project_path.join("vendor/*.nupkg")
       nuget_dir = Dir[path].map{|pkg| File.dirname(pkg)}.uniq
       if nuget_dir.length == 0
         project_path.join(".nuget")

--- a/spec/lib/license_finder/package_managers/nuget_spec.rb
+++ b/spec/lib/license_finder/package_managers/nuget_spec.rb
@@ -48,6 +48,8 @@ module LicenseFinder
 
       context 'when .nupkg files exist, but are not in .nuget directory' do
         before do
+          FileUtils.mkdir_p 'app/submodule/vendor'
+          FileUtils.touch 'app/submodule/vendor/package.nupkg'
           FileUtils.mkdir_p 'app/vendor'
           FileUtils.touch 'app/vendor/package.nupkg'
         end


### PR DESCRIPTION
* Only searches the vendor/ directory

[#121259157]

Signed-off-by: John Shahid <jshahid@pivotal.io>