### PR TITLE
Refactor cli layer

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -36,7 +36,7 @@ task :check_dependencies do
   require './lib/license_finder'
   satisfied = true
   LicenseFinder::PackageManager.package_managers.each do |package_manager|
-    satisfied = false unless package_manager.installed?(LicenseFinder::Logger.new(mode: LicenseFinder::Logger::MODE_INFO))
+    satisfied = false unless package_manager.installed?(LicenseFinder::Logger.new(LicenseFinder::Logger::MODE_INFO))
   end
   STDOUT.flush
   exit 1 unless satisfied

--- a/lib/license_finder/cli/base.rb
+++ b/lib/license_finder/cli/base.rb
@@ -41,21 +41,21 @@ module LicenseFinder
           :save,
           :prepare
         ).merge(
-          logger: logger_config
+          logger: logger_mode
         )
       end
 
-      def logger_config
+      def logger_mode
         quiet = LicenseFinder::Logger::MODE_QUIET
         debug = LicenseFinder::Logger::MODE_DEBUG
         info = LicenseFinder::Logger::MODE_INFO
         mode = extract_options(quiet, debug)
         if mode[quiet]
-          { mode: quiet }
+          quiet
         elsif mode[debug]
-          { mode: debug }
+          debug
         else
-          { mode: info }
+          info
         end
       end
 

--- a/lib/license_finder/cli/base.rb
+++ b/lib/license_finder/cli/base.rb
@@ -41,7 +41,9 @@ module LicenseFinder
           :save,
           :prepare,
           :format,
-          :columns
+          :columns,
+          :aggregate_paths,
+          :recursive
         ).merge(
           logger: logger_mode
         )

--- a/lib/license_finder/cli/base.rb
+++ b/lib/license_finder/cli/base.rb
@@ -10,7 +10,7 @@ module LicenseFinder
 
       no_commands do
         def decisions
-          license_finder.decisions
+          @decisions ||= DecisionsFactory.decisions(Configuration.with_optional_saved_config(license_finder_config).decisions_file_path)
         end
       end
 

--- a/lib/license_finder/cli/base.rb
+++ b/lib/license_finder/cli/base.rb
@@ -10,17 +10,15 @@ module LicenseFinder
 
       no_commands do
         def decisions
-          @decisions ||= DecisionsFactory.decisions(Configuration.with_optional_saved_config(license_finder_config).decisions_file_path)
+          @decisions ||= DecisionsFactory.decisions(config.decisions_file_path)
+        end
+
+        def config
+          @config ||= Configuration.with_optional_saved_config(license_finder_config)
         end
       end
 
       private
-
-      def license_finder
-        @lf ||= LicenseFinder::Core.new(license_finder_config)
-        fail "Project path '#{@lf.config.project_path}' does not exist!" unless @lf.config.valid_project_path?
-        @lf
-      end
 
       def fail(message)
         say(message) && exit(1)

--- a/lib/license_finder/cli/base.rb
+++ b/lib/license_finder/cli/base.rb
@@ -39,7 +39,9 @@ module LicenseFinder
           :mix_command,
           :mix_deps_dir,
           :save,
-          :prepare
+          :prepare,
+          :format,
+          :columns
         ).merge(
           logger: logger_mode
         )

--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -153,9 +153,9 @@ module LicenseFinder
 
       def aggregate_paths
         check_valid_project_path
-        aggregate_paths = license_finder_config[:aggregate_paths]
+        aggregate_paths = config.aggregate_paths
         project_path = config.project_path || Pathname.pwd
-        aggregate_paths = ProjectFinder.new(project_path).find_projects if license_finder_config[:recursive]
+        aggregate_paths = ProjectFinder.new(project_path).find_projects if config.recursive
         return aggregate_paths unless aggregate_paths.nil? || aggregate_paths.empty?
         [config.project_path] unless config.project_path.nil?
       end
