### PR TITLE
Add support for prepare step

### DIFF
--- a/lib/license_finder/cli.rb
+++ b/lib/license_finder/cli.rb
@@ -4,10 +4,8 @@ module LicenseFinder
 end
 
 require 'license_finder/cli/patched_thor'
-
 require 'license_finder/cli/base'
 require 'license_finder/cli/makes_decisions'
-
 require 'license_finder/cli/whitelist'
 require 'license_finder/cli/blacklist'
 require 'license_finder/cli/dependencies'
@@ -16,5 +14,4 @@ require 'license_finder/cli/approvals'
 require 'license_finder/cli/ignored_groups'
 require 'license_finder/cli/ignored_dependencies'
 require 'license_finder/cli/project_name'
-
 require 'license_finder/cli/main'

--- a/lib/license_finder/cli/base.rb
+++ b/lib/license_finder/cli/base.rb
@@ -38,7 +38,8 @@ module LicenseFinder
           :rebar_deps_dir,
           :mix_command,
           :mix_deps_dir,
-          :save
+          :save,
+          :prepare
         ).merge(
           logger: logger_config
         )

--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -39,7 +39,7 @@ module LicenseFinder
         method_option :debug,
                       :aliases => '-d',
                       :type => :boolean,
-                      :desc => 'emit detailed info about what LicenseFinder is doing'
+                      :desc => 'Emit detailed info about what LicenseFinder is doing'
 
         method_option :prepare,
                       :aliases => '-p',

--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -50,12 +50,12 @@ module LicenseFinder
 
       end
 
-      desc "action_items", "List unapproved dependencies (the default action for `license_finder`)"
+      desc 'action_items', 'List unapproved dependencies (the default action for `license_finder`)'
       method_option :quiet, :aliases => '-q',:type => :boolean, :desc => 'Silences progress report', :required => false
       shared_options
       def action_items
 
-
+        run_prepare_phase if prepare?
         any_packages = license_finder.any_packages?
         unapproved = license_finder.unapproved
         blacklisted = license_finder.blacklisted
@@ -64,21 +64,21 @@ module LicenseFinder
         say "\n"
 
         unless any_packages
-          say "No dependencies recognized!", :red
+          say 'No dependencies recognized!', :red
           exit 0
         end
 
         if unapproved.empty?
-          say "All dependencies are approved for use", :green
+          say 'All dependencies are approved for use', :green
         else
           unless blacklisted.empty?
-            say "Blacklisted dependencies:", :red
+            say 'Blacklisted dependencies:', :red
             say report_of(blacklisted)
           end
 
           other_unapproved = unapproved - blacklisted
           unless other_unapproved.empty?
-            say "Dependencies that need approval:", :yellow
+            say 'Dependencies that need approval:', :yellow
             say report_of(other_unapproved)
           end
 
@@ -88,7 +88,7 @@ module LicenseFinder
 
       default_task :action_items
 
-      desc "report", "Print a report of the project's dependencies to stdout"
+      desc 'report', "Print a report of the project's dependencies to stdout"
       shared_options
       def report
         logger_config[:quiet] = true
@@ -105,13 +105,13 @@ module LicenseFinder
         save? ? save_report(report, options[:save]) : say(report)
       end
 
-      desc "version", "Print the version of LicenseFinder"
+      desc 'version', 'Print the version of LicenseFinder'
 
       def version
         puts LicenseFinder::VERSION
       end
 
-      desc "diff OLDFILE NEWFILE", "Command to view the differences between two generated reports (csv)."
+      desc 'diff OLDFILE NEWFILE', 'Command to view the differences between two generated reports (csv).'
 
       def diff(file1, file2)
         f1 = IO.read(file1)
@@ -120,14 +120,14 @@ module LicenseFinder
         save? ? save_report(report, options[:save]) : say(report)
       end
 
