### PR TITLE
package_manager: Do not swallow stderr anymore

### DIFF
--- a/lib/license_finder/package_manager.rb
+++ b/lib/license_finder/package_manager.rb
@@ -103,11 +103,12 @@ module LicenseFinder
     end
 
     def self.command_exists?(command)
-      if LicenseFinder::Platform.windows?
-        _stdout, _stderr, status = Cmd.run("where #{command} 2>NUL")
-      else
-        _stdout, _stderr, status = Cmd.run("which #{command} 2>/dev/null")
-      end
+      _stdout, _stderr, status =
+        if LicenseFinder::Platform.windows?
+          Cmd.run("where #{command}")
+        else
+          Cmd.run("which #{command}")
+        end
 
       status.success?
     end


### PR DESCRIPTION
stderr now gets redirected to a separate variable and should not be
swallowed by the shell anymore.