### PR TITLE
Fix calling the Gradle wrapper on Unix

### DIFF
--- a/lib/license_finder/configuration.rb
+++ b/lib/license_finder/configuration.rb
@@ -27,7 +27,7 @@ module LicenseFinder
           wrapper = 'gradlew.bat'
           gradle = 'gradle.bat'
         else
-          wrapper = 'gradlew'
+          wrapper = './gradlew'
           gradle = 'gradle'
         end
 


### PR DESCRIPTION
On Unix, the current directory (i.e. the project path) is not searched for
executables, so prefix the wrapper script with the current directory.