### PR TITLE
Allow Custom Pip Requirements File Path

### DIFF
--- a/bin/license_finder_pip.py
+++ b/bin/license_finder_pip.py
@@ -8,7 +8,7 @@ from pip._vendor import pkg_resources
 from pip._vendor.six import print_
 
 requirements = [pkg_resources.Requirement.parse(str(req.req)) for req
-                in parse_requirements(sys.argv[1], session=PipSession()) if str(req.req) != 'None']
+                in parse_requirements(sys.argv[1], session=PipSession()) if req.req != None]
 
 transform = lambda dist: {
         'name': dist.project_name,

--- a/bin/license_finder_pip.py
+++ b/bin/license_finder_pip.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 
 import json
+import sys
 from pip.req import parse_requirements
 from pip.download import PipSession
 from pip._vendor import pkg_resources
 from pip._vendor.six import print_
 
 requirements = [pkg_resources.Requirement.parse(str(req.req)) for req
-                in parse_requirements('requirements.txt', session=PipSession())]
+                in parse_requirements(sys.argv[1], session=PipSession()) if str(req.req) != 'None']
 
 transform = lambda dist: {
         'name': dist.project_name,

--- a/lib/license_finder/cli/base.rb
+++ b/lib/license_finder/cli/base.rb
@@ -33,7 +33,7 @@ module LicenseFinder
           :gradle_include_groups,
           :maven_include_groups,
           :maven_options,
-          :python_requirements_path,
+          :pip_requirements_path,
           :rebar_command,
           :rebar_deps_dir,
           :save

--- a/lib/license_finder/cli/base.rb
+++ b/lib/license_finder/cli/base.rb
@@ -33,6 +33,7 @@ module LicenseFinder
           :gradle_include_groups,
           :maven_include_groups,
           :maven_options,
+          :python_requirements_path,
           :rebar_command,
           :rebar_deps_dir,
           :save

--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -25,7 +25,7 @@ module LicenseFinder
       class_option :gradle_command, desc: "Command to use when fetching gradle packages. Only meaningful if used with a Java/gradle project. Defaults to 'gradlew' / 'gradlew.bat' if the wrapper is present, otherwise to 'gradle'."
       class_option :maven_include_groups, desc: "Whether dependency name should include group id. Only meaningful if used with a Java/maven project. Defaults to false."
       class_option :maven_options, desc: "Maven options to append to command. Defaults to empty."
-      class_option :python_requirements_path, desc: "Path to python requirements file. Defaults to requirements.txt."
+      class_option :pip_requirements_path, desc: "Path to python requirements file. Defaults to requirements.txt."
       class_option :rebar_command, desc: "Command to use when fetching rebar packages. Only meaningful if used with a Erlang/rebar project. Defaults to 'rebar'."
       class_option :rebar_deps_dir, desc: "Path to rebar dependencies directory. Only meaningful if used with a Erlang/rebar project. Defaults to 'deps'."
       class_option :subprojects, type: :array, desc: "Generate a single report for multiple sub-projects. Ex: --subprojects='path/to/project1', 'path/to/project2'"

--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -25,6 +25,7 @@ module LicenseFinder
       class_option :gradle_command, desc: "Command to use when fetching gradle packages. Only meaningful if used with a Java/gradle project. Defaults to 'gradlew' / 'gradlew.bat' if the wrapper is present, otherwise to 'gradle'."
       class_option :maven_include_groups, desc: "Whether dependency name should include group id. Only meaningful if used with a Java/maven project. Defaults to false."
       class_option :maven_options, desc: "Maven options to append to command. Defaults to empty."
+      class_option :python_requirements_path, desc: "Path to python requirements file. Defaults to requirements.txt."
       class_option :rebar_command, desc: "Command to use when fetching rebar packages. Only meaningful if used with a Erlang/rebar project. Defaults to 'rebar'."
       class_option :rebar_deps_dir, desc: "Path to rebar dependencies directory. Only meaningful if used with a Erlang/rebar project. Defaults to 'deps'."
       class_option :subprojects, type: :array, desc: "Generate a single report for multiple sub-projects. Ex: --subprojects='path/to/project1', 'path/to/project2'"

--- a/lib/license_finder/configuration.rb
+++ b/lib/license_finder/configuration.rb
@@ -41,8 +41,8 @@ module LicenseFinder
       get(:maven_options)
     end
 
-    def python_requirements_path
-      get(:python_requirements_path)
+    def pip_requirements_path
+      get(:pip_requirements_path)
     end
 
     def rebar_command

--- a/lib/license_finder/configuration.rb
+++ b/lib/license_finder/configuration.rb
@@ -41,6 +41,10 @@ module LicenseFinder
       get(:maven_options)
     end
 
+    def python_requirements_path
+      get(:python_requirements_path)
+    end
+
     def rebar_command
       get(:rebar_command)
     end

--- a/lib/license_finder/core.rb
+++ b/lib/license_finder/core.rb
@@ -69,7 +69,7 @@ module LicenseFinder
         gradle_include_groups: config.gradle_include_groups,
         maven_include_groups: config.maven_include_groups,
         maven_options: config.maven_options,
-        python_requirements_path: config.python_requirements_path,
+        pip_requirements_path: config.pip_requirements_path,
         rebar_command: config.rebar_command,
         rebar_deps_dir: config.rebar_deps_dir,
       )