@@ -167,9 +167,9 @@ module LicenseFinder
       end
 
       def report_of(content)
-        report = FORMATS[license_finder_config[:format]] || FORMATS['text']
-        if report == CsvReport && license_finder_config[:aggregate_paths] then report = MergedReport end
-        report.of(content, columns: license_finder_config[:columns], project_name: decisions.project_name || config.project_path.basename.to_s)
+        report = FORMATS[config.format] || FORMATS['text']
+        report = MergedReport if report == CsvReport && config.aggregate_paths
+        report.of(content, columns: config.columns, project_name: decisions.project_name || config.project_path.basename.to_s)
       end
 
       def save?

--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -77,7 +77,7 @@ module LicenseFinder
       shared_options
       format_option
       def action_items
-        finder = LicenseAggregator.new(license_finder_config, aggregate_paths)
+        finder = LicenseAggregator.new(config, aggregate_paths)
         any_packages = finder.any_packages?
         unapproved = finder.unapproved
         blacklisted = finder.blacklisted
@@ -116,9 +116,7 @@ module LicenseFinder
       method_option :save, desc: "Save report to a file. Default: 'license_report.csv' in project root.", lazy_default: 'license_report'
 
       def report
-        logger_config[:mode] = Logger::MODE_QUIET
-
-        finder = LicenseAggregator.new(license_finder_config, aggregate_paths)
+        finder = LicenseAggregator.new(config, aggregate_paths)
         report = report_of(finder.dependencies)
         save? ? save_report(report, options[:save]) : say(report)
       end

--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -118,7 +118,7 @@ module LicenseFinder
       def report
         finder = LicenseAggregator.new(config, aggregate_paths)
         report = report_of(finder.dependencies)
-        save? ? save_report(report, options[:save]) : say(report)
+        save? ? save_report(report, config.save_file) : say(report)
       end
 
       desc 'version', 'Print the version of LicenseFinder'
@@ -133,7 +133,7 @@ module LicenseFinder
         f1 = IO.read(file1)
         f2 = IO.read(file2)
         report = DiffReport.new(Diff.compare(f1, f2))
-        save? ? save_report(report, options[:save]) : say(report)
+        save? ? save_report(report, config.save_file) : say(report)
       end
 
       subcommand 'dependencies', Dependencies, 'Add or remove dependencies that your package managers are not aware of'
@@ -167,17 +167,13 @@ module LicenseFinder
       end
 
       def report_of(content)
-        report = FORMATS[options[:format]] || FORMATS['text']
+        report = FORMATS[license_finder_config[:format]] || FORMATS['text']
         if report == CsvReport && options[:aggregate_paths] then report = MergedReport end
-        report.of(content, columns: options[:columns], project_name: decisions.project_name || config.project_path.basename.to_s)
+        report.of(content, columns: license_finder_config[:columns], project_name: decisions.project_name || config.project_path.basename.to_s)
       end
 
       def save?
-        !!options[:save]
-      end
-
-      def prepare?
-        options[:prepare]
+        !!config.save_file
       end
     end
   end

--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -150,7 +150,12 @@ module LicenseFinder
 
       private
 
+      def check_valid_project_path
+        raise "Project path '#{config.project_path}' does not exist!" unless config.valid_project_path?
+      end
+
       def aggregate_paths
+        check_valid_project_path
         aggregate_paths = options[:aggregate_paths]
         project_path = license_finder_config[:project_path] || Pathname.pwd
         aggregate_paths = ProjectFinder.new(project_path).find_projects if options[:recursive]
@@ -167,7 +172,7 @@ module LicenseFinder
       def report_of(content)
         report = FORMATS[options[:format]] || FORMATS['text']
         if report == CsvReport && options[:aggregate_paths] then report = MergedReport end
-        report.of(content, columns: options[:columns], project_name: license_finder.project_name)
+        report.of(content, columns: options[:columns], project_name: decisions.project_name || config.project_path.basename.to_s)
       end
 
       def save?

