### PR TITLE
Modifications for successfully running in ConcourseCI

### DIFF
--- a/features/support/testing_dsl.rb
+++ b/features/support/testing_dsl.rb
@@ -383,7 +383,8 @@ module LicenseFinder
 
       def reset_projects!
         # only destroyed when a test starts, so you can poke around after a failure
-        projects.rmtree if projects.exist?
+        require 'fileutils'
+        FileUtils.rmtree(projects) if projects.exist?
         projects.mkpath
       end
     end

--- a/features/support/testing_dsl.rb
+++ b/features/support/testing_dsl.rb
@@ -131,7 +131,7 @@ module LicenseFinder
       end
 
       def install
-        shell_out("bower install 2>/dev/null")
+        shell_out("bower install --allow-root 2>/dev/null")
       end
     end
 

--- a/lib/license_finder/package_managers/bower.rb
+++ b/lib/license_finder/package_managers/bower.rb
@@ -15,7 +15,7 @@ module LicenseFinder
     private
 
     def bower_output
-      command = "#{Bower::package_management_command} list --json -l action"
+      command = "#{Bower::package_management_command} list --json -l action --allow-root"
       output, success = Dir.chdir(project_path) { capture(command) }
       raise "Command '#{command}' failed to execute: #{output}" unless success
 

--- a/spec/lib/license_finder/package_managers/bower_spec.rb
+++ b/spec/lib/license_finder/package_managers/bower_spec.rb
@@ -28,7 +28,7 @@ module LicenseFinder
         JSON
 
         allow(Dir).to receive(:chdir).with(Pathname('/fake/path')) { |&block| block.call }
-        allow(subject).to receive(:capture).with('bower list --json -l action').and_return([json, true])
+        allow(subject).to receive(:capture).with('bower list --json -l action --allow-root').and_return([json, true])
 
         expect(subject.current_packages.map { |p| [p.name, p.install_path] }).to eq [
           %w(dependency-library /path/to/thing), %w(another-dependency /path/to/thing2)


### PR DESCRIPTION
The following changes to unit and feature tests were added to successfully run a multi Ruby pipeline in Concourse CI.

For commit 0dc3da4, we added the `--allow-root` flag to Bower since Concourse uses a Docker container to run its jobs, which runs processes as root user. Bower refuses to install under root by default.

For commit 9d3efc6, we modified `projects.rmtree` to `FileUtils.rmtree` due to a potential bug in JRuby 9.0.4.0 which refused to clear the temporary directory upon start of a test (after NPM feature test, and before Nuget feature test in particular).