-      subcommand "dependencies", Dependencies, "Add or remove dependencies that your package managers are not aware of"
-      subcommand "licenses", Licenses, "Set a dependency's licenses, if the licenses found by license_finder are missing or wrong"
-      subcommand "approvals", Approvals, "Manually approve dependencies, even if their licenses are not whitelisted"
-      subcommand "ignored_groups", IgnoredGroups, "Exclude test and development dependencies from action items and reports"
-      subcommand "ignored_dependencies", IgnoredDependencies, "Exclude individual dependencies from action items and reports"
-      subcommand "whitelist", Whitelist, "Automatically approve any dependency that has a whitelisted license"
-      subcommand "blacklist", Blacklist, "Forbid approval of any dependency whose licenses are all blacklisted"
-      subcommand "project_name", ProjectName, "Set the project name, for display in reports"
+      subcommand 'dependencies', Dependencies, 'Add or remove dependencies that your package managers are not aware of'
+      subcommand 'licenses', Licenses, "Set a dependency's licenses, if the licenses found by license_finder are missing or wrong"
+      subcommand 'approvals', Approvals, 'Manually approve dependencies, even if their licenses are not whitelisted'
+      subcommand 'ignored_groups', IgnoredGroups, 'Exclude test and development dependencies from action items and reports'
+      subcommand 'ignored_dependencies', IgnoredDependencies, 'Exclude individual dependencies from action items and reports'
+      subcommand 'whitelist', Whitelist, 'Automatically approve any dependency that has a whitelisted license'
+      subcommand 'blacklist', Blacklist, 'Forbid approval of any dependency whose licenses are all blacklisted'
+      subcommand 'project_name', ProjectName, 'Set the project name, for display in reports'
 
       private
 

--- a/lib/license_finder/configuration.rb
+++ b/lib/license_finder/configuration.rb
@@ -72,6 +72,10 @@ module LicenseFinder
       Pathname(path_prefix).expand_path
     end
 
+    def prepare
+      get(:prepare)
+    end
+
     private
 
     attr_reader :saved_config

--- a/lib/license_finder/core.rb
+++ b/lib/license_finder/core.rb
@@ -48,8 +48,11 @@ module LicenseFinder
     end
 
     def prepare_projects
-      PackageManager.active_package_managers.each do |manager|
+      package_managers = PackageManager.active_package_managers options
+      package_managers.each do |manager|
+        logger.log self.class, 'Running prepare on projects'
         manager.prepare
+        logger.log self.class, 'Finished prepare on prorojects'
       end
     end
 
@@ -66,23 +69,26 @@ module LicenseFinder
 
     def current_packages
       # lazy, do not move to `initialize`
-      PackageManager.current_packages(
-        logger: logger,
-        project_path: config.project_path,
-        ignored_groups: decisions.ignored_groups,
-        go_full_version: config.go_full_version,
-        gradle_command: config.gradle_command,
-        gradle_include_groups: config.gradle_include_groups,
-        maven_include_groups: config.maven_include_groups,
-        maven_options: config.maven_options,
-        pip_requirements_path: config.pip_requirements_path,
-        rebar_command: config.rebar_command,
-        rebar_deps_dir: config.rebar_deps_dir,
-        mix_command: config.mix_command,
-        mix_deps_dir: config.mix_deps_dir,
-        prepare: config.prepare
-      )
+      PackageManager.current_packages options
     end
 
+    def options
+      {
+          logger: logger,
+          project_path: config.project_path,
+          ignored_groups: decisions.ignored_groups,
+          go_full_version: config.go_full_version,
+          gradle_command: config.gradle_command,
+          gradle_include_groups: config.gradle_include_groups,
+          maven_include_groups: config.maven_include_groups,
+          maven_options: config.maven_options,
+          pip_requirements_path: config.pip_requirements_path,
+          rebar_command: config.rebar_command,
+          rebar_deps_dir: config.rebar_deps_dir,
+          mix_command: config.mix_command,
+          mix_deps_dir: config.mix_deps_dir,
+          prepare: config.prepare
+      }
+    end
   end
 end

--- a/lib/license_finder/core.rb
+++ b/lib/license_finder/core.rb
@@ -50,9 +50,9 @@ module LicenseFinder
     def prepare_projects
       package_managers = PackageManager.active_package_managers options
       package_managers.each do |manager|
-        logger.log self.class, 'Running prepare on projects'
+        logger.log self.class, 'Running prepare on project'
         manager.prepare
-        logger.log self.class, 'Finished prepare on projects'
+        logger.log self.class, Logger.green('Finished prepare on project')
       end
     end
 