--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -153,9 +153,9 @@ module LicenseFinder
 
       def aggregate_paths
         check_valid_project_path
-        aggregate_paths = options[:aggregate_paths]
+        aggregate_paths = license_finder_config[:aggregate_paths]
         project_path = config.project_path || Pathname.pwd
-        aggregate_paths = ProjectFinder.new(project_path).find_projects if options[:recursive]
+        aggregate_paths = ProjectFinder.new(project_path).find_projects if license_finder_config[:recursive]
         return aggregate_paths unless aggregate_paths.nil? || aggregate_paths.empty?
         [config.project_path] unless config.project_path.nil?
       end
@@ -168,7 +168,7 @@ module LicenseFinder
 
       def report_of(content)
         report = FORMATS[license_finder_config[:format]] || FORMATS['text']
-        if report == CsvReport && options[:aggregate_paths] then report = MergedReport end
+        if report == CsvReport && license_finder_config[:aggregate_paths] then report = MergedReport end
         report.of(content, columns: license_finder_config[:columns], project_name: decisions.project_name || config.project_path.basename.to_s)
       end
 

--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -5,7 +5,6 @@ require 'license_finder/package_delta'
 require 'license_finder/license_aggregator'
 require 'license_finder/project_finder'
 require 'license_finder/logger'
-
 module LicenseFinder
   module CLI
     class Main < Base
@@ -157,10 +156,10 @@ module LicenseFinder
       def aggregate_paths
         check_valid_project_path
         aggregate_paths = options[:aggregate_paths]
-        project_path = license_finder_config[:project_path] || Pathname.pwd
+        project_path = config.project_path || Pathname.pwd
         aggregate_paths = ProjectFinder.new(project_path).find_projects if options[:recursive]
         return aggregate_paths unless aggregate_paths.nil? || aggregate_paths.empty?
-        [license_finder_config[:project_path]] unless license_finder_config[:project_path].nil?
+        [config.project_path] unless config.project_path.nil?
       end
 
       def save_report(content, file_name)
@@ -181,10 +180,6 @@ module LicenseFinder
 
       def prepare?
         options[:prepare]
-      end
-
-      def run_prepare_phase
-        license_finder_config[:prepare_projects]
       end
     end
   end

--- a/lib/license_finder/cli/makes_decisions.rb
+++ b/lib/license_finder/cli/makes_decisions.rb
@@ -24,8 +24,9 @@ module LicenseFinder
         }
       end
 
-      def modifying(&block)
-        license_finder.modifying(&block)
+      def modifying
+        yield
+        decisions.save!(config.decisions_file_path)
       end
     end
   end

--- a/lib/license_finder/configuration.rb
+++ b/lib/license_finder/configuration.rb
@@ -86,6 +86,14 @@ module LicenseFinder
       get(:save)
     end
 
+    def aggregate_paths
+      get(:aggregate_paths)
+    end
+
+    def recursive
+      get(:recursive)
+    end
+
     protected
 
     attr_accessor :primary_config

--- a/lib/license_finder/configuration.rb
+++ b/lib/license_finder/configuration.rb
@@ -19,6 +19,10 @@ module LicenseFinder
       true
     end
 
+    def logger_mode
+      get(:logger)
+    end
+
     def gradle_command
       get(:gradle_command)
     end
@@ -51,6 +55,10 @@ module LicenseFinder
       get(:mix_command) || 'mix'
     end
 
+    def merge(other_hash)
+      dup_with other_hash
+    end
+
     def rebar_deps_dir
       path = get(:rebar_deps_dir) || 'deps'
       project_path.join(path).expand_path
@@ -74,12 +82,26 @@ module LicenseFinder
       get(:prepare)
     end
 
