### PR TITLE
Fix for issue #290 (LF doesn't recognize .NET projects using 'packages' directory instead of '.nuget' for dependencies)

### DIFF
--- a/lib/license_finder/package_managers/nuget.rb
+++ b/lib/license_finder/package_managers/nuget.rb
@@ -7,7 +7,12 @@ module LicenseFinder
       path = project_path.join("vendor/*.nupkg")
       nuget_dir = Dir[path].map{|pkg| File.dirname(pkg)}.uniq
       if nuget_dir.length == 0
-        project_path.join(".nuget")
+        path = project_path.join(".nuget")
+        if File.directory?(path)
+          path
+        else
+          project_path.join("packages")
+        end
       else
         Pathname(nuget_dir.first)
       end

--- a/spec/lib/license_finder/package_managers/nuget_spec.rb
+++ b/spec/lib/license_finder/package_managers/nuget_spec.rb
@@ -54,9 +54,20 @@ module LicenseFinder
           FileUtils.touch 'app/vendor/package.nupkg'
         end
 
-        it "returns vendored director" do
+        it "returns vendored directory" do
           nuget = Nuget.new project_path: Pathname.new("app")
           expect(nuget.package_path).to eq Pathname('/app/vendor')
+        end
+      end
+
+      context 'when vendor and .nuget are not present but a packages directory exists' do
+        before do
+          FileUtils.mkdir_p 'app/packages'
+        end
+
+        it "returns the packages directory" do
+          nuget = Nuget.new project_path: Pathname.new("app")
+          expect(nuget.package_path).to eq Pathname('app/packages')
         end
       end
     end


### PR DESCRIPTION
Add check for whether .nuget directory is present, if it isn't look for a packages directory.