--- a/lib/license_finder/core.rb
+++ b/lib/license_finder/core.rb
@@ -52,7 +52,7 @@ module LicenseFinder
       package_managers.each do |manager|
         logger.log self.class, 'Running prepare on projects'
         manager.prepare
-        logger.log self.class, 'Finished prepare on prorojects'
+        logger.log self.class, 'Finished prepare on projects'
       end
     end
 
@@ -69,7 +69,7 @@ module LicenseFinder
 
     def current_packages
       # lazy, do not move to `initialize`
-      PackageManager.current_packages options
+      PackageManager.active_packages options
     end
 
     def options

--- a/lib/license_finder/core.rb
+++ b/lib/license_finder/core.rb
@@ -47,6 +47,12 @@ module LicenseFinder
       @decisions ||= Decisions.fetch_saved(config.decisions_file_path)
     end
 
+    def prepare_projects
+      PackageManager.active_package_managers.each do |manager|
+        manager.prepare
+      end
+    end
+
     private
 
     attr_reader :logger
@@ -74,7 +80,9 @@ module LicenseFinder
         rebar_deps_dir: config.rebar_deps_dir,
         mix_command: config.mix_command,
         mix_deps_dir: config.mix_deps_dir,
+        prepare: config.prepare
       )
     end
+
   end
 end

--- a/lib/license_finder/license_aggregator.rb
+++ b/lib/license_finder/license_aggregator.rb
@@ -18,6 +18,7 @@ module LicenseFinder
     def aggregate_packages
       @subprojects.flat_map do |project_path|
         finder = LicenseFinder::Core.new(@license_finder_config.merge(project_path: project_path))
+        finder.prepare_projects if @license_finder_config[:prepare]
         finder.acknowledged.map { |dep| MergedPackage.new(dep, [project_path]) }
       end
     end

--- a/lib/license_finder/logger.rb
+++ b/lib/license_finder/logger.rb
@@ -22,6 +22,16 @@ module LicenseFinder
         end
       end
 
+      def prepare package_manager, can_prepare
+        if String === can_prepare
+          log package_manager, can_prepare
+        elsif can_prepare
+          log package_manager, Logger.green('preparing')
+        else
+          log package_manager, Logger.red('no prepare step provided')
+        end
+      end
+
       def active package_manager, is_active
         if is_active
           log package_manager, Logger.green("is active")

--- a/lib/license_finder/package_manager.rb
+++ b/lib/license_finder/package_manager.rb
@@ -14,7 +14,6 @@ module LicenseFinder
   #
   class PackageManager
     class << self
-      attr_accessor :active_managers
       def package_managers
         [GoDep, GoWorkspace, Go15VendorExperiment, Glide, Gvt, Govendor, Dep, Bundler, NPM, Pip,
          Yarn, Bower, Maven, Gradle, CocoaPods, Rebar, Nuget, Carthage, Mix, Conan]
@@ -25,11 +24,9 @@ module LicenseFinder
       end
 
       def active_package_managers(options={:project_path => Pathname.new('')})
-
-        return @active_managers unless @active_managers.nil?
         active_pm_classes = package_managers.select { |pm_class| pm_class.new(options).active? }
         active_pm_classes -= active_pm_classes.map(&:takes_priority_over)
-        @active_managers = active_pm_classes.map { |pm_class| pm_class.new(options) }
+        active_pm_classes.map { |pm_class| pm_class.new(options) }
       end
 
       def takes_priority_over

--- a/lib/license_finder/package_manager.rb
+++ b/lib/license_finder/package_manager.rb
@@ -13,43 +13,47 @@ module LicenseFinder
   # - implement(Optional) #prepare, this is the method that gets run when the --prepare flag is passed to license_finder. This should call the relevant package manager setup methods to setup the project.
   #
   class PackageManager
