### PR TITLE
Capture also stderr, and return the exit status code

### DIFF
--- a/lib/license_finder/package_manager.rb
+++ b/lib/license_finder/package_manager.rb
@@ -69,7 +69,9 @@ module LicenseFinder
     end
 
     def capture(command)
-      [`#{command}`, $?.success?]
+      require 'open3'
+      stdout, stderr, process = Open3.capture3(command)
+      [stdout, stderr, process.exitstatus]
     end
 
     def current_packages_with_relations

--- a/lib/license_finder/package_managers/bower.rb
+++ b/lib/license_finder/package_managers/bower.rb
@@ -16,10 +16,10 @@ module LicenseFinder
 
     def bower_output
       command = "#{Bower::package_management_command} list --json -l action --allow-root"
-      output, success = Dir.chdir(project_path) { capture(command) }
-      raise "Command '#{command}' failed to execute: #{output}" unless success
+      stdout, stderr, exitstatus = Dir.chdir(project_path) { capture(command) }
+      raise "Command '#{command}' failed to execute: #{stderr}" unless exitstatus == 0
 
-      JSON(output)
+      JSON(stdout)
         .fetch("dependencies", {})
         .values
     end

--- a/lib/license_finder/package_managers/go_15vendorexperiment.rb
+++ b/lib/license_finder/package_managers/go_15vendorexperiment.rb
@@ -23,7 +23,7 @@ module LicenseFinder
     def project_sha(path)
       Dir.chdir(path) do
         val = capture('git rev-list --max-count 1 HEAD')
-        raise 'git rev-list failed' unless val.last
+        raise 'git rev-list failed' unless val.last == 0
         val.first.strip
       end
     end
@@ -55,7 +55,7 @@ module LicenseFinder
         ENV['GOPATH'] = nil
         val = capture('go list -f "{{join .Deps \"\n\"}}" ./...')
         ENV['GOPATH'] = orig_gopath
-        return [] unless val.last
+        return [] unless val.last == 0
         # Select non-standard packages. `go list std` returns the list of standard
         # dependencies. We then filter those dependencies out of the full list of
         # dependencies.

--- a/lib/license_finder/package_managers/go_workspace.rb
+++ b/lib/license_finder/package_managers/go_workspace.rb
@@ -74,7 +74,7 @@ module LicenseFinder
         ENV['GOPATH'] = nil
         val = capture('go list -f "{{join .Deps \"\n\"}}" ./...')
         ENV['GOPATH'] = orig_gopath
-        raise 'go list failed' unless val.last
+        raise 'go list failed' unless val.last == 0
         # Select non-standard packages. `go list std` returns the list of standard
         # dependencies. We then filter those dependencies out of the full list of
         # dependencies.

--- a/lib/license_finder/package_managers/gradle.rb
+++ b/lib/license_finder/package_managers/gradle.rb
@@ -13,8 +13,8 @@ module LicenseFinder
     def current_packages
       WithEnv.with_env({"TERM" => "dumb"}) do
         command = "#{@command} downloadLicenses"
-        output, success = Dir.chdir(project_path) { capture(command) }
-        raise "Command '#{command}' failed to execute: #{output}" unless success
+        stdout, stderr, exitstatus = Dir.chdir(project_path) { capture(command) }
+        raise "Command '#{command}' failed to execute: #{stderr}" unless exitstatus == 0
 
         dependencies = GradleDependencyFinder.new(project_path).dependencies
         packages = dependencies.flat_map do |xml_file|

--- a/lib/license_finder/package_managers/maven.rb
+++ b/lib/license_finder/package_managers/maven.rb
@@ -14,8 +14,8 @@ module LicenseFinder
       command = "#{package_management_command} org.codehaus.mojo:license-maven-plugin:download-licenses"
       command += " -Dlicense.excludedScopes=#{@ignored_groups.to_a.join(',')}" if @ignored_groups and !@ignored_groups.empty?
       command += " #{@maven_options}" if !@maven_options.nil?
