### PR TITLE
Fix for issue #177

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,13 @@ task :spec do
   end
 end
 
+desc "Only run cocoapods specs"
+RSpec::Core::RakeTask.new("spec:cocoapods") do |t|
+  t.fail_on_error = true
+  t.pattern = "./spec/lib/license_finder/package_managers/cocoa_pods_*spec.rb"
+  t.rspec_opts = %w[--color]
+end
+
 desc "Run all specs in features/"
 task :features do
   RSpec::Core::RakeTask.new(:features) do |t|

--- a/lib/license_finder/package_managers/cocoa_pods.rb
+++ b/lib/license_finder/package_managers/cocoa_pods.rb
@@ -40,19 +40,15 @@ module LicenseFinder
     end
 
     def acknowledgements_path
-      filename = 'Pods-acknowledgements.plist'
-      directories = [
-        'Pods',                          # cocoapods < 0.34
-        'Pods/Target Support Files/Pods' # cocoapods >= 0.34
-      ]
+      search_paths = [ "Pods/Pods-acknowledgements.plist",
+                       "Pods/Target Support Files/Pods/Pods-acknowledgements.plist",
+                       "Pods/Target Support Files/Pods-*/Pods-*-acknowledgements.plist" ]
 
-      directories
-        .map { |dir| project_path.join(dir, filename) }
-        .find(&:exist?)
+      Dir[*search_paths.map {|path| File.join(project_path, path) }].first
     end
 
     def read_plist pathname
-      JSON.parse(`plutil -convert json -o - '#{pathname.expand_path}'`)
+      JSON.parse(`plutil -convert json -o - '#{pathname}'`)
     end
   end
 end


### PR DESCRIPTION
Search for acknowledgements paths in Cocoapods via a glob -- Cocoapods saves acknoledgements files in a structure like Pods-<target>/Pods-<target>-acknowledgements.plist.

Note that it is still not possible in Cocoapods to ignore specific targets when running license_finder.