-    def self.package_managers
-      [GoDep, GoWorkspace, Go15VendorExperiment, Glide, Gvt, Govendor, Dep, Bundler, NPM, Pip,
-       Yarn, Bower, Maven, Gradle, CocoaPods, Rebar, Nuget, Carthage, Mix, Conan]
-    end
-
-    def self.current_packages(options)
-      active_package_managers(options).flat_map(&:current_packages_with_relations)
-    end
-
-    def self.active_package_managers(options={:project_path => Pathname.new('')})
-      active_pm_classes = package_managers.select { |pm_class| pm_class.new(options).active? }
-      active_pm_classes -= active_pm_classes.map(&:takes_priority_over)
-      active_pm_classes.map { |pm_class| pm_class.new(options) }
-    end
-
-
-    def self.takes_priority_over
-      nil
-    end
-
-    def self.installed?(logger=Core.default_logger)
-      if package_management_command.nil?
-        logger.installed self, "no command defined" # TODO comment me out
-        return true
+    class << self
+      attr_accessor :active_managers
+      def package_managers
+        [GoDep, GoWorkspace, Go15VendorExperiment, Glide, Gvt, Govendor, Dep, Bundler, NPM, Pip,
+         Yarn, Bower, Maven, Gradle, CocoaPods, Rebar, Nuget, Carthage, Mix, Conan]
       end
 
-      if command_exists?(package_management_command)
-        logger.installed self, true
-        return true
+      def current_packages(options)
+        active_package_managers(options).flat_map(&:current_packages_with_relations)
       end
 
-      logger.installed self, false
-      return false
-    end
+      def active_package_managers(options={:project_path => Pathname.new('')})
 
-    def self.package_management_command
-      nil
+        return @active_managers unless @active_managers.nil?
+        active_pm_classes = package_managers.select { |pm_class| pm_class.new(options).active? }
+        active_pm_classes -= active_pm_classes.map(&:takes_priority_over)
+        @active_managers = active_pm_classes.map { |pm_class| pm_class.new(options) }
+      end
+
+      def takes_priority_over
+        nil
+      end
+
+      def installed?(logger=Core.default_logger)
+        if package_management_command.nil?
+          logger.installed self, "no command defined" # TODO comment me out
+          return true
+        end
+
+        if command_exists?(package_management_command)
+          logger.installed self, true
+          return true
+        end
+
+        logger.installed self, false
+        return false
+      end
+
+      def package_management_command
+        nil
+      end
     end
 
     def initialize options={}
@@ -71,6 +75,8 @@ module LicenseFinder
     end
 
     def prepare
+      # warn the user that there is no prepare
+      logger.prepare self.class, false
     end
 
     def capture(command)

--- a/lib/license_finder/package_manager.rb
+++ b/lib/license_finder/package_manager.rb
@@ -19,7 +19,7 @@ module LicenseFinder
          Yarn, Bower, Maven, Gradle, CocoaPods, Rebar, Nuget, Carthage, Mix, Conan]
       end
 
-      def current_packages(options)
+      def active_packages(options)
         active_package_managers(options).flat_map(&:current_packages_with_relations)
       end
 
@@ -81,7 +81,7 @@ module LicenseFinder
     end
 
     def current_packages_with_relations
-      packages = current_packages
+      packages = self.current_packages
       packages.each do |parent|
         parent.children.each do |child_name|
           child = packages.detect { |child| child.name == child_name }

--- a/lib/license_finder/package_manager.rb
+++ b/lib/license_finder/package_manager.rb
@@ -10,6 +10,7 @@ module LicenseFinder
   #
   # - implement #current_packages, to return a list of `Package`s this package manager is tracking
   # - implement #possible_package_paths, an array of `Pathname`s which are the possible locations which contain a configuration file/folder indicating the package manager is in use.
+  # - implement(Optional) #prepare, this is the method that gets run when the --prepare flag is passed to license_finder. This should call the relevant package manager setup methods to setup the project.
   #
   class PackageManager
     def self.package_managers
@@ -26,6 +27,7 @@ module LicenseFinder
       active_pm_classes -= active_pm_classes.map(&:takes_priority_over)
       active_pm_classes.map { |pm_class| pm_class.new(options) }
     end
+
 
     def self.takes_priority_over
       nil
@@ -66,6 +68,9 @@ module LicenseFinder
       possible_package_paths.find { |path|
         path.exist?
       }
+    end
+
+    def prepare
     end
 
     def capture(command)

--- a/lib/license_finder/package_manager.rb
+++ b/lib/license_finder/package_manager.rb
@@ -10,8 +10,9 @@ module LicenseFinder
   #
   # - implement #current_packages, to return a list of `Package`s this package manager is tracking
   # - implement #possible_package_paths, an array of `Pathname`s which are the possible locations which contain a configuration file/folder indicating the package manager is in use.
