### PR TITLE
Fixed the issue when recursive option is specified, some columns are missed like homepage etc.

### DIFF
--- a/features/features/report/subproject_spec.rb
+++ b/features/features/report/subproject_spec.rb
@@ -7,6 +7,17 @@ describe 'Subproject report' do
 
   let(:developer) { LicenseFinder::TestingDSL::User.new }
 
+  specify 'shows specified columns' do
+    foo_10 = developer.create_gem_in_path('foo', 'v-10', version: '1.0.0', license: 'MIT', homepage: 'http://example.homepage.com')
+
+    project1 = developer.create_ruby_app('project_1')
+    project1.depend_on(foo_10)
+
+    developer.create_empty_project
+    developer.execute_command("license_finder report --columns name homepage subproject_paths --subprojects #{project1.project_dir} --format=csv")
+    expect(developer).to be_seeing_once("foo,http://example.homepage.com,#{project1.project_dir}")
+  end
+
   specify 'shows dependencies for multiple subprojects' do
     project1 = developer.create_ruby_app('project_1')
     project1.depend_on(developer.create_gem('foo', version: '1.0.0', license: 'MIT'))

--- a/lib/license_finder/package_managers/merged_package.rb
+++ b/lib/license_finder/package_managers/merged_package.rb
@@ -24,6 +24,30 @@ module LicenseFinder
       dependency.install_path
     end
 
+    def authors
+      dependency.authors
+    end
+
+    def homepage
+      dependency.homepage
+    end
+
+    def summary
+      dependency.summary
+    end
+
+    def description
+      dependency.description
+    end
+
+    def groups
+      dependency.groups
+    end
+
+    def package_manager
+      dependency.package_manager
+    end
+
     def subproject_paths
       @subproject_paths.map { |p| p.expand_path.to_s }
     end

--- a/spec/lib/license_finder/package_managers/merged_package_spec.rb
+++ b/spec/lib/license_finder/package_managers/merged_package_spec.rb
@@ -2,7 +2,17 @@ require 'spec_helper'
 
 module LicenseFinder
   describe MergedPackage do
-    let(:package) { Package.new('foo', '1.0.0', spec_licenses: ['MIT'], install_path: '/tmp/foo') }
+    let(:package) { Package.new(
+        'foo', '1.0.0',
+        spec_licenses: ['MIT'],
+        install_path: '/tmp/foo',
+        authors: "An author",
+        description: "A description",
+        summary: "A summary",
+        homepage: "http://homepage.example.com",
+        groups: %w[development production]
+      )}
+
     let(:subproject_paths) { 'path/to/project/with/foo' }
 
     subject { MergedPackage.new(package, [subproject_paths]) }
@@ -26,6 +36,30 @@ module LicenseFinder
 
     it 'returns the install path' do
       expect(subject.install_path).to eq('/tmp/foo')
+    end
+
+    it 'returns the homepage' do
+      expect(subject.homepage).to eq('http://homepage.example.com')
+    end
+
+    it 'returns the summary' do
+      expect(subject.summary).to eq('A summary')
+    end
+
+    it 'returns the authors' do
+      expect(subject.authors).to eq('An author')
+    end
+
+    it 'returns the description' do
+      expect(subject.description).to eq('A description')
+    end
+
+    it 'returns the groups' do
+      expect(subject.groups).to eq(%w[development production])
+    end
+
+    it 'returns the package_manager' do
+      expect(subject.package_manager).to eq('unknown')
     end
 
     describe '#eql?' do

--- a/spec/lib/license_finder/reports/merged_report_spec.rb
+++ b/spec/lib/license_finder/reports/merged_report_spec.rb
@@ -16,6 +16,32 @@ module LicenseFinder
         expect(report.to_s).to include("foo,1.0.0,MIT,#{expanded_foo_path}")
         expect(report.to_s).to include("bar,2.0.0,GPLv2,#{expanded_bar_path}")
       end
+
+      it 'supports license_links column' do
+        dep = Package.new('gem_a', '1.0')
+        mit = License.find_by_name("MIT")
+        dep.decide_on_license(mit)
+        subject = described_class.new([dep], columns: %w[name licenses license_links])
+        expect(subject.to_s).to eq("gem_a,MIT,#{mit.url}\n")
+      end
+    end
+
+    context "when no groups are specified" do
+      let( :dep ) { Package.new('gem_a', '1.0') }
+      subject { described_class.new([dep], columns: %w[name version groups]) }
+
+      it 'supports a groups column' do
+        expect(subject.to_s).to eq("gem_a,1.0,\"\"\n")
+      end
+    end
+
+    context "when some groups are specified" do
+      let( :dep ) { Package.new('gem_a', '1.0', groups: %w[development production]) }
+      subject { described_class.new([dep], columns: %w[name version groups]) }
+
+      it 'supports a groups column' do
+        expect(subject.to_s).to eq("gem_a,1.0,\"development,production\"\n")
+      end
     end
   end
 end


### PR DESCRIPTION
When recursive flag along with report option, the report does not contain columns like homepage, authors, summary, description, groups and package_manager. 
- Added getter methods for columns in merged_package
- Added test cases for merged_report and subproject_spec.