-      output, success = Dir.chdir(project_path) { capture(command) }
-      raise "Command '#{command}' failed to execute: #{output}" unless success
+      stdout, stderr, exitstatus = Dir.chdir(project_path) { capture(command) }
+      raise "Command '#{command}' failed to execute: #{stderr}" unless exitstatus == 0
 
       dependencies = MavenDependencyFinder.new(project_path).dependencies
       packages = dependencies.flat_map do |xml|

--- a/lib/license_finder/package_managers/mix.rb
+++ b/lib/license_finder/package_managers/mix.rb
@@ -25,10 +25,10 @@ module LicenseFinder
 
     def mix_output
       command = "#{@command} deps"
-      output, success = Dir.chdir(project_path) { capture(command) }
-      raise "Command '#{command}' failed to execute: #{output}" unless success
+      stdout, stderr, exitstatus = Dir.chdir(project_path) { capture(command) }
+      raise "Command '#{command}' failed to execute: #{stderr}" unless exitstatus == 0
 
-      output
+      stdout
         .each_line
         .map(&:strip)
         .select { |line| line_of_interest? line }

--- a/lib/license_finder/package_managers/npm.rb
+++ b/lib/license_finder/package_managers/npm.rb
@@ -17,35 +17,12 @@ module LicenseFinder
       [project_path.join('package.json')]
     end
 
-    def run_command_with_tempfile_buffer(command, &block)
-      tempfile = Tempfile.new 'npm-list.json'
-      begin
-        output, success = Dir.chdir(project_path) { capture("#{command} > #{tempfile.path}") }
-        result = block.call(File.read(tempfile.path))
-      ensure
-        tempfile.close
-        tempfile.unlink
-      end
-      [output, result, success]
-    end
-
     def npm_json
       command = "#{NPM::package_management_command} list --json --long"
-      output, json, success = run_command_with_tempfile_buffer(command, &:parse_json_safely)
-      unless success
-        if json
-          $stderr.puts "Command '#{command}' returned an error but parsing succeeded."
-        else
-          raise "Command '#{command}' failed to execute: #{output}"
-        end
-      end
-      json
-    end
-  end
+      stdout, stderr, exitstatus = Dir.chdir(project_path) { capture(command) }
+      raise "Command '#{command}' failed to execute: #{stderr}" unless exitstatus == 0
 
-  String.class_eval do
-    def parse_json_safely
-      JSON.parse(self) rescue nil
+      JSON.parse(stdout)
     end
   end
 

--- a/lib/license_finder/package_managers/rebar.rb
+++ b/lib/license_finder/package_managers/rebar.rb
@@ -26,10 +26,10 @@ module LicenseFinder
 
     def rebar_ouput
       command = "#{@command} list-deps"
-      output, success = Dir.chdir(project_path) { capture(command) }
-      raise "Command '#{command}' failed to execute: #{output}" unless success
+      stdout, stderr, exitstatus = Dir.chdir(project_path) { capture(command) }
+      raise "Command '#{command}' failed to execute: #{stderr}" unless exitstatus == 0
 
-      output
+      stdout
         .each_line
         .reject { |line| line.start_with?("=") }
         .map { |line| line.split(" ") }

--- a/spec/lib/license_finder/package_managers/bower_spec.rb
+++ b/spec/lib/license_finder/package_managers/bower_spec.rb
@@ -28,7 +28,7 @@ module LicenseFinder
         JSON
 
         allow(Dir).to receive(:chdir).with(Pathname('/fake/path')) { |&block| block.call }