-  # - implement(Optional) #prepare_command, this is the package manager command that gets run when the --prepare flag is passed to license_finder.
-  #
+  # - implement(Optional) #package_management_command, string for invoking the package manager
+  # - implement(Optional) #prepare_command, string for fetching dependencies for package manager (runs when the --prepare flag is passed to license_finder)
+
   class PackageManager
     class << self
       def package_managers
@@ -48,10 +49,12 @@ module LicenseFinder
         return false
       end
 
+      # see class description
       def package_management_command
         nil
       end
 
+      # see class description
       def prepare_command
         nil
       end

--- a/lib/license_finder/package_manager.rb
+++ b/lib/license_finder/package_manager.rb
@@ -10,7 +10,7 @@ module LicenseFinder
   #
   # - implement #current_packages, to return a list of `Package`s this package manager is tracking
   # - implement #possible_package_paths, an array of `Pathname`s which are the possible locations which contain a configuration file/folder indicating the package manager is in use.
-  # - implement(Optional) #prepare, this is the method that gets run when the --prepare flag is passed to license_finder. This should call the relevant package manager setup methods to setup the project.
+  # - implement(Optional) #prepare_command, this is the package manager command that gets run when the --prepare flag is passed to license_finder.
   #
   class PackageManager
     class << self
@@ -51,6 +51,10 @@ module LicenseFinder
       def package_management_command
         nil
       end
+
+      def prepare_command
+        nil
+      end
     end
 
     def initialize options={}
@@ -72,8 +76,12 @@ module LicenseFinder
     end
 
     def prepare
-      # warn the user that there is no prepare
-      logger.prepare self.class, false
+      if self.class.prepare_command
+        _, success = capture(self.class.prepare_command)
+        raise "Prepare command '#{self.class.prepare_command}' failed" unless success
+      end
+
+      logger.prepare self.class, self.class.prepare_command
     end
 
     def capture(command)

--- a/lib/license_finder/package_managers/gvt.rb
+++ b/lib/license_finder/package_managers/gvt.rb
@@ -10,6 +10,10 @@ module LicenseFinder
       'gvt'
     end
 
+    def self.prepare_command
+      'gvt restore'
+    end
+
     def current_packages
       split_project_path = project_path.to_s.split('/')
       project_root_depth = split_project_path.length - 1
@@ -42,15 +46,6 @@ module LicenseFinder
                                       'Homepage' => repo
                                   }, nil, true)
       end
-    end
-
-    def prepare
-      shell_command = 'gvt restore'
-      _, success = capture(shell_command)
-      #TODO should crash out if not successs
-      #TODO output logs if logging is verbose
-      raise RuntimeError.new('GVT prepare step failed') unless success
-      #TODO if !success, raise should also specify failure cause.
     end
 
     def self.takes_priority_over

--- a/lib/license_finder/package_managers/gvt.rb
+++ b/lib/license_finder/package_managers/gvt.rb
@@ -46,7 +46,11 @@ module LicenseFinder
 
     def prepare
       shell_command = 'gvt restore'
-      output, success = capture(shell_command)
+      _, success = capture(shell_command)
+      #TODO should crash out if not successs
+      #TODO output logs if logging is verbose
+      raise RuntimeError.new('GVT prepare step failed') unless success
+      #TODO if !success, raise should also specify failure cause.
     end
 
     def self.takes_priority_over

--- a/lib/license_finder/package_managers/gvt.rb
+++ b/lib/license_finder/package_managers/gvt.rb
@@ -44,6 +44,11 @@ module LicenseFinder
       end
     end
 
+    def prepare
+      shell_command = 'gvt restore'
+      output, success = capture(shell_command)
+    end
+
     def self.takes_priority_over
       Go15VendorExperiment
     end

--- a/spec/lib/license_finder/cli/main_spec.rb
+++ b/spec/lib/license_finder/cli/main_spec.rb
@@ -13,7 +13,7 @@ module LicenseFinder
       end
       let(:configuration) { double(:configuration, valid_project_path?: true) }
       let(:found_any_packages) { true }
