### PR TITLE
Fix detecting the Gradle wrapper if not scanning the current directory

### DIFF
--- a/lib/license_finder/configuration.rb
+++ b/lib/license_finder/configuration.rb
@@ -31,7 +31,7 @@ module LicenseFinder
           gradle = 'gradle'
         end
 
-        File.exist?(wrapper) ? wrapper : gradle
+        File.exist?(File.join(project_path, wrapper)) ? wrapper : gradle
       )
     end
 


### PR DESCRIPTION
Append the actual project path to the file existence check so we do not
just use the current directory if the --project-path option is used.