### PR TITLE
Revert "Fix Gradle command variable interpolation"

### DIFF
--- a/lib/license_finder/package_managers/gradle.rb
+++ b/lib/license_finder/package_managers/gradle.rb
@@ -14,7 +14,7 @@ module LicenseFinder
       WithEnv.with_env({"TERM" => "dumb"}) do
         command = "#{@command} downloadLicenses"
         output, success = Dir.chdir(project_path) { capture(command) }
-        raise "Command '#{@command}' failed to execute: #{output}" unless success
+        raise "Command '#{command}' failed to execute: #{output}" unless success
 
         dependencies = GradleDependencyFinder.new(project_path).dependencies
         packages = dependencies.flat_map do |xml_file|


### PR DESCRIPTION
This reverts commit f42b11b as there is a local variable called
"command", and using that one is what we actually want.