### PR TITLE
Made packages unique based on name and version

### DIFF
--- a/features/features/report/diff_spec.rb
+++ b/features/features/report/diff_spec.rb
@@ -18,8 +18,8 @@ describe 'Diff report' do
 
       developer.execute_command('license_finder diff report-1.csv report-2.csv')
 
-      expect(developer).to be_seeing('added,bar,2.0.0,,GPLv2')
-      expect(developer).to be_seeing('unchanged,foo,1.0.0,1.0.0,MIT')
+      expect(developer).to be_seeing('added,bar,2.0.0,GPLv2')
+      expect(developer).to be_seeing('unchanged,foo,1.0.0,MIT')
     end
 
     specify 'shows version changes between two csv reports' do
@@ -31,7 +31,8 @@ describe 'Diff report' do
       developer.execute_command('license_finder report --save=report-2.csv --format=csv')
 
       developer.execute_command('license_finder diff report-1.csv report-2.csv')
-      expect(developer).to be_seeing('unchanged,foo,2.0.0,1.0.0,MIT')
+      expect(developer).to be_seeing('added,foo,2.0.0,MIT')
+      expect(developer).to be_seeing('removed,foo,1.0.0,MIT')
     end
 
     specify 'shows license changes between two csv reports' do
@@ -43,8 +44,8 @@ describe 'Diff report' do
       developer.execute_command('license_finder report --save=report-2.csv --format=csv')
 
       developer.execute_command('license_finder diff report-1.csv report-2.csv')
-      expect(developer).to be_seeing('removed,foo,,1.0.0,MIT')
-      expect(developer).to be_seeing('added,foo,2.0.0,,GPLv2')
+      expect(developer).to be_seeing('removed,foo,1.0.0,MIT')
+      expect(developer).to be_seeing('added,foo,2.0.0,GPLv2')
     end
   end
 
@@ -69,9 +70,9 @@ describe 'Diff report' do
       developer.execute_command('license_finder diff report-1.csv report-2.csv --save=diff.csv --format=csv')
 
       diff = IO.read(project.project_dir.join('diff.csv'))
-      expect(diff).to include("unchanged,foo,1.0.0,1.0.0,MIT,\"#{project1.project_dir},#{project2.project_dir}\"")
-      expect(diff).to include("unchanged,bar,2.0.0,2.0.0,GPLv2,#{project1.project_dir}")
-      expect(diff).to include("added,baz,3.0.0,,BSD,#{project2.project_dir}")
+      expect(diff).to include("unchanged,foo,1.0.0,MIT,\"#{project1.project_dir},#{project2.project_dir}\"")
+      expect(diff).to include("unchanged,bar,2.0.0,GPLv2,#{project1.project_dir}")
+      expect(diff).to include("added,baz,3.0.0,BSD,#{project2.project_dir}")
     end
 
     context 'when change affects only one file' do
@@ -96,9 +97,10 @@ describe 'Diff report' do
         developer.execute_command('license_finder diff report-1.csv report-2.csv --save=diff.csv --format=csv')
 
         diff = IO.read(project.project_dir.join('diff.csv'))
-        expect(diff).to include("unchanged,foo,1.0.0,1.0.0,MIT,\"#{project1.project_dir},#{project2.project_dir}\"")
-        expect(diff).to include("unchanged,bar,3.0.0,2.0.0,GPLv2,#{project1.project_dir}")
-        expect(diff).to include("added,baz,3.0.0,,BSD,#{project2.project_dir}")
+        expect(diff).to include("unchanged,foo,1.0.0,MIT,\"#{project1.project_dir},#{project2.project_dir}\"")
+        expect(diff).to include("added,bar,3.0.0,GPLv2,#{project1.project_dir}")
+        expect(diff).to include("removed,bar,2.0.0,GPLv2,#{project1.project_dir}")
+        expect(diff).to include("added,baz,3.0.0,BSD,#{project2.project_dir}")
       end
 
       specify 'shows license changes' do
