### PR TITLE
Add --maven-options to allow options for maven scans

### DIFF
--- a/lib/license_finder/cli/base.rb
+++ b/lib/license_finder/cli/base.rb
@@ -32,6 +32,7 @@ module LicenseFinder
           :gradle_command,
           :gradle_include_groups,
           :maven_include_groups,
+          :maven_options,
           :rebar_command,
           :rebar_deps_dir,
           :save
@@ -70,4 +71,3 @@ module LicenseFinder
     end
   end
 end
-

--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -24,6 +24,7 @@ module LicenseFinder
       class_option :gradle_include_groups, desc: "Whether dependency name should include group id. Only meaningful if used with a Java/gradle project. Defaults to false."
       class_option :gradle_command, desc: "Command to use when fetching gradle packages. Only meaningful if used with a Java/gradle project. Defaults to 'gradlew' / 'gradlew.bat' if the wrapper is present, otherwise to 'gradle'."
       class_option :maven_include_groups, desc: "Whether dependency name should include group id. Only meaningful if used with a Java/maven project. Defaults to false."
+      class_option :maven_options, desc: "Maven options to append to command. Defaults to empty."
       class_option :rebar_command, desc: "Command to use when fetching rebar packages. Only meaningful if used with a Erlang/rebar project. Defaults to 'rebar'."
       class_option :rebar_deps_dir, desc: "Path to rebar dependencies directory. Only meaningful if used with a Erlang/rebar project. Defaults to 'deps'."
       class_option :subprojects, type: :array, desc: "Generate a single report for multiple sub-projects. Ex: --subprojects='path/to/project1', 'path/to/project2'"

--- a/lib/license_finder/configuration.rb
+++ b/lib/license_finder/configuration.rb
@@ -37,6 +37,10 @@ module LicenseFinder
       get(:maven_include_groups)
     end
 
+    def maven_options
+      get(:maven_options)
+    end
+
     def rebar_command
       get(:rebar_command)
     end

--- a/lib/license_finder/core.rb
+++ b/lib/license_finder/core.rb
@@ -68,10 +68,10 @@ module LicenseFinder
         gradle_command: config.gradle_command,
         gradle_include_groups: config.gradle_include_groups,
         maven_include_groups: config.maven_include_groups,
+        maven_options: config.maven_options,
         rebar_command: config.rebar_command,
         rebar_deps_dir: config.rebar_deps_dir,
       )
     end
   end
 end
-

--- a/lib/license_finder/package_managers/maven.rb
+++ b/lib/license_finder/package_managers/maven.rb
@@ -7,12 +7,13 @@ module LicenseFinder
       super
       @ignored_groups = options[:ignored_groups]
       @include_groups = options[:maven_include_groups]
+      @maven_options = options[:maven_options]
     end
 
     def current_packages
       command = "#{package_management_command} org.codehaus.mojo:license-maven-plugin:download-licenses"
       command += " -Dlicense.excludedScopes=#{@ignored_groups.to_a.join(',')}" if @ignored_groups and !@ignored_groups.empty?
-
+      command += " #{@maven_options}" if !@maven_options.nil?
       output, success = Dir.chdir(project_path) { capture(command) }
       raise "Command '#{command}' failed to execute: #{output}" unless success
 

--- a/lib/license_finder/reports/csv_report.rb
+++ b/lib/license_finder/reports/csv_report.rb
@@ -2,7 +2,7 @@ require 'csv'
 
 module LicenseFinder
   class CsvReport < Report
-    COMMA_SEP =  ","
+    COMMA_SEP = ","
     AVAILABLE_COLUMNS = %w[name version authors licenses license_links approved summary description homepage install_path package_manager groups]
     MISSING_DEPENDENCY_TEXT = "This package is not installed. Please install to determine licenses."
 
@@ -76,7 +76,11 @@ module LicenseFinder
     end
 
     def format_groups(dep)
-      dep.groups.join(",")
+      if dep.groups.nil?
+        ''
+      else
+        dep.groups.join(self.class::COMMA_SEP)
+      end
     end
   end
 end

--- a/lib/license_finder/version.rb
+++ b/lib/license_finder/version.rb
@@ -1,3 +1,3 @@
 module LicenseFinder
-  VERSION = "3.0.0"
+  VERSION = "3.0.1"
 end

--- a/spec/lib/license_finder/core_spec.rb
+++ b/spec/lib/license_finder/core_spec.rb
@@ -31,6 +31,7 @@ module LicenseFinder
           gradle_command: configuration.gradle_command,
           gradle_include_groups: nil,
           maven_include_groups: nil,
+          maven_options: nil,
           rebar_command: configuration.rebar_command,
           rebar_deps_dir: configuration.rebar_deps_dir
         }


### PR DESCRIPTION
Added a new option`--maven-options` to allow maven users to provide build options.
Here is example usuage
`license_finder --recursive --project-path /src/project --decisions-file /src/project/dependency_decisions.yml --maven-options "-Pdist -Drevision=1.0.0"`
Added Guard code in csvreport.rb as `groups` were sometime nil

( I bumped the version number to 3.0.1 .. need I revert ? )