+    protected
+
+    attr_accessor :primary_config
+    def dup_with(other_hash)
+      dup.tap do |dup|
+        dup.primary_config.merge!(other_hash)
+      end
+    end
+
     private
 
     attr_reader :saved_config
 
     def get(key)
       @primary_config[key.to_sym] || @saved_config[key.to_s]
+    end
+
+    def initialize_copy(orig)
+      super
+      @primary_config = @primary_config.dup
     end
 
     def path_prefix

--- a/lib/license_finder/configuration.rb
+++ b/lib/license_finder/configuration.rb
@@ -94,6 +94,14 @@ module LicenseFinder
       get(:recursive)
     end
 
+    def format
+      get(:format)
+    end
+
+    def columns
+      get(:columns)
+    end
+
     protected
 
     attr_accessor :primary_config

--- a/lib/license_finder/configuration.rb
+++ b/lib/license_finder/configuration.rb
@@ -82,6 +82,10 @@ module LicenseFinder
       get(:prepare)
     end
 
+    def save_file
+      get(:save)
+    end
+
     protected
 
     attr_accessor :primary_config

--- a/lib/license_finder/core.rb
+++ b/lib/license_finder/core.rb
@@ -27,9 +27,9 @@ module LicenseFinder
     #   rebar_command: "rebar",
     #   rebar_deps_dir: "deps",
     # }
-    def initialize(options = {})
-      @logger = Logger.new(options.fetch(:logger, {}))
-      @config = Configuration.with_optional_saved_config(options)
+    def initialize(configuration)
+      @logger = Logger.new(configuration.logger_mode)
+      @config = configuration
     end
 
     def modifying

--- a/lib/license_finder/core.rb
+++ b/lib/license_finder/core.rb
@@ -48,7 +48,7 @@ module LicenseFinder
     end
 
     def decisions
-      @decisions ||= Decisions.fetch_saved(config.decisions_file_path)
+      @decisions ||= DecisionsFactory.decisions(config.decisions_file_path)
     end
 
     def prepare_projects

--- a/lib/license_finder/core.rb
+++ b/lib/license_finder/core.rb
@@ -6,6 +6,7 @@ require 'license_finder/license'
 require 'license_finder/configuration'
 require 'license_finder/package_manager'
 require 'license_finder/decisions'
+require 'license_finder/decisions_factory'
 require 'license_finder/decision_applier'
 
 module LicenseFinder

--- a/lib/license_finder/decisions_factory.rb
+++ b/lib/license_finder/decisions_factory.rb
@@ -1,0 +1,11 @@
+class DecisionsFactory
+  @decisions = {}
+  class << self
+    def decisions(decisions_file_path)
+      if @decisions[decisions_file_path].nil?
+        @decisions[decisions_file_path] = Decisions.fetch_saved(decisions_file_path)
+      end
+      @decisions[decisions_file_path]
+    end
+  end
+end

--- a/lib/license_finder/decisions_factory.rb
+++ b/lib/license_finder/decisions_factory.rb
@@ -1,11 +1,13 @@
-class DecisionsFactory
-  @decisions = {}
-  class << self
-    def decisions(decisions_file_path)
-      if @decisions[decisions_file_path].nil?
-        @decisions[decisions_file_path] = Decisions.fetch_saved(decisions_file_path)
+module LicenseFinder
+  class DecisionsFactory
+    @decisions = {}
+    class << self
+      def decisions(decisions_file_path)
+        if @decisions[decisions_file_path].nil?
+          @decisions[decisions_file_path] = Decisions.fetch_saved(decisions_file_path)
+        end
+        @decisions[decisions_file_path]
       end
-      @decisions[decisions_file_path]
     end
   end
 end

--- a/lib/license_finder/logger.rb
+++ b/lib/license_finder/logger.rb
@@ -8,13 +8,13 @@ module LicenseFinder
 
     attr_reader :mode
 