-      let(:license_finder_instance) { double(:license_finder, unapproved: unapproved_dependencies, blacklisted: [], project_name: 'taco stand', config: configuration, any_packages?: found_any_packages) }
+      let(:license_finder_instance) { double(:license_finder, unapproved: unapproved_dependencies, blacklisted: [], project_name: 'taco stand', config: configuration, any_packages?: found_any_packages, prepare_projects: nil) }
       let(:license) { double(:license, name: "thing") }
       let(:unapproved_dependencies) { [double(:dependency, name: "a dependency", version: "2.4.1", missing?: false, licenses: [license])] }
 
@@ -80,6 +80,7 @@ module LicenseFinder
 
       describe "#report" do
         let(:packages) { [Package.new('one dependency', "1.1")] }
+
 
         def report
           capture_stdout { subject.report }
@@ -180,6 +181,29 @@ module LicenseFinder
             expect(subject).to receive(:report_of)
 
             report
+          end
+        end
+
+        describe 'Prepare Option' do
+
+          let(:license_finder) { double(:license_finder, unapproved: unapproved_dependencies, blacklisted: [], project_name: 'taco stand', config: configuration, any_packages?: found_any_packages, prepare_projects: nil, acknowledged: []) }
+          before do
+            allow(LicenseFinder::Core).to receive(:new).and_return(license_finder)
+          end
+          context 'when the --prepare option is passed' do
+            it 'runs the prepare phase for package managers' do
+              subject.options = {prepare: true, format: 'text'}
+              expect(license_finder).to receive(:prepare_projects)
+              subject.report
+            end
+          end
+
+          context 'when the --prepare option is NOT passed' do
+            it 'runs the prepare phase for package managers' do
+              subject.options = {prepare: false, format: 'text'}
+              expect(license_finder).not_to receive(:prepare_projects)
+              subject.report
+            end
           end
         end
       end

--- a/spec/lib/license_finder/cli/main_spec.rb
+++ b/spec/lib/license_finder/cli/main_spec.rb
@@ -41,7 +41,8 @@ module LicenseFinder
           "--rebar_deps_dir=rebar_dir",
           "--mix_command=surprise_me",
           "--mix_deps_dir=mix_dir",
-          "--save"
+          "--save",
+          "--prepare"
         ] }
         let(:logger_options) {
           [
@@ -58,6 +59,7 @@ module LicenseFinder
           mix_command: 'surprise_me',
           mix_deps_dir: 'mix_dir',
           save: 'license_report',
+          prepare: true ,
           logger: {}
         } }
 
@@ -69,7 +71,7 @@ module LicenseFinder
         end
 
         it "passes the logger options to the new LicenseFinder::Core instance" do
-          expect(LicenseFinder::Core).to receive(:new).with({logger: {debug: true, quiet: true}}).and_return(license_finder_instance)
+          expect(LicenseFinder::Core).to receive(:new).with({prepare: false, logger: {debug: true, quiet: true}}).and_return(license_finder_instance)
           silence_stdout do
             expect { described_class.start(logger_options) }.to raise_error(SystemExit)
           end

--- a/spec/lib/license_finder/core_spec.rb
+++ b/spec/lib/license_finder/core_spec.rb
@@ -21,7 +21,8 @@ module LicenseFinder
           rebar_command: 'do_it',
           rebar_deps_dir: 'nowhere/deps',
           mix_command: 'mix_it',
-          mix_deps_dir: 'mixes_in_here/deps'
+          mix_deps_dir: 'mixes_in_here/deps',
+          prepare: 'prepare'
         }
       }
       let(:package_options) {
@@ -38,7 +39,8 @@ module LicenseFinder
           rebar_command: configuration.rebar_command,
           rebar_deps_dir: configuration.rebar_deps_dir,
           mix_command: configuration.mix_command,
-          mix_deps_dir: configuration.mix_deps_dir
+          mix_deps_dir: configuration.mix_deps_dir,
+          prepare: configuration.prepare
         }
       }
 

--- a/spec/lib/license_finder/core_spec.rb
+++ b/spec/lib/license_finder/core_spec.rb
@@ -12,7 +12,7 @@ module LicenseFinder
       allow(Logger).to receive(:new).and_return(logger)
     end
 
-    describe "#unapproved" do
+    describe '#unapproved' do
       let(:options) {
         {
           logger: {},
@@ -44,15 +44,15 @@ module LicenseFinder
         }
       }
 
