### PR TITLE
Glide alternate

### DIFF
--- a/lib/license_finder/package_managers/glide.rb
+++ b/lib/license_finder/package_managers/glide.rb
@@ -1,7 +1,14 @@
 module LicenseFinder
   class Glide < PackageManager
     def package_path
+      return alternate_package_path if alternate_package_path
       project_path.join('src', 'glide.lock')
+    end
+
+    def alternate_package_path
+      path = project_path.join('glide.lock')
+      return nil unless File.exist? path
+      path
     end
 
     def current_packages

--- a/license_finder.gemspec
+++ b/license_finder.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "capybara", "~> 2.0.0"
   s.add_development_dependency "cocoapods", "0.34.0" if LicenseFinder::Platform.darwin?
-  s.add_development_dependency "fakefs", "~> 0.6.7"
+  s.add_development_dependency "fakefs", "~> 0.11.3"
   s.add_development_dependency "pry"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 3"

--- a/spec/lib/license_finder/package_managers/glide_spec.rb
+++ b/spec/lib/license_finder/package_managers/glide_spec.rb
@@ -4,13 +4,34 @@ require 'fakefs/spec_helpers'
 module LicenseFinder
   describe Glide do
     it_behaves_like "a PackageManager"
-    describe "#current_packages" do
-      subject {Glide.new(project_path: Pathname('/app'), logger: double(:logger, active: nil))}
 
-      it "returns the packages described by glide.lock" do
-        FakeFS do
+    subject {Glide.new(project_path: Pathname('/app'), logger: double(:logger, active: nil, installed: true))}
+
+    context "when lock file is contained in src folder" do
+      it "should return active" do
+        FakeFS.with_fresh do
           FileUtils.mkdir_p '/app/src'
-          File.write(subject.package_path.to_s,
+          File.write(Pathname('/app/src/glide.lock').to_s,'')
+          expect(subject.active?).to be_truthy
+        end
+      end
+    end
+
+    context "when lock file is contained in root folder" do
+      it "should return active" do
+        FakeFS.with_fresh do
+          FileUtils.mkdir_p '/app'
+          File.write(Pathname('/app/glide.lock').to_s,'')
+          expect(subject.active?).to be_truthy
+        end
+      end
+    end
+
+    describe "#current_packages" do
+      it "returns the packages described by glide.lock" do
+        FakeFS.with_fresh do
+          FileUtils.mkdir_p '/app/src'
+          File.write(Pathname('/app/src/glide.lock').to_s,
                      'imports:
 - name: some-package-name
   version: 123abc


### PR DESCRIPTION
# Alternate Set up for Glide
The current implementation of glide support in license finder expects to find glide.lock under a src folder. However it is common for repos to instead have glide.lock in the repo root (i.e. not under a src directory).
This PR updates LicenseFinder to support both usage patterns