-        allow(subject).to receive(:capture).with('bower list --json -l action --allow-root').and_return([json, true])
+        allow(subject).to receive(:capture).with('bower list --json -l action --allow-root').and_return([json, '', 0])
 
         expect(subject.current_packages.map { |p| [p.name, p.install_path] }).to eq [
           %w(dependency-library /path/to/thing), %w(another-dependency /path/to/thing2)

--- a/spec/lib/license_finder/package_managers/go_15vendorexperiment_spec.rb
+++ b/spec/lib/license_finder/package_managers/go_15vendorexperiment_spec.rb
@@ -48,16 +48,16 @@ module LicenseFinder
 
       describe '#current_packages' do
         let(:go_deps) {
-          ["github.com/foo/bar", true]
+          ['github.com/foo/bar', '', 0]
         }
         let(:std_deps) {
-          ["stdbar/baz", true]
+          ['stdbar/baz', '', 0]
         }
 
         before do
           allow(subject).to receive(:capture).with(%q[go list -f "{{join .Deps \"\n\"}}" ./...]).and_return(go_deps)
           allow(subject).to receive(:capture).with(%q[go list std]).and_return(std_deps)
-          allow(subject).to receive(:capture).with(%q[git rev-list --max-count 1 HEAD]).and_return(["e0ff7ae205f\n", true])
+          allow(subject).to receive(:capture).with(%q[git rev-list --max-count 1 HEAD]).and_return(["e0ff7ae205f\n", '', 0])
         end
 
         RSpec.shared_examples 'current_packages' do |parameter|

--- a/spec/lib/license_finder/package_managers/go_workspace_spec.rb
+++ b/spec/lib/license_finder/package_managers/go_workspace_spec.rb
@@ -54,8 +54,8 @@ HERE
         allow(Dir).to receive(:chdir).with(Pathname.new project_path) { |&b| b.call() }
         allow(FileTest).to receive(:exist?).and_return(false)
         allow(FileTest).to receive(:exist?).with(File.join(project_path, '.envrc')).and_return(true)
-        allow(subject).to receive(:capture).with('go list -f "{{join .Deps \"\n\"}}" ./...').and_return([go_list_output, true])
-        allow(subject).to receive(:capture).with('go list std').and_return([std_packages, true])
+        allow(subject).to receive(:capture).with('go list -f "{{join .Deps \"\n\"}}" ./...').and_return([go_list_output, '', 0])
+        allow(subject).to receive(:capture).with('go list std').and_return([std_packages, '', 0])
       end
 
       it 'changes the directory' do
@@ -73,7 +73,7 @@ HERE
       it 'sets gopath to the envrc path' do
         allow(subject).to receive(:capture).with('go list -f "{{join .Deps \"\n\"}}" ./...') {
           expect(ENV['GOPATH']).to be_nil
-          ['', true]
+          ['', '', 0]
         }
 
         subject.send(:go_list)
@@ -90,7 +90,7 @@ HERE
 
       context 'if git submodule status fails' do
         before do
-          allow(subject).to receive(:capture).with('git submodule status').and_return(['', false])
+          allow(subject).to receive(:capture).with('git submodule status').and_return(['', '', 1])
         end
 
         it 'should raise an exception' do
@@ -107,7 +107,7 @@ HERE
         }
 
         before do
-          allow(subject).to receive(:capture).with('git submodule status').and_return([git_submodule_status_output, true])
+          allow(subject).to receive(:capture).with('git submodule status').and_return([git_submodule_status_output, '', 0])
         end
 
         it 'should return the filtered submodules' do

--- a/spec/lib/license_finder/package_managers/gradle_spec.rb
+++ b/spec/lib/license_finder/package_managers/gradle_spec.rb
@@ -12,7 +12,7 @@ module LicenseFinder
 
     describe '#current_packages' do
       before do
-        allow(Dir).to receive(:chdir).with(Pathname('/fake/path')).and_return(['', true])
+        allow(Dir).to receive(:chdir).with(Pathname('/fake/path')).and_return(['', '', 0])
         dependencies = double(:subject_dependency_file, dependencies: content)
         expect(GradleDependencyFinder).to receive(:new).and_return(dependencies)
 
@@ -36,7 +36,7 @@ BUILD SUCCESSFUL in 0s
       it 'uses custom subject command, if provided' do
         subject = Gradle.new(gradle_command: 'subjectfoo', project_path: Pathname('/fake/path'))
         expect(Dir).to receive(:chdir).with(Pathname('/fake/path')) { |&block| block.call }
-        expect(subject).to receive(:capture).with('subjectfoo downloadLicenses').and_return(['', true])
+        expect(subject).to receive(:capture).with('subjectfoo downloadLicenses').and_return(['', '', 0])
         subject.current_packages
       end
 