@@ -122,10 +124,10 @@ describe 'Diff report' do
         developer.execute_command('license_finder diff report-1.csv report-2.csv --save=diff.csv --format=csv')
 
         diff = IO.read(project.project_dir.join('diff.csv'))
-        expect(diff).to include("unchanged,foo,1.0.0,1.0.0,MIT,\"#{project1.project_dir},#{project2.project_dir}\"")
-        expect(diff).to include("removed,bar,,2.0.0,GPLv2,#{project1.project_dir}")
-        expect(diff).to include("added,bar,3.0.0,,MIT,#{project1.project_dir}")
-        expect(diff).to include("added,baz,3.0.0,,BSD,#{project2.project_dir}")
+        expect(diff).to include("unchanged,foo,1.0.0,MIT,\"#{project1.project_dir},#{project2.project_dir}\"")
+        expect(diff).to include("removed,bar,2.0.0,GPLv2,#{project1.project_dir}")
+        expect(diff).to include("added,bar,3.0.0,MIT,#{project1.project_dir}")
+        expect(diff).to include("added,baz,3.0.0,BSD,#{project2.project_dir}")
       end
     end
 
@@ -151,10 +153,10 @@ describe 'Diff report' do
         developer.execute_command('license_finder diff report-1.csv report-2.csv --save=diff.csv --format=csv')
 
         diff = IO.read(project.project_dir.join('diff.csv'))
-        expect(diff).to include("unchanged,bar,2.0.0,2.0.0,GPLv2,#{project1.project_dir}")
-        expect(diff).to include("removed,foo,,1.0.0,MIT,\"#{project1.project_dir},#{project2.project_dir}\"")
-        expect(diff).to include("added,foo,2.0.0,,BSD,\"#{project1.project_dir},#{project2.project_dir}\"")
-        expect(diff).to include("added,baz,3.0.0,,BSD,#{project2.project_dir}")
+        expect(diff).to include("unchanged,bar,2.0.0,GPLv2,#{project1.project_dir}")
+        expect(diff).to include("removed,foo,1.0.0,MIT,\"#{project1.project_dir},#{project2.project_dir}\"")
+        expect(diff).to include("added,foo,2.0.0,BSD,\"#{project1.project_dir},#{project2.project_dir}\"")
+        expect(diff).to include("added,baz,3.0.0,BSD,#{project2.project_dir}")
       end
 
       xspecify 'show licenses change when files do not contain exact copies of a dep' do
@@ -178,12 +180,13 @@ describe 'Diff report' do
         developer.execute_command('license_finder diff report-1.csv report-2.csv --save=diff.csv --format=csv')
 
         diff = IO.read(project.project_dir.join('diff.csv'))
-        expect(diff).to include("removed,foo,,1.0.0,MIT,#{project1.project_dir}")
+        expect(diff).to include("removed,foo,1.0.0,MIT,#{project1.project_dir}")
         # expect(diff).to include("removed,foo,,2.0.0,BSD,#{project2.project_dir}")
-        expect(diff).to include("unchanged,foo,2.0.0,1.0.0,BSD,\"#{project1.project_dir},#{project2.project_dir}\"")
+        expect(diff).to include("added,foo,2.0.0,BSD,\"#{project1.project_dir},#{project2.project_dir}\"")
+        expect(diff).to include("removed,foo,1.0.0,BSD,\"#{project1.project_dir},#{project2.project_dir}\"")
 
-        expect(diff).to include("unchanged,bar,2.0.0,2.0.0,GPLv2,#{project1.project_dir}")
-        expect(diff).to include("added,baz,3.0.0,,BSD,#{project2.project_dir}")
+        expect(diff).to include("unchanged,bar,2.0.0,GPLv2,#{project1.project_dir}")
+        expect(diff).to include("added,baz,3.0.0,BSD,#{project2.project_dir}")
       end
     end
   end

--- a/lib/license_finder/diff.rb
+++ b/lib/license_finder/diff.rb
@@ -10,8 +10,8 @@ module LicenseFinder
 
       [].tap do |packages|
         unchanged.each do |package|
