### PR TITLE
Strip 'The' prefix from names

### DIFF
--- a/features/features/package_managers/gradle_spec.rb
+++ b/features/features/package_managers/gradle_spec.rb
@@ -16,7 +16,7 @@ describe 'Gradle Dependencies' do
     LicenseFinder::TestingDSL::GradleProject::MultiModule.create
     java_developer.run_license_finder('multi-module-gradle')
     expect(java_developer).to be_seeing_line 'junit, 4.12, "Eclipse Public License 1.0"'
-    expect(java_developer).to be_seeing_line 'mockito-core, 1.9.5, "The MIT License"'
+    expect(java_developer).to be_seeing_line 'mockito-core, 1.9.5, MIT'
   end
 
   specify 'show both file-based jars and downloaded dependencies' do

--- a/lib/license_finder/license.rb
+++ b/lib/license_finder/license.rb
@@ -17,7 +17,7 @@ module LicenseFinder
 
       def find_by_name(name)
         name ||= "unknown"
-        all.detect { |l| l.matches_name? name } || Definitions.build_unrecognized(name)
+        all.detect { |l| l.matches_name? l.stripped_name(name) } || Definitions.build_unrecognized(name)
       end
 
       def find_by_text(text)
@@ -37,6 +37,10 @@ module LicenseFinder
 
     def name
       pretty_name
+    end
+
+    def stripped_name(name)
+      name.sub(/^The /i,'')
     end
 
     def matches_name?(name)

--- a/lib/license_finder/license/definitions.rb
+++ b/lib/license_finder/license/definitions.rb
@@ -40,7 +40,7 @@ module LicenseFinder
             "Apache License 2.0",
             "Apache License Version 2.0",
             "Apache Public License 2.0",
-            "The Apache Software License, Version 2.0",
+            "Apache Software License, Version 2.0",
             "Apache 2",
             "Apache License",
             "Apache License, Version 2.0"

--- a/spec/lib/license_finder/license_spec.rb
+++ b/spec/lib/license_finder/license_spec.rb
@@ -8,6 +8,11 @@ module LicenseFinder
         expect(license.name).to eq "MIT"
       end
 
+      it "should ignore certain prefixes of name" do
+        license = License.find_by_name("The MIT License")
+        expect(license.name).to eq "MIT"
+      end
+
       it "should make an unrecognized license" do
         license = License.find_by_name("not a known license")
         expect(license.name).to eq "not a known license"


### PR DESCRIPTION
*Story*: https://www.pivotaltracker.com/story/show/68675464

#### Summary
It seems that occasionally some tools return a license name beginning with the word "The". 
This PR simply strips the prefix before running the name through our system. 

Signed-off-by: Li Tai <ltai@pivotal.io>