### PR TITLE
Use the group id and full name of the mvn license plugin when downloading licenses

### DIFF
--- a/lib/license_finder/package_managers/maven.rb
+++ b/lib/license_finder/package_managers/maven.rb
@@ -10,7 +10,7 @@ module LicenseFinder
     end
 
     def current_packages
-      command = "#{package_management_command} license:download-licenses"
+      command = "#{package_management_command} org.codehaus.mojo:license-maven-plugin:download-licenses"
       command += " -Dlicense.excludedScopes=#{@ignored_groups.to_a.join(',')}" if @ignored_groups and !@ignored_groups.empty?
 
       output, success = Dir.chdir(project_path) { capture(command) }

--- a/spec/lib/license_finder/package_managers/maven_spec.rb
+++ b/spec/lib/license_finder/package_managers/maven_spec.rb
@@ -22,7 +22,7 @@ module LicenseFinder
     describe '.current_packages' do
       before do
         allow(Dir).to receive(:chdir).with(Pathname('/fake/path')) { |&block| block.call }
-        allow(subject).to receive(:capture).with('mvn license:download-licenses').and_return(['', true])
+        allow(subject).to receive(:capture).with('mvn org.codehaus.mojo:license-maven-plugin:download-licenses').and_return(['', true])
       end
 
       def stub_license_report(deps)
@@ -66,7 +66,7 @@ module LicenseFinder
         }
 
         before do
-          expect(subject).to receive(:capture).with('mvn license:download-licenses -Dlicense.excludedScopes=system,test,provided,import').and_return(['', true])
+          expect(subject).to receive(:capture).with('mvn org.codehaus.mojo:license-maven-plugin:download-licenses -Dlicense.excludedScopes=system,test,provided,import').and_return(['', true])
         end
 
         it 'uses skips the specified groups' do


### PR DESCRIPTION
Use the full name (including group id) of the license-maven-plugin when
invoking the `download-licenses` goal.

There are other plugins with the same name but different group ids. For real
world projects, using 'license' may result in invoking the incorrect
plugin.

When invoking the download-licenses goal of the license-maven-plugin,
LicenseFinder currently calls it using `mvn license:download-licenses`.
Maven automatically maps the word 'license' to 'license-maven-plugin'
base on some prefix mapping rules and invokes the 'download-licenses'
goal on that plugin. 

See Issue #284
[#140716339]