-          package_previous = package_with_name(p1, package)
-          package_current = package_with_name(p2, package)
+          package_previous = find_package(p1, package)
+          package_current = find_package(p2, package)
 
           if package_current.licenses == package_previous.licenses
             packages << PackageDelta.unchanged(package_current, package_previous)
@@ -40,8 +40,8 @@ module LicenseFinder
       end
     end
 
-    def self.package_with_name(set, package)
-      set.find { |p| p.name == package.name }
+    def self.find_package(set, package)
+      set.find { |p| p.eql? package}
     end
   end
 end

--- a/lib/license_finder/package.rb
+++ b/lib/license_finder/package.rb
@@ -99,15 +99,17 @@ module LicenseFinder
     ## EQUALITY
 
     def <=>(other)
-      name <=> other.name
+      eq_name = name <=> other.name
+      return eq_name unless eq_name == 0
+      version <=> other.version
     end
 
     def eql?(other)
-      name == other.name
+      name == other.name && version == other.version
     end
 
     def hash
-      [name].hash
+      [name,version].hash
     end
 
     ## LICENSING

--- a/lib/license_finder/package_delta.rb
+++ b/lib/license_finder/package_delta.rb
@@ -12,13 +12,10 @@ module LicenseFinder
       pick_package.name
     end
 
-    def current_version
-      @current_package ? @current_package.version : nil
+    def version
+      pick_package.version
     end
 
-    def previous_version
-      @previous_package ? @previous_package.version : nil
-    end
 
     def subproject_paths
       pick_package.subproject_paths

--- a/lib/license_finder/reports/diff_report.rb
+++ b/lib/license_finder/reports/diff_report.rb
@@ -10,12 +10,8 @@ module LicenseFinder
       dep.status
     end
 
-    def format_current_version(dep)
-      dep.current_version
-    end
-
-    def format_previous_version(dep)
-      dep.previous_version
+    def format_version(dep)
+      dep.version
     end
 
     def format_project_paths(dep)
@@ -25,7 +21,7 @@ module LicenseFinder
     private
 
     def build_columns(dependencies)
-      columns = %w[status name current_version previous_version licenses]
+      columns = %w[status name version licenses]
       columns << 'project_paths' if dependencies.all? { |delta| delta.merged_package? }
       columns
     end

--- a/spec/lib/license_finder/diff_spec.rb
+++ b/spec/lib/license_finder/diff_spec.rb
@@ -6,8 +6,8 @@ module LicenseFinder
 
     let(:diff) { subject.compare(file1_content, file2_content) }
 
-    def find_package(name)
-      diff.find { |d| d.name == name }
+    def find_package_with_name(name)
+      diff.find_all { |d| d.name == name }
     end
 
     describe '#compare' do
@@ -16,7 +16,7 @@ module LicenseFinder
         let(:file2_content) { "nokogiri,1.6.6.2,MIT\nrspec,3.2.0,MIT" }
 
         it 'should create and set packages with added diff state' do
-          rspec = find_package('rspec')
+          rspec = find_package_with_name('rspec')[0]
           expect(rspec.status).to eq :added
         end
       end
@@ -26,7 +26,7 @@ module LicenseFinder
         let(:file2_content) { "nokogiri,1.6.6.2,MIT" }
 
         it 'should create and set packages with removed diff state' do
-          rspec = find_package('rspec')
+          rspec = find_package_with_name('rspec')[0]
           expect(rspec.status).to eq :removed
         end
       end
@@ -36,7 +36,7 @@ module LicenseFinder
         let(:file2_content) { "nokogiri,1.6.6.2,MIT" }
 
         it 'should create and set packages with unchanged diff state' do
-          nokogiri = find_package('nokogiri')
+          nokogiri = find_package_with_name('nokogiri')[0]
           expect(nokogiri.status).to eq :unchanged
         end
       end
