### PR TITLE
Enable '--columns' option with text reports

### DIFF
--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -18,7 +18,7 @@ module LicenseFinder
       }
 
       class_option :format, desc: "The desired output format.", default: 'text', enum: FORMATS.keys
-      class_option :columns, type: :array, desc: "For CSV reports, which columns to print. Pick from: #{CsvReport::AVAILABLE_COLUMNS}", default: %w[name version licenses]
+      class_option :columns, type: :array, desc: "For text or CSV reports, which columns to print. Pick from: #{CsvReport::AVAILABLE_COLUMNS}", default: %w[name version licenses]
       class_option :save, desc: "Save report to a file. Default: 'license_report.csv' in project root.", lazy_default: "license_report"
       class_option :go_full_version, desc: "Whether dependency version should include full version. Only meaningful if used with a Go project. Defaults to false."
       class_option :gradle_include_groups, desc: "Whether dependency name should include group id. Only meaningful if used with a Java/gradle project. Defaults to false."

--- a/lib/license_finder/reports/text_report.rb
+++ b/lib/license_finder/reports/text_report.rb
@@ -2,8 +2,11 @@ module LicenseFinder
   class TextReport < CsvReport
     COMMA_SEP =  ", "
 
-    def initialize(dependencies, options={})
-      super(dependencies, options.merge(columns: %w[name version licenses]))
+    def initialize(dependencies, options)
+      empty_options = {}
+      default_columns = %w[name version licenses]
+      columns = (Array(options[:columns]) & self.class::AVAILABLE_COLUMNS) || default_columns
+      super(dependencies, empty_options.merge(columns: columns))
     end
   end
 end

--- a/lib/license_finder/reports/text_report.rb
+++ b/lib/license_finder/reports/text_report.rb
@@ -5,7 +5,10 @@ module LicenseFinder
     def initialize(dependencies, options)
       empty_options = {}
       default_columns = %w[name version licenses]
-      columns = (Array(options[:columns]) & self.class::AVAILABLE_COLUMNS) || default_columns
+      columns = (Array(options[:columns]) & self.class::AVAILABLE_COLUMNS)
+      if columns.empty?
+        columns = default_columns
+      end
       super(dependencies, empty_options.merge(columns: columns))
     end
   end

--- a/lib/license_finder/reports/text_report.rb
+++ b/lib/license_finder/reports/text_report.rb
@@ -2,14 +2,13 @@ module LicenseFinder
   class TextReport < CsvReport
     COMMA_SEP =  ", "
 
-    def initialize(dependencies, options)
-      empty_options = {}
+    def initialize(dependencies, options={})
+      super(dependencies, options)
+
       default_columns = %w[name version licenses]
-      columns = (Array(options[:columns]) & self.class::AVAILABLE_COLUMNS)
-      if columns.empty?
-        columns = default_columns
+      if @columns.empty?
+        @columns = default_columns
       end
-      super(dependencies, empty_options.merge(columns: columns))
     end
   end
 end

--- a/spec/lib/license_finder/reports/text_report_spec.rb
+++ b/spec/lib/license_finder/reports/text_report_spec.rb
@@ -22,7 +22,7 @@ module LicenseFinder
         result
       end
 
-      subject { described_class.new([dep3, dep2, dep1], {}).to_s }
+      subject { described_class.new([dep3, dep2, dep1]).to_s }
 
       it 'should generate a text report with the name, version and license of each dependency, sorted by name' do
         is_expected.to eq("gem_a, 1.0, MIT\ngem_b, 1.0, MIT\ngem_c, 2.0, \"MIT, BSD\"\n")
@@ -35,7 +35,7 @@ module LicenseFinder
 
       it 'prints a warning message for packages that have not been installed' do
         dep = Package.new('gem_d', '2.0', missing: true)
-        report = described_class.new([dep], {}).to_s
+        report = described_class.new([dep]).to_s
         expect(report).to eq("gem_d, 2.0, \"This package is not installed. Please install to determine licenses.\"\n")
       end
     end

--- a/spec/lib/license_finder/reports/text_report_spec.rb
+++ b/spec/lib/license_finder/reports/text_report_spec.rb
@@ -28,6 +28,11 @@ module LicenseFinder
         is_expected.to eq("gem_a, 1.0, MIT\ngem_b, 1.0, MIT\ngem_c, 2.0, \"MIT, BSD\"\n")
       end
 
+      it 'should generate a text report with the name, version of each dependency, use --columns option' do
+        report = described_class.new([dep3, dep2, dep1], columns: %w[name version]).to_s
+        expect(report).to eq("gem_a, 1.0\ngem_b, 1.0\ngem_c, 2.0\n")
+      end
+
       it 'prints a warning message for packages that have not been installed' do
         dep = Package.new('gem_d', '2.0', missing: true)
         report = described_class.new([dep], {}).to_s

--- a/spec/lib/license_finder/reports/text_report_spec.rb
+++ b/spec/lib/license_finder/reports/text_report_spec.rb
@@ -22,7 +22,7 @@ module LicenseFinder
         result
       end
 
-      subject { described_class.new([dep3, dep2, dep1]).to_s }
+      subject { described_class.new([dep3, dep2, dep1], {}).to_s }
 
       it 'should generate a text report with the name, version and license of each dependency, sorted by name' do
         is_expected.to eq("gem_a, 1.0, MIT\ngem_b, 1.0, MIT\ngem_c, 2.0, \"MIT, BSD\"\n")
@@ -30,7 +30,7 @@ module LicenseFinder
 
       it 'prints a warning message for packages that have not been installed' do
         dep = Package.new('gem_d', '2.0', missing: true)
-        report = described_class.new([dep]).to_s
+        report = described_class.new([dep], {}).to_s
         expect(report).to eq("gem_d, 2.0, \"This package is not installed. Please install to determine licenses.\"\n")
       end
     end


### PR DESCRIPTION
Hi, `--columns` option is very useful. I want to use it in `text` format, too.

It's keep compatibility by the default:

``` sh
$ bundle exec license_finder --format=text
...................................................................
Dependencies that need approval:
sinatra, 1.0, MIT
```

When user appointed `--columns` option, `LicenseFinder` output it according to an appointed values:

``` sh
$ bundle exec license_finder --columns=name version homepage authors --format=text
...................................................................
Dependencies that need approval:
sinatra, 1.0, http://sinatra.rubyforge.org, "Blake Mizerany, Ryan Tomayko, Simon Rozet"
```
