### PR TITLE
Make the Maven wrapper call mvn.cmd and fall back to mvn.bat

### DIFF
--- a/features/fixtures/maven-wrapper/mvnw.cmd
+++ b/features/fixtures/maven-wrapper/mvnw.cmd
@@ -1,1 +1,7 @@
-@call mvn.bat
+@echo off
+where /q mvn.cmd
+if %ERRORLEVEL% equ 0 (
+    mvn.cmd %*
+) else (
+    mvn.bat %*
+)


### PR DESCRIPTION
Starting with Maven 3.3.1, mvn.bat was replaced with mvn.cmd. So try the
more modern .cmd first, and use the .bat only as a fall-back.