@@ -46,9 +46,9 @@ module LicenseFinder
         let(:file2_content) { "nokogiri,1.6.6.2,MIT\nminitest,5.7.0,MIT\nfakefs,0.6.7,BSD" }
 
         it 'should create and set packages diff states' do
-          expect(find_package('minitest').status).to eq :added
-          expect(find_package('rspec').status).to eq :removed
-          expect(find_package('nokogiri').status).to eq :unchanged
+          expect(find_package_with_name('minitest')[0].status).to eq :added
+          expect(find_package_with_name('rspec')[0].status).to eq :removed
+          expect(find_package_with_name('nokogiri')[0].status).to eq :unchanged
         end
       end
 
@@ -57,11 +57,37 @@ module LicenseFinder
         let(:file2_content) { "rspec,3.3.0,MIT" }
 
         it 'should set the state to unchanged and record the version change' do
-          rspec = find_package('rspec')
+          rspecs = find_package_with_name('rspec')
+          expect(rspecs.size).to eq(2)
+          rspecs.each do |rspec|
+            case rspec.status
+              when :removed
+                expect(rspec.previous_version).to eq('3.2.0')
+              when :added
+                expect(rspec.current_version).to eq('3.3.0')
+            end
+          end
+        end
 
-          expect(rspec.status).to eq(:unchanged)
-          expect(rspec.current_version).to eq('3.3.0')
-          expect(rspec.previous_version).to eq('3.2.0')
+        context 'when there are two versions of the same dependency' do
+          let(:file1_content) { "rspec,3.2.0,MIT\nrspec,1.1.0,MIT\nnokogiri,1.6.6.2,MIT" }
+          let(:file2_content) { "rspec,3.3.0,MIT\nrspec,1.1.0,MIT\nnokogiri,1.6.6.2,MIT" }
+          it 'should identify which version was updated' do
+            rspecs = find_package_with_name('rspec')
+            expect(rspecs.size).to eq(3)
+            rspecs.each do |rspec|
+              case rspec.status
+                when :removed
+                  expect(rspec.previous_version).to eq('3.2.0')
+                when :added
+                  expect(rspec.current_version).to eq('3.3.0')
+                else
+                  expect(rspec.status).to eq(:unchanged)
+                  expect(rspec.current_version).to eq('1.1.0')
+                  expect(rspec.previous_version).to eq('1.1.0')
+              end
+            end
+          end
         end
       end
 
@@ -88,14 +114,14 @@ module LicenseFinder
         let(:file2_content) { "rspec,3.2.0,MIT,\"/path/to/project1,/path/to/project2\"\nrails,4.2.0,MIT,/path/to/project1" }
 
         it 'should show the diff of the reports' do
-          rspec = find_package('rspec')
+          rspec = find_package_with_name('rspec')[0]
           expect(rspec.status).to eq(:unchanged)
           expect(rspec.current_version).to eq('3.2.0')
           expect(rspec.previous_version).to eq('3.2.0')
           paths = ['/path/to/project1', '/path/to/project2'].map { |p| File.absolute_path(p) }
           expect(rspec.subproject_paths).to match_array(paths)
 
-          rails = find_package('rails')
+          rails = find_package_with_name('rails')[0]
           expect(rails.status).to eq(:added)
           expect(rails.current_version).to eq('4.2.0')
           expect(rails.previous_version).to eq(nil)

--- a/spec/lib/license_finder/diff_spec.rb
+++ b/spec/lib/license_finder/diff_spec.rb
@@ -56,15 +56,15 @@ module LicenseFinder
         let(:file1_content) { "rspec,3.2.0,MIT" }
         let(:file2_content) { "rspec,3.3.0,MIT" }
 
-        it 'should set the state to unchanged and record the version change' do
+        it 'should add the new version and remove the previous version' do
           rspecs = find_package_with_name('rspec')
           expect(rspecs.size).to eq(2)
           rspecs.each do |rspec|
             case rspec.status
               when :removed
