### PR TITLE
Upgrade the license-gradle-plugin to version 0.14.0

### DIFF
--- a/features/fixtures/alternate-build-file-gradle/build-alt.gradle
+++ b/features/fixtures/alternate-build-file-gradle/build-alt.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'com.github.hierynomus.license' version '0.14.0'
+}
+
 apply plugin: 'java'
 
 sourceCompatibility = 1.5
@@ -8,19 +12,5 @@ repositories {
 }
 
 dependencies {
-    compile group: 'junit', name: 'junit', version: '4.11'
+    compile 'junit:junit:4.11'
 }
-
-buildscript {
-    repositories {
-        maven {
-            url 'https://plugins.gradle.org/m2/'
-        }
-    }
-
-    dependencies {
-        classpath 'gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.12.1'
-    }
-}
-
-apply plugin: 'license'

--- a/features/fixtures/build.gradle
+++ b/features/fixtures/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'com.github.hierynomus.license' version '0.14.0'
+}
+
 apply plugin: 'java'
 
 sourceCompatibility = 1.5
@@ -8,19 +12,5 @@ repositories {
 }
 
 dependencies {
-    compile group: 'junit', name: 'junit', version: '4.11'
+    compile 'junit:junit:4.11'
 }
-
-buildscript {
-    repositories {
-        maven {
-            url 'https://plugins.gradle.org/m2/'
-        }
-    }
-
-    dependencies {
-        classpath 'gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.12.1'
-    }
-}
-
-apply plugin: 'license'

--- a/features/fixtures/file-based-libs-gradle/build.gradle
+++ b/features/fixtures/file-based-libs-gradle/build.gradle
@@ -1,18 +1,16 @@
 plugins {
-    id "com.github.hierynomus.license" version "0.14.0"
+    id 'com.github.hierynomus.license' version '0.14.0'
 }
 
 repositories {
-        mavenCentral()
+    mavenCentral()
 }
 
 apply plugin: 'java'
 
 dependencies {
-        compile(
-                "com.google.guava:guava:18.0"
-        )
+    compile 'com.google.guava:guava:18.0'
 
-        // Import external libraries that are **not** available to download via repo
-        compile fileTree(dir: 'libs', include: ['*.jar'])
+    // Import external libraries that are **not** available to download via repo
+    compile fileTree(dir: 'libs', include: ['*.jar'])
 }

--- a/features/fixtures/gradle-wrapper/build.gradle
+++ b/features/fixtures/gradle-wrapper/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'com.github.hierynomus.license' version '0.14.0'
+}
+
 apply plugin: 'java'
 
 sourceCompatibility = 1.5
@@ -8,19 +12,5 @@ repositories {
 }
 
 dependencies {
-    compile group: 'junit', name: 'junit', version: '4.11'
+    compile 'junit:junit:4.11'
 }
-
-buildscript {
-    repositories {
-        maven {
-            url 'https://plugins.gradle.org/m2/'
-        }
-    }
-
-    dependencies {
-        classpath 'gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.12.1'
-    }
-}
-
-apply plugin: 'license'

--- a/features/fixtures/multi-module-gradle/build.gradle
+++ b/features/fixtures/multi-module-gradle/build.gradle
@@ -1,20 +1,12 @@
-buildscript {
-  repositories {
-    maven {
-        url 'https://plugins.gradle.org/m2/'
-    }
-  }
-
-  dependencies {
-    classpath 'gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.12.1'
-  }
+plugins {
+    id 'com.github.hierynomus.license' version '0.14.0' apply false
 }
 
 allprojects {
-  apply plugin: 'java'
-  apply plugin: 'license'
+    apply plugin: 'java'
+    apply plugin: 'license'
 
-  repositories {
-    mavenCentral()
-  }
+    repositories {
+      mavenCentral()
+    }
 }

--- a/features/fixtures/single-module-gradle/build.gradle
+++ b/features/fixtures/single-module-gradle/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'com.github.hierynomus.license' version '0.14.0'
+}
+
 apply plugin: 'java'
 
 sourceCompatibility = 1.5
@@ -8,19 +12,5 @@ repositories {
 }
 
 dependencies {
-    compile group: 'junit', name: 'junit', version: '4.11'
+    compile 'junit:junit:4.11'
 }
-
-buildscript {
-    repositories {
-        maven {
-            url 'https://plugins.gradle.org/m2/'
-        }
-    }
-
-    dependencies {
-        classpath 'gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.12.1'
-    }
-}
-
-apply plugin: 'license'


### PR DESCRIPTION
This fixes the

    Could not get unknown property 'source'

error.

Also consistently use Gradle 2.1 syntax to load plugins and align the
formatting a bit.