### PR TITLE
Fall back to a default GOPATH

### DIFF
--- a/lib/license_finder/package_managers/go_dep.rb
+++ b/lib/license_finder/package_managers/go_dep.rb
@@ -36,7 +36,11 @@ module LicenseFinder
     private
 
     def install_prefix
-      go_path = workspace_dir.exist? ? workspace_dir : Pathname(ENV['GOPATH'])
+      go_path = if workspace_dir.directory?
+        workspace_dir
+      else
+        Pathname(ENV['GOPATH'] || ENV['HOME'] + '/go')
+      end
       go_path.join('src')
     end
 

--- a/spec/lib/license_finder/package_managers/go_dep_spec.rb
+++ b/spec/lib/license_finder/package_managers/go_dep_spec.rb
@@ -44,7 +44,7 @@ module LicenseFinder
 
       context 'when dependencies are vendored' do
         before do
-          allow(FileTest).to receive(:exist?).with('/fake/path/Godeps/_workspace').and_return(true)
+          allow(FileTest).to receive(:directory?).with('/fake/path/Godeps/_workspace').and_return(true)
         end
 
         it 'should return an array of packages' do


### PR DESCRIPTION
This avoids the need to have GOPATH set and is in line with how Go itself
behaves, see https://github.com/golang/go/issues/17262.