### PR TITLE
Avoid packaging tests into gem

### DIFF
--- a/license_finder.gemspec
+++ b/license_finder.gemspec
@@ -71,6 +71,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'addressable', '< 2.5.0'
   s.add_development_dependency 'mime-types', '< 3.0'
 
-  s.files         = `git ls-files`.split("\n").reject { |f| f.start_with? 'spec' }
+  s.files         = `git ls-files`.split("\n").reject { |f| f.start_with?('spec', 'features') }
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 end


### PR DESCRIPTION
Besides being the right thing to do, and saving 20% off the gem size,
this also avoids packaging a symslink that'll cause rubygems to fail
to install the gem on windows.

Before:
```
david@davids:~/git/LicenseFinder$ bundle exec rake build
license_finder 4.0.2 built to pkg/license_finder-4.0.2.gem.
david@davids:~/git/LicenseFinder$ ls -la pkg/license_finder-4.0.2.gem
total 132
-rw-r--r--  1 david david 125440 Jan  4 14:20 license_finder-4.0.2.gem
```

After:
```
david@davids:~/git/LicenseFinder$ bundle exec rake build
license_finder 4.0.2 built to pkg/license_finder-4.0.2.gem.
david@davids:~/git/LicenseFinder$ ls -la pkg/license_finder-4.0.2.gem
total 112
-rw-r--r--  1 david david 102912 Jan  4 14:21 license_finder-4.0.2.gem
david@davids:~/git/LicenseFinder$ git gui &
```

Bundler error on [appveyor](https://ci.appveyor.com/project/puppetlabs/puppet-resource-api/build/job/ttgvb1s384g5ysx4):
```
Fetching license_finder 4.0.2
Installing license_finder 4.0.2
fatal: Not a git repository (or any of the parent directories): .git
--- ERROR REPORT TEMPLATE -------------------------------------------------------
[...]
## Backtrace

NotImplementedError: symlink() function is unimplemented on this machine
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/rubygems/package.rb:388:in `symlink'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/rubygems/package.rb:388:in `block (2 levels) in extract_tar_gz'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/rubygems/package/tar_reader.rb:65:in `each'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/rubygems/package.rb:365:in `block in extract_tar_gz'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/rubygems/package.rb:459:in `block in open_tar_gz'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/rubygems/package.rb:456:in `wrap'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/rubygems/package.rb:456:in `open_tar_gz'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/rubygems/package.rb:364:in `extract_tar_gz'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/rubygems/package.rb:345:in `block (2 levels) in extract_files'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/rubygems/package/tar_reader.rb:65:in `each'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/rubygems/package.rb:342:in `block in extract_files'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/rubygems/package/file_source.rb:30:in `open'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/rubygems/package/file_source.rb:30:in `with_read_io'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/rubygems/package.rb:339:in `extract_files'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/rubygems/installer.rb:789:in `extract_files'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/rubygems/installer.rb:304:in `install'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/source/rubygems.rb:153:in `block in install'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/rubygems_integration.rb:217:in `preserve_paths'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/source/rubygems.rb:142:in `install'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/installer/gem_installer.rb:56:in `install'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/installer/parallel_installer.rb:162:in `do_install'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/installer/parallel_installer.rb:147:in `install_serially'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/installer/parallel_installer.rb:102:in `call'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/installer/parallel_installer.rb:78:in `call'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/installer.rb:258:in `install_in_parallel'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/installer.rb:194:in `install'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/installer.rb:91:in `block in run'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/process_lock.rb:12:in `block in lock'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/process_lock.rb:9:in `open'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/process_lock.rb:9:in `lock'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/installer.rb:72:in `run'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/installer.rb:25:in `install'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/cli/install.rb:65:in `run'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/cli.rb:224:in `block in install'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/settings.rb:136:in `temporary'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/cli.rb:223:in `install'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/cli.rb:27:in `dispatch'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/cli.rb:18:in `start'
  C:/Ruby21-x64/bin/bundle:30:in `block in <main>'
  C:/Ruby21-x64/lib/ruby/site_ruby/2.1.0/bundler/friendly_errors.rb:122:in `with_friendly_errors'
  C:/Ruby21-x64/bin/bundle:22:in `<main>'

## Environment

Bundler       1.16.0
  Platforms   ruby, x64-mingw32
Ruby          2.1.9p490 (2016-03-30 revision 54437) [x64-mingw32]
  Full Path   C:/Ruby21-x64/bin/ruby.exe
  Config Dir  C:/ProgramData
RubyGems      2.7.2
  Gem Home    C:/Ruby21-x64/lib/ruby/gems/2.1.0
  Gem Path    C:/Ruby21-x64/lib/ruby/gems/2.1.0;C:/Users/appveyor/.gem/ruby/2.1.0
  User Path   C:/Users/appveyor/.gem/ruby/2.1.0
  Bin Dir     C:/Ruby21-x64/bin
OpenSSL
  Compiled    OpenSSL 1.0.1l 15 Jan 2015
  Loaded      OpenSSL 1.0.1l 15 Jan 2015
  Cert File   C:/Users/Justin/Projects/knap-build/var/knapsack/software/x64-windows/openssl/1.0.1l/ssl/cert.pem
  Cert Dir    C:/Users/Justin/Projects/knap-build/var/knapsack/software/x64-windows/openssl/1.0.1l/ssl/certs
Tools
  Git         2.14.1.windows.1
  RVM         not installed
  rbenv       not installed
  chruby      not installed
```

The symlink was originally introduced in https://github.com/pivotal/LicenseFinder/commit/b71843fb8e43ec3357cb08f431d4c9a590ca3429