-    def initialize(options = {})
+    def initialize(mode = nil)
       @system_logger = ::Logger.new(STDOUT)
       @system_logger.formatter = proc do |_, _, _, msg|
         "#{msg}\n"
       end
 
-      self.mode = options[:mode] || MODE_INFO
+      self.mode = mode || MODE_INFO
     end
 
     [MODE_INFO, MODE_DEBUG].each do |level|

--- a/spec/lib/license_finder/cli/approvals_spec.rb
+++ b/spec/lib/license_finder/cli/approvals_spec.rb
@@ -6,7 +6,7 @@ module LicenseFinder
       let(:decisions) { Decisions.new }
 
       before do
-        allow(Decisions).to receive(:fetch_saved) { decisions }
+        allow(DecisionsFactory).to receive(:decisions) { decisions }
       end
 
       describe '#add' do

--- a/spec/lib/license_finder/cli/blacklist_spec.rb
+++ b/spec/lib/license_finder/cli/blacklist_spec.rb
@@ -6,7 +6,7 @@ module LicenseFinder
       let(:decisions) { Decisions.new }
 
       before do
-        allow(Decisions).to receive(:fetch_saved) { decisions }
+        allow(DecisionsFactory).to receive(:decisions) { decisions }
       end
 
       describe 'list' do

--- a/spec/lib/license_finder/cli/dependencies_spec.rb
+++ b/spec/lib/license_finder/cli/dependencies_spec.rb
@@ -6,7 +6,7 @@ module LicenseFinder
       let(:decisions) { Decisions.new }
 
       before do
-        allow(Decisions).to receive(:fetch_saved) { decisions }
+        allow(DecisionsFactory).to receive(:decisions) { decisions }
       end
 
       describe 'add' do

--- a/spec/lib/license_finder/cli/ignored_dependencies_spec.rb
+++ b/spec/lib/license_finder/cli/ignored_dependencies_spec.rb
@@ -6,7 +6,7 @@ module LicenseFinder
       let(:decisions) { Decisions.new }
 
       before do
-        allow(Decisions).to receive(:fetch_saved) { decisions }
+        allow(DecisionsFactory).to receive(:decisions) { decisions }
       end
 
       describe 'list' do

--- a/spec/lib/license_finder/cli/ignored_groups_spec.rb
+++ b/spec/lib/license_finder/cli/ignored_groups_spec.rb
@@ -6,7 +6,7 @@ module LicenseFinder
       let(:decisions) { Decisions.new }
 
       before do
-        allow(Decisions).to receive(:fetch_saved) { decisions }
+        allow(DecisionsFactory).to receive(:decisions) { decisions }
       end
 
       describe 'list' do

--- a/spec/lib/license_finder/cli/licenses_spec.rb
+++ b/spec/lib/license_finder/cli/licenses_spec.rb
@@ -6,7 +6,7 @@ module LicenseFinder
       let(:decisions) { Decisions.new }
 
       before do
-        allow(Decisions).to receive(:fetch_saved) { decisions }
+        allow(DecisionsFactory).to receive(:decisions) { decisions }
       end
 
       describe 'add' do

--- a/spec/lib/license_finder/cli/main_spec.rb
+++ b/spec/lib/license_finder/cli/main_spec.rb
@@ -85,11 +85,13 @@ module LicenseFinder
         end
 
         it 'passes the config options to the new LicenseFinder::LicenseAggregator instance' do
-          configuration = double(:configuration, valid_project_path?: true, project_path: Pathname('../other_project'), decisions_file_path: Pathname('../other_project'))
+          stubs = { valid_project_path?: true, project_path: Pathname('../other_project'),
+                    decisions_file_path: Pathname('../other_project'), aggregate_paths: nil, recursive: false, format: nil, columns: nil }
+          configuration = double(:configuration, stubs)
           allow(LicenseFinder::Configuration).to receive(:with_optional_saved_config).and_return(configuration)
           expect(LicenseFinder::LicenseAggregator).to receive(:new).with(configuration, anything).and_return(license_finder_instance)
