### PR TITLE
support license_links csv option

### DIFF
--- a/lib/license_finder/reports/csv_report.rb
+++ b/lib/license_finder/reports/csv_report.rb
@@ -3,7 +3,7 @@ require 'csv'
 module LicenseFinder
   class CsvReport < Report
     COMMA_SEP =  ","
-    AVAILABLE_COLUMNS = %w[name version authors licenses approved summary description homepage install_path package_manager groups]
+    AVAILABLE_COLUMNS = %w[name version authors licenses license_links approved summary description homepage install_path package_manager groups]
     MISSING_DEPENDENCY_TEXT = "This package is not installed. Please install to determine licenses."
 
     def initialize(dependencies, options)
@@ -49,6 +49,10 @@ module LicenseFinder
       else
         dep.licenses.map(&:name).join(self.class::COMMA_SEP)
       end
+    end
+
+    def format_license_links(dep)
+      dep.licenses.map(&:url).join(self.class::COMMA_SEP)
     end
 
     def format_approved(dep)

--- a/spec/lib/license_finder/reports/csv_report_spec.rb
+++ b/spec/lib/license_finder/reports/csv_report_spec.rb
@@ -35,6 +35,14 @@ module LicenseFinder
       expect(subject.to_s).to eq("gem_a,1.0,Nuget\n")
     end
 
+    it 'supports license_links column' do
+      dep = Package.new('gem_a', '1.0')
+      mit = License.find_by_name("MIT")
+      dep.decide_on_license(mit)
+      subject = described_class.new([dep], columns: %w[name licenses license_links])
+      expect(subject.to_s).to eq("gem_a,MIT,#{mit.url}\n")
+    end
+
     it "does not include columns that should only be in merged reports" do
       dep = Package.new('gem_a', '1.0')
       subject = described_class.new([dep], columns: %w[subproject_paths])


### PR DESCRIPTION
This change adds `license_links` to the AVAILABLE_COLUMNS for `--format csv`.

####  Background

Added in to have some parity with the `--report html` format (which has links to licenses) since I mainly use the csv format