### PR TITLE
Rename GoVendor to Go15VendorExperiment to differentiate from govendor package manager

### DIFF
--- a/lib/license_finder/package_manager.rb
+++ b/lib/license_finder/package_manager.rb
@@ -13,7 +13,7 @@ module LicenseFinder
   #
   class PackageManager
     def self.package_managers
-      [GoDep, GoWorkspace, GoVendor, Glide, Gvt, Bundler, NPM, Pip,
+      [GoDep, GoWorkspace, Go15VendorExperiment, Glide, Gvt, Bundler, NPM, Pip,
        Yarn, Bower, Maven, Gradle, CocoaPods, Rebar, Nuget, Carthage, Mix]
     end
 
@@ -95,7 +95,7 @@ end
 
 require 'license_finder/package_managers/bower'
 require 'license_finder/package_managers/go_workspace'
-require 'license_finder/package_managers/go_vendor'
+require 'license_finder/package_managers/go_15vendorexperiment'
 require 'license_finder/package_managers/go_dep'
 require 'license_finder/package_managers/gvt'
 require 'license_finder/package_managers/glide'

--- a/lib/license_finder/package_managers/glide.rb
+++ b/lib/license_finder/package_managers/glide.rb
@@ -16,7 +16,7 @@ module LicenseFinder
     end
 
     def self.takes_priority_over
-      GoVendor
+      Go15VendorExperiment
     end
   end
 end

--- a/lib/license_finder/package_managers/go_15vendorexperiment.rb
+++ b/lib/license_finder/package_managers/go_15vendorexperiment.rb
@@ -1,7 +1,7 @@
 require 'json'
 
 module LicenseFinder
-  class GoVendor < PackageManager
+  class Go15VendorExperiment < PackageManager
 
     def initialize(options={})
       super

--- a/lib/license_finder/package_managers/gvt.rb
+++ b/lib/license_finder/package_managers/gvt.rb
@@ -47,7 +47,7 @@ module LicenseFinder
     end
 
     def self.takes_priority_over
-      GoVendor
+      Go15VendorExperiment
     end
   end
 end

--- a/spec/lib/license_finder/package_manager_spec.rb
+++ b/spec/lib/license_finder/package_manager_spec.rb
@@ -70,8 +70,8 @@ module LicenseFinder
         gvt = Gvt.new
         allow(Gvt).to receive(:new).and_return gvt
         allow(gvt).to receive(:active?).and_return true
-        govendor = GoVendor.new
-        allow(GoVendor).to receive(:new).and_return govendor
+        govendor = Go15VendorExperiment.new
+        allow(Go15VendorExperiment).to receive(:new).and_return govendor
         allow(govendor).to receive(:active?).and_return true
         expect(LicenseFinder::PackageManager.active_package_managers).to include gvt
         expect(LicenseFinder::PackageManager.active_package_managers).not_to include govendor

--- a/spec/lib/license_finder/package_managers/go_15vendorexperiment_spec.rb
+++ b/spec/lib/license_finder/package_managers/go_15vendorexperiment_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 require 'fakefs/spec_helpers'
 
 module LicenseFinder
-  describe GoVendor do
+  describe Go15VendorExperiment do
     include FakeFS::SpecHelpers
 
     let(:logger) { double(:logger, active: nil) }
-    subject { GoVendor.new(options.merge(project_path: Pathname(project_path), logger: logger)) }
+    subject { Go15VendorExperiment.new(options.merge(project_path: Pathname(project_path), logger: logger)) }
 
     before do
       allow(logger).to receive(:installed)


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/151698409