-      it "delegates to the decision_applier" do
+      it 'delegates to the decision_applier' do
         decision_applier =  double(:decision_applier)
         allow(license_finder).to receive(:decision_applier).and_return(decision_applier)
         expect(decision_applier).to receive(:unapproved)
         license_finder.unapproved
       end
 
-      it "passes through options when fetching current packages" do
-        expect(PackageManager).to receive(:current_packages).with(package_options).and_return([])
+      it 'passes through options when fetching current packages' do
+        expect(PackageManager).to receive(:active_packages).with(package_options).and_return([])
         license_finder.unapproved
       end
     end

--- a/spec/lib/license_finder/license_aggregator_spec.rb
+++ b/spec/lib/license_finder/license_aggregator_spec.rb
@@ -19,6 +19,17 @@ module LicenseFinder
         expect(results.map(&:name)).to match_array ['hammer', 'helmet']
       end
 
+      context 'when prepare flag is included' do
+        it 'should run the prepare_projects method on the finders' do
+
+          expect(license_finder_1).to receive(:prepare_projects)
+          expect(license_finder_2).to receive(:prepare_projects)
+
+          aggregator = LicenseAggregator.new({prepare: true}, ['path/to/subproject-1', 'path/to/subproject-2'])
+          results = aggregator.dependencies
+        end
+      end
+
       context 'when there are duplicates' do
         let(:license_finder_2) { double(:license_finder, acknowledged: [helmet, hammer])}
 

--- a/spec/lib/license_finder/package_manager_spec.rb
+++ b/spec/lib/license_finder/package_manager_spec.rb
@@ -61,14 +61,6 @@ module LicenseFinder
 
     describe ".active_package_managers" do
 
-      before do
-        LicenseFinder::PackageManager.active_managers = nil
-      end
-
-      after do
-        LicenseFinder::PackageManager.active_managers = nil
-      end
-
       it "should return active package managers" do
         bundler = double(:bundler, :active? => true)
         allow(Bundler).to receive(:new).and_return bundler

--- a/spec/lib/license_finder/package_manager_spec.rb
+++ b/spec/lib/license_finder/package_manager_spec.rb
@@ -78,5 +78,36 @@ module LicenseFinder
         expect(LicenseFinder::PackageManager.active_package_managers).not_to include govendor
       end
     end
+
+    describe '#prepare' do
+      context 'when there is a prepare_command' do
+        before do
+          allow(described_class).to receive(:prepare_command).and_return('sh commands')
+        end
+
+        it 'succeeds when prepare command runs successfully' do
+          expect(subject).to receive(:capture).with('sh commands').and_return(['output', true])
+
+          expect { subject.prepare }.to_not raise_error
+        end
+
+        it 'raises exception when prepare command runs into failure' do
+          expect(subject).to receive(:capture).with('sh commands').and_return(['output', false])
+
+          expect { subject.prepare }.to raise_error("Prepare command 'sh commands' failed")
+        end
+      end
+
+      context 'when there is no prepare_command' do
+        it 'issues a warning' do
+          logger = double(:logger)
+          expect(logger).to receive(:prepare).with(described_class, nil)
+          expect(subject).to_not receive(:capture).with('sh commands')
+
+          subject = described_class.new logger: logger
+          subject.prepare
+        end
+      end
+    end
   end
 end

--- a/spec/lib/license_finder/package_manager_spec.rb
+++ b/spec/lib/license_finder/package_manager_spec.rb
@@ -60,6 +60,15 @@ module LicenseFinder
     end
 
     describe ".active_package_managers" do
+
+      before do
+        LicenseFinder::PackageManager.active_managers = nil
+      end
+
+      after do
+        LicenseFinder::PackageManager.active_managers = nil
+      end
+
       it "should return active package managers" do
         bundler = double(:bundler, :active? => true)
         allow(Bundler).to receive(:new).and_return bundler


### PR DESCRIPTION
# Prepare
### Technical notes
- Initial work for `--prepare` step
- `action_items` and `report` tasks now support a `--prepare` switch
- Passing in the `--prepare` switch will result in `prepare` method being called on each package manager which is active in the current project path. 
- Currently none of the package managers fully implement the prepare step. (experimental GVT support is currently included though) 