-          expect { described_class.start(config_options) }.to raise_error(SystemExit)
           silence_stdout do
+            expect { described_class.start(config_options) }.to raise_error(SystemExit)
           end
         end
       end

--- a/spec/lib/license_finder/cli/main_spec.rb
+++ b/spec/lib/license_finder/cli/main_spec.rb
@@ -107,7 +107,7 @@ module LicenseFinder
           expect(report).to eq "\"one dependency\", 1.1, unknown\n"
         end
 
-        it 'will output a specific format', :focus do
+        it 'will output a specific format' do
           subject.options = { 'format' => 'markdown' }
           expect(report).to include '## Action'
         end

--- a/spec/lib/license_finder/cli/main_spec.rb
+++ b/spec/lib/license_finder/cli/main_spec.rb
@@ -86,9 +86,11 @@ module LicenseFinder
         end
 
         it 'passes the config options to the new LicenseFinder::LicenseAggregator instance' do
+          configuration = double(:configuration, valid_project_path?: true, project_path: Pathname('../other_project'), decisions_file_path: Pathname('../other_project'))
+          allow(LicenseFinder::Configuration).to receive(:with_optional_saved_config).and_return(configuration)
           expect(LicenseFinder::LicenseAggregator).to receive(:new).with(parsed_config, anything).and_return(license_finder_instance)
+          expect { described_class.start(config_options) }.to raise_error(SystemExit)
           silence_stdout do
-            expect { described_class.start(config_options) }.to raise_error(SystemExit)
           end
         end
       end

--- a/spec/lib/license_finder/cli/main_spec.rb
+++ b/spec/lib/license_finder/cli/main_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-
 module LicenseFinder
   module CLI
     describe Main do
@@ -106,14 +105,13 @@ module LicenseFinder
           expect(report).to eq "\"one dependency\", 1.1, unknown\n"
         end
 
-        it 'will output a specific format' do
-          subject.options = { format: 'markdown' }
-
+        it 'will output a specific format', :focus do
+          subject.options = { 'format' => 'markdown' }
           expect(report).to include '## Action'
         end
 
         it 'will output a custom csv' do
-          subject.options = { format: 'csv', columns: %w[name version] }
+          subject.options = { 'format' => 'csv', 'columns' => %w[name version] }
 
           expect(report).to eq "one dependency,1.1\n"
         end
@@ -122,7 +120,7 @@ module LicenseFinder
           let(:packages) { [NugetPackage.new('one dependency', '1.1')] }
 
           it 'will includes package_manager for csv report' do
-            subject.options = { format: 'csv', columns: %w[name version package_manager] }
+            subject.options = { 'format' => 'csv', 'columns' => %w[name version package_manager] }
 
             expect(report).to eq "one dependency,1.1,Nuget\n"
           end
@@ -130,7 +128,7 @@ module LicenseFinder
 
         context 'in html reports' do
           before do
-            subject.options = { format: 'html' }
+            subject.options = { 'format' => 'html' }
           end
 
           context 'when the project has a name' do
@@ -152,7 +150,7 @@ module LicenseFinder
 
         context 'when the --save option is passed' do
           it 'calls report method and calls save_report' do
-            subject.options = { save: 'license_report', format: 'text' }
+            subject.options = { 'save' => 'license_report', 'format' => 'text' }
             expect(subject).to receive(:report).and_call_original
             expect(subject).to receive(:save_report)
 
@@ -162,7 +160,7 @@ module LicenseFinder
           context 'when file name is not specified (--save)' do
             it 'creates report that is called the default file name' do
               provided_by_thor_as_default_name = 'license_report' # ####FIX ME
-              subject.options = { save: provided_by_thor_as_default_name, format: 'text' }
+              subject.options = { 'save' => provided_by_thor_as_default_name, 'format' => 'text' }
               expect(subject).to receive(:report).and_call_original
               expect(subject).to receive(:save_report).with(instance_of(String), 'license_report')
 