--- a/lib/license_finder/core.rb
+++ b/lib/license_finder/core.rb
@@ -69,6 +69,7 @@ module LicenseFinder
         gradle_include_groups: config.gradle_include_groups,
         maven_include_groups: config.maven_include_groups,
         maven_options: config.maven_options,
+        python_requirements_path: config.python_requirements_path,
         rebar_command: config.rebar_command,
         rebar_deps_dir: config.rebar_deps_dir,
       )

--- a/lib/license_finder/package_managers/pip.rb
+++ b/lib/license_finder/package_managers/pip.rb
@@ -5,7 +5,7 @@ module LicenseFinder
   class Pip < PackageManager
     def initialize(options={})
       super
-      @requirements_path = options[:python_requirements_path] || 'requirements.txt'
+      @requirements_path = options[:pip_requirements_path] || 'requirements.txt'
     end
 
     def current_packages

--- a/lib/license_finder/package_managers/pip.rb
+++ b/lib/license_finder/package_managers/pip.rb
@@ -3,6 +3,11 @@ require 'httparty'
 
 module LicenseFinder
   class Pip < PackageManager
+    def initialize(options={})
+      super
+      @requirements_path = options[:python_requirements_path] || 'requirements.txt'
+    end
+
     def current_packages
       pip_output.map do |name, version, children, location|
         PipPackage.new(
@@ -23,11 +28,15 @@ module LicenseFinder
     private
 
     def package_path
-      project_path.join('requirements.txt')
+      unless project_path.nil?
+        project_path.join(@requirements_path)
+      else
+        @requirements_path
+      end
     end
 
     def pip_output
-      output = `#{LicenseFinder::BIN_PATH.join("license_finder_pip.py")}`
+      output = `#{LicenseFinder::BIN_PATH.join("license_finder_pip.py")} #{package_path}`
       JSON(output).map do |package|
         package.values_at(*%w[name version dependencies location])
       end

--- a/spec/lib/license_finder/core_spec.rb
+++ b/spec/lib/license_finder/core_spec.rb
@@ -32,6 +32,7 @@ module LicenseFinder
           gradle_include_groups: nil,
           maven_include_groups: nil,
           maven_options: nil,
+          python_requirements_path: nil,
           rebar_command: configuration.rebar_command,
           rebar_deps_dir: configuration.rebar_deps_dir
         }

--- a/spec/lib/license_finder/core_spec.rb
+++ b/spec/lib/license_finder/core_spec.rb
@@ -32,7 +32,7 @@ module LicenseFinder
           gradle_include_groups: nil,
           maven_include_groups: nil,
           maven_options: nil,
-          python_requirements_path: nil,
+          pip_requirements_path: nil,
           rebar_command: configuration.rebar_command,
           rebar_deps_dir: configuration.rebar_deps_dir
         }


### PR DESCRIPTION
This PR adds a new argument to the cli `--pip-requirements-path` which allows for custom requirements file paths.

The usage is as follows: `license_finder --pip-requirements-path=requirements/base.txt`

Additionally, it fixes a bug where using a local editable requirement would throw an error since it would stringify `None` instead of excluding it from the list of items to check.