-                expect(rspec.previous_version).to eq('3.2.0')
+                expect(rspec.version).to eq('3.2.0')
               when :added
-                expect(rspec.current_version).to eq('3.3.0')
+                expect(rspec.version).to eq('3.3.0')
             end
           end
         end
@@ -78,13 +78,12 @@ module LicenseFinder
             rspecs.each do |rspec|
               case rspec.status
                 when :removed
-                  expect(rspec.previous_version).to eq('3.2.0')
+                  expect(rspec.version).to eq('3.2.0')
                 when :added
-                  expect(rspec.current_version).to eq('3.3.0')
+                  expect(rspec.version).to eq('3.3.0')
                 else
                   expect(rspec.status).to eq(:unchanged)
-                  expect(rspec.current_version).to eq('1.1.0')
-                  expect(rspec.previous_version).to eq('1.1.0')
+                  expect(rspec.version).to eq('1.1.0')
               end
             end
           end
@@ -96,16 +95,14 @@ module LicenseFinder
         let(:file2_content) { "rspec,3.3.0,GPLv2" }
 
         it 'should set the state to unchanged and record the version change' do
-          rspec_old = diff.find {|p| p.previous_version == '3.2.0'}
-          rspec_new = diff.find {|p| p.current_version == '3.3.0'}
+          rspec_old = diff.find {|p| p.version == '3.2.0'}
+          rspec_new = diff.find {|p| p.version == '3.3.0'}
 
           expect(rspec_old.status).to eq(:removed)
-          expect(rspec_old.current_version).to eq(nil)
-          expect(rspec_old.previous_version).to eq('3.2.0')
+          expect(rspec_old.version).to eq('3.2.0')
 
           expect(rspec_new.status).to eq(:added)
-          expect(rspec_new.current_version).to eq('3.3.0')
-          expect(rspec_new.previous_version).to eq(nil)
+          expect(rspec_new.version).to eq('3.3.0')
         end
       end
 
@@ -116,15 +113,13 @@ module LicenseFinder
         it 'should show the diff of the reports' do
           rspec = find_package_with_name('rspec')[0]
           expect(rspec.status).to eq(:unchanged)
-          expect(rspec.current_version).to eq('3.2.0')
-          expect(rspec.previous_version).to eq('3.2.0')
+          expect(rspec.version).to eq('3.2.0')
           paths = ['/path/to/project1', '/path/to/project2'].map { |p| File.absolute_path(p) }
           expect(rspec.subproject_paths).to match_array(paths)
 
           rails = find_package_with_name('rails')[0]
           expect(rails.status).to eq(:added)
-          expect(rails.current_version).to eq('4.2.0')
-          expect(rails.previous_version).to eq(nil)
+          expect(rails.version).to eq('4.2.0')
           paths = ['/path/to/project1'].map { |p| File.absolute_path(p) }
           expect(rails.subproject_paths).to match_array(paths)
         end

--- a/spec/lib/license_finder/package_managers/merged_package_spec.rb
+++ b/spec/lib/license_finder/package_managers/merged_package_spec.rb
@@ -29,27 +29,31 @@ module LicenseFinder
     end
 
     describe '#eql?' do
-      it 'returns true when the package names are equal' do
+      it 'returns false when the package names are the same, but the version is different' do
         p1 = MergedPackage.new(Package.new('foo', '1.0.0'), ['/path/to/package1'])
         p2 = MergedPackage.new(Package.new('foo', '2.0.0'), ['/path/to/package2'])
         p3 = MergedPackage.new(Package.new('bar', '1.0.0'), ['/path/to/package3'])
-        expect(p1.eql?(p2)).to eq(true)
+        expect(p1.eql?(p2)).to eq(false)
         expect(p1.eql?(p3)).not_to eq(true)
       end
 
       it 'can handle merged packages that contain other merged packages' do
         p1 = MergedPackage.new(Package.new('foo', '1.0.0'), ['/path/to/package1'])
         p2 = MergedPackage.new(Package.new('foo', '2.0.0'), ['/path/to/package2'])
