### PR TITLE
Fix 'package_management_command()' to 'bundle'

### DIFF
--- a/lib/license_finder/package_managers/bundler.rb
+++ b/lib/license_finder/package_managers/bundler.rb
@@ -18,7 +18,7 @@ module LicenseFinder
     end
 
     def self.package_management_command
-      "bundler"
+      "bundle"
     end
 
     private


### PR DESCRIPTION
Hi, I wanted to look for dependencies license with Bundler. However, I was not able to do it. At license_finder v2.1.2.

I tried `--debug` option and arrived at this correction.