### PR TITLE
Nuget package provider: Converting License URL from REXML::Text to string (Obvious Fix)

### DIFF
--- a/lib/license_finder/package_managers/nuget.rb
+++ b/lib/license_finder/package_managers/nuget.rb
@@ -53,7 +53,7 @@ module LicenseFinder
       Zip::File.open file do |zipfile|
         content = zipfile.read(dep.name + '.nuspec')
         xml = REXML::Document.new(content)
-        REXML::XPath.match(xml, '//metadata//licenseUrl').map(&:get_text)
+        REXML::XPath.match(xml, '//metadata//licenseUrl').map(&:get_text).map(&:to_s)
       end
     end
 


### PR DESCRIPTION
This is to fix an exception: 
```
> license_finder
LicenseFinder::Nuget: is active
C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/license_finder-5.0.0/lib/license_finder/license.rb:43:in `stripped_name': undefined method `sub' for "http://go.microsoft.com/fwlink/?LinkID=320539":REXML::Text (NoMethodError)
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/license_finder-5.0.0/lib/license_finder/license.rb:20:in `block in find_by_name'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/license_finder-5.0.0/lib/license_finder/license.rb:20:in `each'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/license_finder-5.0.0/lib/license_finder/license.rb:20:in `detect'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/license_finder-5.0.0/lib/license_finder/license.rb:20:in `find_by_name'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/license_finder-5.0.0/lib/license_finder/package.rb:141:in `block in licenses_from_spec'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/license_finder-5.0.0/lib/license_finder/package.rb:141:in `map'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/license_finder-5.0.0/lib/license_finder/package.rb:141:in `licenses_from_spec'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/license_finder-5.0.0/lib/license_finder/package.rb:132:in `licensing'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/license_finder-5.0.0/lib/license_finder/package.rb:126:in `activations'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/license_finder-5.0.0/lib/license_finder/package.rb:122:in `licenses'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/license_finder-5.0.0/lib/license_finder/decision_applier.rb:47:in `with_approval'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/license_finder-5.0.0/lib/license_finder/decision_applier.rb:30:in `block in apply_decisions'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/license_finder-5.0.0/lib/license_finder/decision_applier.rb:30:in `map'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/license_finder-5.0.0/lib/license_finder/decision_applier.rb:30:in `apply_decisions'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/license_finder-5.0.0/lib/license_finder/decision_applier.rb:6:in `initialize'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/license_finder-5.0.0/lib/license_finder/core.rb:76:in `new'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/license_finder-5.0.0/lib/license_finder/core.rb:76:in `decision_applier'
        from C:/Ruby24-x64/lib/ruby/2.4.0/forwardable.rb:223:in `any_packages?'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/license_finder-5.0.0/lib/license_finder/license_aggregator.rb:15:in `block in any_packages?'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/license_finder-5.0.0/lib/license_finder/license_aggregator.rb:13:in `map'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/license_finder-5.0.0/lib/license_finder/license_aggregator.rb:13:in `any_packages?'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/license_finder-5.0.0/lib/license_finder/cli/main.rb:87:in `action_items'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/license_finder-5.0.0/bin/license_finder:5:in `<top (required)>'
        from C:/Ruby24-x64/bin/license_finder:22:in `load'
        from C:/Ruby24-x64/bin/license_finder:22:in `<main>'
```

Not sure how this is working for anyone else, but adding the map(&:to_s) fixed it for me locally.