### PR TITLE
Update Ruby dependency. Closes #311.

### DIFF
--- a/license_finder.gemspec
+++ b/license_finder.gemspec
@@ -5,7 +5,7 @@ require 'license_finder/platform'
 require 'license_finder/version'
 
 Gem::Specification.new do |s|
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.3'
   s.name        = "license_finder"
   s.version     = LicenseFinder::VERSION
 


### PR DESCRIPTION
This  should fix #311 where the "Safe Navigation Operator" makes a build fail.