### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ report.
 ### Experimental project types
 
 * Erlang (via `rebar`)
-* Objective-C (+ CocoaPods)
+* Objective-C (+ CocoaPods 0.39 and below. See [CocoaPods Specs Repo Sharding](http://blog.cocoapods.org/Sharding/))
 
 ## Installation
 


### PR DESCRIPTION
Specifying that, at this time, only CocoaPods 0.39 and below are supported. Linked to article describing what to do with CocoaPods 0.39 and below vs. 1.0 and above.