@@ -44,9 +44,9 @@ BUILD SUCCESSFUL in 0s
         subject = Gradle.new(project_path: Pathname('/Users/foo/bar'))
         expect(Dir).to receive(:chdir).with(Pathname('/Users/foo/bar')) { |&block| block.call }
         if Platform.windows?
-          expect(subject).to receive(:capture).with('gradle.bat downloadLicenses').and_return(['', true])
+          expect(subject).to receive(:capture).with('gradle.bat downloadLicenses').and_return(['', '', 0])
         else
-          expect(subject).to receive(:capture).with('gradle downloadLicenses').and_return(['', true])
+          expect(subject).to receive(:capture).with('gradle downloadLicenses').and_return(['', '', 0])
         end
         subject.current_packages
       end

--- a/spec/lib/license_finder/package_managers/maven_spec.rb
+++ b/spec/lib/license_finder/package_managers/maven_spec.rb
@@ -22,7 +22,7 @@ module LicenseFinder
     describe '.current_packages' do
       before do
         allow(Dir).to receive(:chdir).with(Pathname('/fake/path')) { |&block| block.call }
-        allow(subject).to receive(:capture).with('mvn org.codehaus.mojo:license-maven-plugin:download-licenses').and_return(['', true])
+        allow(subject).to receive(:capture).with('mvn org.codehaus.mojo:license-maven-plugin:download-licenses').and_return(['', '', 0])
       end
 
       def stub_license_report(deps)
@@ -67,7 +67,7 @@ module LicenseFinder
         }
 
         before do
-          expect(subject).to receive(:capture).with('mvn org.codehaus.mojo:license-maven-plugin:download-licenses -Dlicense.excludedScopes=system,test,provided,import').and_return(['', true])
+          expect(subject).to receive(:capture).with('mvn org.codehaus.mojo:license-maven-plugin:download-licenses -Dlicense.excludedScopes=system,test,provided,import').and_return(['', '', 0])
         end
 
         it 'uses skips the specified groups' do

--- a/spec/lib/license_finder/package_managers/mix_spec.rb
+++ b/spec/lib/license_finder/package_managers/mix_spec.rb
@@ -44,7 +44,7 @@ module LicenseFinder
       end
 
       it 'lists all the current packages' do
-        allow(subject).to receive(:capture).with('mix deps').and_return([output, true])
+        allow(subject).to receive(:capture).with('mix deps').and_return([output, '', 0])
 
         current_packages = subject.current_packages
         expect(current_packages.map(&:name)).to eq(["fs", "gettext", "uuid-refknown", "uuid"])
@@ -53,13 +53,13 @@ module LicenseFinder
       end
 
       it "fails when command fails" do
-        allow(subject).to receive(:capture).with(/mix/).and_return(['Some error', false]).once
+        allow(subject).to receive(:capture).with(/mix/).and_return(['Some error', '', 1]).once
         expect { subject.current_packages }.to raise_error(RuntimeError)
       end
 
       it "uses custom mix command, if provided" do
         mix = Mix.new(mix_command: "mixfoo", project_path: Pathname('/fake/path'))
-        allow(mix).to receive(:capture).with(/mixfoo/).and_return([output, true])
+        allow(mix).to receive(:capture).with(/mixfoo/).and_return([output, '', 0])
 
         current_packages = mix.current_packages
         expect(current_packages.map(&:name)).to eq(["fs", "gettext", "uuid-refknown", "uuid"])
@@ -67,7 +67,7 @@ module LicenseFinder
 
       it "uses custom mix_deps_dir, if provided" do
         mix = Mix.new(mix_deps_dir: "foo", project_path: Pathname('/fake/path'))
-        allow(mix).to receive(:capture).with(/mix/).and_return([output, true])
+        allow(mix).to receive(:capture).with(/mix/).and_return([output, '', 0])
 
         current_packages = mix.current_packages
         expect(current_packages.map(&:install_path)).to eq([Pathname("foo/fs"), Pathname("foo/gettext"), Pathname("foo/uuid-refknown"), Pathname("foo/uuid")])