@@ -180,7 +178,7 @@ module LicenseFinder
 
           context "when file name is specified (--save='FILENAME')" do
             it 'saves with a specified file name' do
-              subject.options = { save: 'my_report', format: 'text' }
+              subject.options = { 'save' => 'my_report', 'format' => 'text' }
               expect(subject).to receive(:report).and_call_original
               expect(subject).to receive(:save_report).with(instance_of(String), 'my_report')
 
@@ -191,7 +189,7 @@ module LicenseFinder
 
         context 'when the --save option is not passed' do
           it 'calls report method and does not call save_report' do
-            subject.options = { format: 'text' }
+            subject.options = { 'format' => 'text' }
             expect(subject).to receive(:report).and_call_original
             expect(subject).not_to receive(:save_report)
             expect(subject).to receive(:report_of)
@@ -203,7 +201,7 @@ module LicenseFinder
 
       describe '#action_items' do
         def action_items
-          subject.options = { quiet: true, format: 'text' }
+          subject.options = { 'quiet' => true, 'format' => 'text' }
           subject.action_items
         end
 

--- a/spec/lib/license_finder/cli/main_spec.rb
+++ b/spec/lib/license_finder/cli/main_spec.rb
@@ -88,7 +88,7 @@ module LicenseFinder
         it 'passes the config options to the new LicenseFinder::LicenseAggregator instance' do
           configuration = double(:configuration, valid_project_path?: true, project_path: Pathname('../other_project'), decisions_file_path: Pathname('../other_project'))
           allow(LicenseFinder::Configuration).to receive(:with_optional_saved_config).and_return(configuration)
-          expect(LicenseFinder::LicenseAggregator).to receive(:new).with(parsed_config, anything).and_return(license_finder_instance)
+          expect(LicenseFinder::LicenseAggregator).to receive(:new).with(configuration, anything).and_return(license_finder_instance)
           expect { described_class.start(config_options) }.to raise_error(SystemExit)
           silence_stdout do
           end

--- a/spec/lib/license_finder/cli/main_spec.rb
+++ b/spec/lib/license_finder/cli/main_spec.rb
@@ -35,7 +35,7 @@ module LicenseFinder
       end
 
       before do
-        allow(Decisions).to receive(:fetch_saved) { decisions }
+        allow(DecisionsFactory).to receive(:decisions) { decisions }
         allow(DecisionApplier).to receive(:new) { decision_applier }
       end
 

--- a/spec/lib/license_finder/cli/project_name_spec.rb
+++ b/spec/lib/license_finder/cli/project_name_spec.rb
@@ -1,18 +1,16 @@
 require 'spec_helper'
-
 module LicenseFinder
   module CLI
     describe ProjectName do
       let(:decisions) { Decisions.new }
 
       before do
-        allow(Decisions).to receive(:fetch_saved) { decisions }
+        allow(DecisionsFactory).to receive(:decisions) { decisions }
       end
 
       describe 'show' do
         it 'shows the configured project name' do
           decisions.name_project('test')
-
           expect(capture_stdout { subject.show }).to match /test/
         end
       end

--- a/spec/lib/license_finder/cli/whitelist_spec.rb
+++ b/spec/lib/license_finder/cli/whitelist_spec.rb
@@ -6,7 +6,7 @@ module LicenseFinder
       let(:decisions) { Decisions.new }
 
       before do
-        allow(Decisions).to receive(:fetch_saved) { decisions }
+        allow(DecisionsFactory).to receive(:decisions) { decisions }
       end
 
       describe 'list' do

--- a/spec/lib/license_finder/configuration_spec.rb
+++ b/spec/lib/license_finder/configuration_spec.rb
@@ -167,5 +167,16 @@ module LicenseFinder
         expect(subject.mix_command.to_s).to eq 'newmix'
       end
     end