-        p3 = MergedPackage.new(p2, ['/path/to/package3', '/path/to/package2'])
+        p3 = MergedPackage.new(p1, ['/path/to/package3', '/path/to/package1'])
+        p4 = MergedPackage.new(p2, ['/path/to/package4', '/path/to/package2'])
         expect(p1.eql?(p3)).to eq(true)
+        expect(p1.eql?(p4)).not_to eq(true)
       end
     end
 
     describe 'hash' do
       it 'returns equal hash codes for packages that are equal' do
         p1 = MergedPackage.new(Package.new('foo', '1.0.0'), ['/path/to/package1'])
-        p2 = MergedPackage.new(Package.new('foo', '2.0.0'), ['/path/to/package2'])
+        p2 = MergedPackage.new(Package.new('foo', '1.0.0'), ['/path/to/package2'])
+        p3 = MergedPackage.new(Package.new('foo', '2.0.0'), ['/path/to/package3'])
         expect(p1.hash).to eq(p2.hash)
+        expect(p1.hash).not_to eq(p3.hash)
       end
     end
   end

--- a/spec/lib/license_finder/package_spec.rb
+++ b/spec/lib/license_finder/package_spec.rb
@@ -153,13 +153,16 @@ module LicenseFinder
     describe '#eql?' do
       it 'returns true if package name matches' do
         p1 = Package.new('package', '0.0.1')
-        p2 = Package.new('package', '0.0.2')
+        p2 = Package.new('package', '0.0.1')
         p3 = Package.new('foo', 'foo')
+        p4 = Package.new('foo', 'foo2')
 
         expect(p1.eql?(p2)).to be true
         expect(p1.eql?(p3)).to be false
+        expect(p3.eql?(p4)).to be false
 
         expect(p1.hash).to eq p2.hash
+        expect(p3.hash).not_to eq p4.hash
       end
     end
 

--- a/spec/lib/license_finder/reports/diff_report_spec.rb
+++ b/spec/lib/license_finder/reports/diff_report_spec.rb
@@ -13,8 +13,8 @@ module LicenseFinder
           bar_change = PackageDelta.removed(bar)
 
           report = DiffReport.new([foo_change, bar_change])
-          expect(report.to_s).to include('removed,bar,,1.1.0,GPLv2')
-          expect(report.to_s).to include('added,foo,1.0.0,,MIT')
+          expect(report.to_s).to include('removed,bar,1.1.0,GPLv2')
+          expect(report.to_s).to include('added,foo,1.0.0,MIT')
         end
 
         it 'should generate a diff report displaying version changes' do
@@ -25,7 +25,7 @@ module LicenseFinder
           foo = PackageDelta.unchanged(foo_new, foo_old)
 
           report = DiffReport.new([foo])
-          expect(report.to_s).to include('unchanged,foo,1.1.0,1.0.0,MIT')
+          expect(report.to_s).to include('unchanged,foo,1.1.0,MIT')
         end
       end
 
@@ -47,8 +47,8 @@ module LicenseFinder
 
 
           report = DiffReport.new([foo, bar])
-          expect(report.to_s).to include("unchanged,foo,1.1.0,1.0.0,MIT,#{expanded_foo_path}")
-          expect(report.to_s).to include("added,bar,1.1.0,,MIT,\"#{expanded_bar_path1},#{expanded_bar_path2}\"")
+          expect(report.to_s).to include("unchanged,foo,1.1.0,MIT,#{expanded_foo_path}")
+          expect(report.to_s).to include("added,bar,1.1.0,MIT,\"#{expanded_bar_path1},#{expanded_bar_path2}\"")
         end
       end
     end


### PR DESCRIPTION
- changes functionality of diff
  - updated versions now show up as "removed <old>" and "added <new>"

- changes functionality of report
  - report now shows duplicate dependencies as long as the versions are
    different

[Finish #134721259]

Signed-off-by: Vikram Yadav <vyadav@pivotal.io>