--- a/spec/lib/license_finder/package_managers/npm_spec.rb
+++ b/spec/lib/license_finder/package_managers/npm_spec.rb
@@ -94,7 +94,7 @@ module LicenseFinder
         FileUtils.mkdir_p(Dir.tmpdir)
         FileUtils.mkdir_p(root)
         File.write(File.join(root, 'package.json'), package_json)
-        allow(npm).to receive(:run_command_with_tempfile_buffer).and_return ['', JSON.parse(dependency_json), true]
+        allow(npm).to receive(:npm_json).and_return JSON.parse(dependency_json)
       end
 
       it 'fetches data from npm' do
@@ -122,19 +122,19 @@ module LicenseFinder
         JSON
 
         allow(Dir).to receive(:chdir).with(Pathname('/fake-node-project')) { |&block| block.call }
-        allow(npm).to receive(:run_command_with_tempfile_buffer).and_return ['', JSON.parse(json), true]
+        allow(npm).to receive(:npm_json).and_return JSON.parse(json)
 
         current_packages = npm.current_packages
         expect(current_packages.map(&:name)).to eq([])
       end
 
       it 'fails when command fails' do
-        allow(npm).to receive(:run_command_with_tempfile_buffer).with(/npm/).and_return('Some error', nil, false).once
+        allow(npm).to receive(:capture).with('npm list --json --long').and_return ['', '', 1]
         expect { npm.current_packages }.to raise_error(RuntimeError)
       end
 
       it 'does not fail when command fails but produces output' do
-        allow(npm).to receive(:run_command_with_tempfile_buffer).and_return ['', {'foo' => 'bar'}, false]
+        allow(npm).to receive(:npm_json).and_return({'foo' => 'bar'})
         silence_stderr { npm.current_packages }
       end
 

--- a/spec/lib/license_finder/package_managers/rebar_spec.rb
+++ b/spec/lib/license_finder/package_managers/rebar_spec.rb
@@ -18,7 +18,7 @@ jiffy TAG 0.9.0 https://github.com/davisp/jiffy.git
       end
 
       it 'lists all the current packages' do
-        allow(subject).to receive(:capture).with('rebar list-deps').and_return([output, true])
+        allow(subject).to receive(:capture).with('rebar list-deps').and_return([output, '', 0])
 
         current_packages = subject.current_packages
         expect(current_packages.map(&:name)).to eq(["uuid", "jiffy"])
@@ -26,13 +26,13 @@ jiffy TAG 0.9.0 https://github.com/davisp/jiffy.git
       end
 
       it "fails when command fails" do
-        allow(subject).to receive(:capture).with(/rebar/).and_return(['Some error', false]).once
+        allow(subject).to receive(:capture).with(/rebar/).and_return(['Some error', '', 1]).once
         expect { subject.current_packages }.to raise_error(RuntimeError)
       end
 
       it "uses custom rebar command, if provided" do
         rebar = Rebar.new(rebar_command: "rebarfoo", project_path: Pathname('/fake/path'))
-        allow(rebar).to receive(:capture).with(/rebarfoo/).and_return([output, true])
+        allow(rebar).to receive(:capture).with(/rebarfoo/).and_return([output, '', 0])
 
         current_packages = rebar.current_packages
         expect(current_packages.map(&:name)).to eq(["uuid", "jiffy"])
@@ -40,7 +40,7 @@ jiffy TAG 0.9.0 https://github.com/davisp/jiffy.git
 
       it "uses custom rebar_deps_dir, if provided" do
         rebar = Rebar.new(rebar_deps_dir: "foo", project_path: Pathname('/fake/path'))
-        allow(rebar).to receive(:capture).with(/rebar/).and_return([output, true])
+        allow(rebar).to receive(:capture).with(/rebar/).and_return([output, '', 0])
 
         current_packages = rebar.current_packages
         expect(current_packages.map(&:install_path)).to eq([Pathname("foo/uuid"), Pathname("foo/jiffy")])


### PR DESCRIPTION
This way the caller can inspect the actual exit status code, and we do
not need to manually redirect stderr anymore via ">" which is causing
problems on Windows.