### PR TITLE
Adding JSON lib attribute to handle deeply nested JSON

### DIFF
--- a/lib/license_finder/package_managers/npm.rb
+++ b/lib/license_finder/package_managers/npm.rb
@@ -29,7 +29,7 @@ module LicenseFinder
     private
 
     def direct_dependencies
-      package_json = JSON.parse(File.read(package_path))
+      package_json = JSON.parse(File.read(package_path), :max_nesting => false)
       DEPENDENCY_GROUPS.map do |group|
         package_json.fetch(group, {}).keys.map do |dependency|
           {
@@ -55,10 +55,10 @@ module LicenseFinder
       output, success = Dir.chdir(project_path) { capture(command) }
 
       if success
-        json = JSON(output)
+        json = JSON(output, :max_nesting => false)
       else
         json = begin
-                 JSON(output)
+                 JSON(output, :max_nesting => false)
                rescue JSON::ParserError
                  nil
                end


### PR DESCRIPTION
Ran into an issue with a npm list returning a JSON that was too deep for the default depth of 19.

```
/Users/agurov/.rvm/rubies/ruby-1.9.3-p551/lib/ruby/1.9.1/json/common.rb:148:in `parse': nesting of 20 is too deep (JSON::NestingError)
	from /Users/agurov/.rvm/rubies/ruby-1.9.3-p551/lib/ruby/1.9.1/json/common.rb:148:in `parse'
	from /Users/agurov/.rvm/rubies/ruby-1.9.3-p551/lib/ruby/1.9.1/json/common.rb:426:in `JSON'
	from /Users/agurov/.rvm/gems/ruby-1.9.3-p551/gems/license_finder-2.1.2/lib/license_finder/package_managers/npm.rb:58:in `npm_json'
	from /Users/agurov/.rvm/gems/ruby-1.9.3-p551/gems/license_finder-2.1.2/lib/license_finder/package_managers/npm.rb:44:in `walk_dependency_tree'
	from /Users/agurov/.rvm/gems/ruby-1.9.3-p551/gems/license_finder-2.1.2/lib/license_finder/package_managers/npm.rb:11:in `block in current_packages'
	from /Users/agurov/.rvm/gems/ruby-1.9.3-p551/gems/license_finder-2.1.2/lib/license_finder/package_managers/npm.rb:9:in `each'
	from /Users/agurov/.rvm/gems/ruby-1.9.3-p551/gems/license_finder-2.1.2/lib/license_finder/package_managers/npm.rb:9:in `current_packages'
	from /Users/agurov/.rvm/gems/ruby-1.9.3-p551/gems/license_finder-2.1.2/lib/license_finder/package_manager.rb:60:in `current_packages_with_relations'
	from /Users/agurov/.rvm/gems/ruby-1.9.3-p551/gems/license_finder-2.1.2/lib/license_finder/package_manager.rb:23:in `each'
	from /Users/agurov/.rvm/gems/ruby-1.9.3-p551/gems/license_finder-2.1.2/lib/license_finder/package_manager.rb:23:in `flat_map'
	from /Users/agurov/.rvm/gems/ruby-1.9.3-p551/gems/license_finder-2.1.2/lib/license_finder/package_manager.rb:23:in `current_packages'
	from /Users/agurov/.rvm/gems/ruby-1.9.3-p551/gems/license_finder-2.1.2/lib/license_finder/core.rb:63:in `current_packages'
	from /Users/agurov/.rvm/gems/ruby-1.9.3-p551/gems/license_finder-2.1.2/lib/license_finder/core.rb:58:in `decision_applier'
	from /Users/agurov/.rvm/gems/ruby-1.9.3-p551/gems/license_finder-2.1.2/lib/license_finder/cli/main.rb:36:in `action_items'
	from /Users/agurov/.rvm/gems/ruby-1.9.3-p551/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
	from /Users/agurov/.rvm/gems/ruby-1.9.3-p551/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
```

As a result, license_finder was not completing.

Added the following option to get past the problem:

https://github.com/flori/json/blob/master/lib/json/common.rb#L164