### PR TITLE
use minimum JIT for jruby to improve test time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:trusty
-RUN apt-get update && apt-get install -y curl git-core build-essential wget unzip
+RUN dpkg --add-architecture i386 && \
+    apt-get update && \
+    apt-get install -y curl git-core build-essential wget unzip openjdk-7-jre-headless:i386
 
 # nodejs seems to be required for the one of the gems
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \

--- a/ci/scripts/run-tests.sh
+++ b/ci/scripts/run-tests.sh
@@ -11,8 +11,10 @@ gem install bundler
 bundle install
 
 # jruby-9 specific: requires  >= rack 2.x
-if [ "$RUBY_VERSION_UNDER_TEST" == "jruby-9.0.4.0" ]
-then
+if [ "$RUBY_VERSION_UNDER_TEST" == "jruby-9.0.4.0" ]; then
+  export JAVA_HOME="/usr/lib/jvm/java-1.7.0-openjdk-i386"
+  export JAVA_OPTS="-client"
+  export JRUBY_OPTS="--dev"
   bundle update rack
 fi
 #


### PR DESCRIPTION
- following advice from
  - http://blog.headius.com/2010/03/jruby-startup-time-tips.html
  - https://github.com/jruby/jruby/wiki/Improving-startup-time

[finish #151267640]

Signed-off-by: Yash Pancholi <ypancholi@pivotal.io>