### PR TITLE
Reflect requirement of Ruby 2.3.x in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ downloadLicenses {
 
 ## Requirements
 
-`license_finder` requires ruby >= 1.9, or jruby.
+`license_finder` requires ruby >= 2.3.0, or jruby.
 
 
 ## Upgrading


### PR DESCRIPTION
Otherwise at least generating a report with presence of a package.json file is a problem
because of the safe navigation operator in https://github.com/pivotal/LicenseFinder/blob/28d2568164e384d7a46bdf90ea62e49b8e20246f/lib/license_finder/package_managers/npm.rb#L13

Well, I have to admit not having a requirement of 2.3.x would be better at this point in time, but anyway. The previous version license_finder 3.0.0 worked with Ruby 2.2.5 by the way.

This should either be merged in conjunction with https://github.com/pivotal/LicenseFinder/pull/312 or if that's preferred, I might copy the change from it and integrate it into this pull request.