+
+    describe '#merge' do
+      it 'should return a new config with an altered project path' do
+        subject = described_class.with_optional_saved_config(project_path: '/path/to/project')
+        duped_subject = subject.merge(project_path: '/path/to/other/project')
+
+        expect(duped_subject.project_path.to_s).to eq '/path/to/other/project'
+        expect(subject.project_path.to_s).to eq '/path/to/project'
+        expect(subject.project_path).to_not eq duped_subject.project_path
+      end
+    end
   end
 end

--- a/spec/lib/license_finder/configuration_spec.rb
+++ b/spec/lib/license_finder/configuration_spec.rb
@@ -178,5 +178,26 @@ module LicenseFinder
         expect(subject.project_path).to_not eq duped_subject.project_path
       end
     end
+
+    describe '#save_file' do
+      context 'when there is no save file present' do
+        it 'returns the save file path' do
+          subject = described_class.with_optional_saved_config(project_path: '/path/to/project', save: '/path/to/save_file')
+
+          expect(subject.save_file).to eq '/path/to/save_file'
+        end
+      end
+
+      context 'when there is a save file present' do
+        it 'returns the save file path when no primary ' do
+          allow(Pathname).to receive(:expand_path).and_return Pathname('/path/to/project').expand_path
+          allow(YAML).to receive(:safe_load).and_return(project_path: '/path/to/project', save: '/path/to/save_file')
+
+          subject = described_class.with_optional_saved_config(project_path: '/path/to/project', save: '/path/to/save_file')
+
+          expect(subject.save_file).to eq '/path/to/save_file'
+        end
+      end
+    end
   end
 end

--- a/spec/lib/license_finder/core_spec.rb
+++ b/spec/lib/license_finder/core_spec.rb
@@ -2,10 +2,9 @@ require 'spec_helper'
 
 module LicenseFinder
   describe Core do
-    let(:options) { {} }
-    let(:license_finder) { described_class.new(options) }
-    let(:logger) { LicenseFinder::Logger.new(options[:logger]) }
+    let(:logger) { LicenseFinder::Logger.new }
     let(:configuration) { LicenseFinder::Configuration.new(options, {}) }
+    let(:license_finder) { described_class.new(configuration) }
     let(:pathname) { Pathname.pwd + Pathname(options[:project_path]) }
 
     before do

--- a/spec/lib/logger_spec.rb
+++ b/spec/lib/logger_spec.rb
@@ -30,13 +30,13 @@ describe LicenseFinder::Logger, :focus do
     it 'should log all information' do
       # set system logger level to x
       expect(system_logger).to receive(:level=).with Logger::DEBUG
-      described_class.new(mode: :debug)
+      described_class.new(:debug)
     end
   end
 
   context 'when the log level is set to --quiet' do
     it 'should not log any information' do
-      subject = described_class.new(mode: :quiet)
+      subject = described_class.new(:quiet)
 
       [LicenseFinder::Logger::MODE_INFO, LicenseFinder::Logger::MODE_DEBUG].each do |level|
         expect(system_logger).to_not receive(level)
@@ -48,7 +48,7 @@ describe LicenseFinder::Logger, :focus do
   context 'when the log level is set to --default' do
     it 'should log only standard information' do
       expect(system_logger).to receive(:level=).with Logger::INFO
-      described_class.new(mode: :info)
+      described_class.new(:info)
     end
   end
 end


### PR DESCRIPTION
## Configuration and Options refactor
* Refactor and clean up CLI layer
* Logger now no longer takes a hash consisting of quiet / debug but rather just a mode
[CHANGED] Class options format and columns are now method options specific to report since they have no effect on either action_items nor diff 
* core no longer holds onto the decisions object thus forcing main to keep a random core around even when it isn't being used
* Spec file for main now mimics Thor situations more accurately