### PR TITLE
Partial(?) fix for #235

### DIFF
--- a/features/features/cli/cli_spec.rb
+++ b/features/features/cli/cli_spec.rb
@@ -36,7 +36,7 @@ describe "License Finder command line executable" do
 
     developer.run_license_finder
     expect(developer).to be_receiving_exit_code(0)
-    expect(developer).to be_seeing 'All dependencies are approved for use'
+    expect(developer).to be_seeing 'No dependencies recognized!'
   end
 
   specify "displays an error if project_path does not exist" do

--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -34,11 +34,17 @@ module LicenseFinder
       desc "action_items", "List unapproved dependencies (the default action for `license_finder`)"
 
       def action_items
+        any_packages = license_finder.any_packages?
         unapproved = license_finder.unapproved
         blacklisted = license_finder.blacklisted
 
         # Ensure to start output on a new line even with dot progress indicators.
         say "\n"
+
+        unless any_packages
+          say "No dependencies recognized!", :red
+          exit 1
+        end
 
         if unapproved.empty?
           say "All dependencies are approved for use", :green

--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -43,7 +43,7 @@ module LicenseFinder
 
         unless any_packages
           say "No dependencies recognized!", :red
-          exit 1
+          exit 0
         end
 
         if unapproved.empty?

--- a/lib/license_finder/core.rb
+++ b/lib/license_finder/core.rb
@@ -37,7 +37,7 @@ module LicenseFinder
     end
 
     extend Forwardable
-    def_delegators :decision_applier, :acknowledged, :unapproved, :blacklisted
+    def_delegators :decision_applier, :acknowledged, :unapproved, :blacklisted, :any_packages?
 
     def project_name
       decisions.project_name || config.project_path.basename.to_s

--- a/lib/license_finder/decision_applier.rb
+++ b/lib/license_finder/decision_applier.rb
@@ -2,7 +2,8 @@ module LicenseFinder
   class DecisionApplier
     def initialize(options)
       @decisions = options.fetch(:decisions)
-      @acknowledged = apply_decisions(options.fetch(:packages))
+      @all_packages = decisions.packages + options.fetch(:packages)
+      @acknowledged = apply_decisions
     end
 
     attr_reader :acknowledged
@@ -15,12 +16,15 @@ module LicenseFinder
       acknowledged.select(&:blacklisted?)
     end
 
+    def any_packages?
+      all_packages.any?
+    end
+
     private
 
-    attr_reader :decisions
+    attr_reader :decisions, :all_packages
 
-    def apply_decisions(system_packages)
-      all_packages = decisions.packages + system_packages
+    def apply_decisions
       all_packages
         .map { |package| with_decided_licenses(package) }
         .map { |package| with_approval(package) }

--- a/spec/lib/license_finder/cli/main_spec.rb
+++ b/spec/lib/license_finder/cli/main_spec.rb
@@ -191,7 +191,7 @@ module LicenseFinder
             allow(LicenseFinder::Core).to receive(:new).and_return(license_finder_instance)
           end
 
-          it "reports that no packages were found" do
+          it "reports that no dependencies were recognized" do
             result = capture_stdout do
               expect { action_items }.to raise_error(SystemExit)
             end

--- a/spec/lib/license_finder/decision_applier_spec.rb
+++ b/spec/lib/license_finder/decision_applier_spec.rb
@@ -2,6 +2,14 @@ require 'spec_helper'
 
 module LicenseFinder
   describe DecisionApplier do
+    it "reports nothing found" do
+      decision_applier = described_class.new(
+        decisions: Decisions.new,
+        packages: []
+      )
+      expect(decision_applier.any_packages?).to be false
+    end
+
     describe "#acknowledged" do
       it "combines manual and system packages" do
         decision_applier = described_class.new(


### PR DESCRIPTION
Print a message when LF can't find any packages.

This isn't the most comprehensive fix for #235 but at least gets rid of the misleading false positive case.

Sample output:
```
pivotal@DESKTOP-KJBQ0TC:~/temp$ license_finder
........................
No dependencies recognized!
```

Thanks, @flavorjones @kdykeman @LukeWinikates !