### PR TITLE
Update contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,31 +10,17 @@
 
 ## Running Tests
 
-You can use the [LicenseFinder docker image](https://hub.docker.com/r/licensefinder/license_finder/) to run the tests.
+You can use the [LicenseFinder docker image](https://hub.docker.com/r/licensefinder/license_finder/) to run the tests by using the `dlf` script.
+There are 2 sets of tests to run in order to confirm that License Finder is working as intended:
 
 ```
-$ docker run -it licensefinder/license_finder /bin/bash --login
-
-# inside the container...
-
-$ cd /LicenseFinder
-$ rake
+./dlf rake spec
+./dlf rake features
 ```
 
-There are 2 sets of tests to run in order to confirm that License Finder is working as intended.
-
-```
-rake spec
-rake features
-```
 The `spec` task runs all the unit test and the `features` task will run all the feature test.
 Note that the feature test will use the installed gem, therefore if you are running the feature test in the docker using
 the `dlf` script, you must rebuild the docker image or ensure that the gem is updated with your changes. 
-
-```
-dlf rake spec
-dlf rake features
-```
 
 ## Useful Tips
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,12 +15,12 @@ There are 2 sets of tests to run in order to confirm that License Finder is work
 
 ```
 ./dlf rake spec
-./dlf rake features
+./dlf bundle exec rake features
 ```
 
 The `spec` task runs all the unit test and the `features` task will run all the feature test.
-Note that the feature test will use the installed gem, therefore if you are running the feature test in the docker using
-the `dlf` script, you must rebuild the docker image or ensure that the gem is updated with your changes. 
+Note that the feature test needs to be wrapped in `bundle exec`, or else it
+will use the gem version installed inside the docker image.
 
 ## Useful Tips
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ To launch the docker image and interact with it via bash:
 docker run -v $PWD:/scan -it licensefinder/license_finder /bin/bash -l
 
 ```
-`-v $PWD:/scan` will mount the current working directory to the /scan path
+`-v $PWD:/scan` will mount the current working directory to the /scan path.
 
 ## Adding Package Managers
 


### PR DESCRIPTION
The updates to the documentation in 3fda4a1b40037ecb0b716a94509265922d87c2f1 due to my issue #415 helped me find the `dlf` script. However, I think the first instructions about running a shell inside docker are still a little distracting.

This PR improves the guidelines by:
* Immediately pointing at the `dlf` script as the way to run the tests inside a docker image.
* Adding `bundle exec` so the feature tests use the checked out version of the gem.