### PR TITLE
Fix in_umbrella: true dependencies

### DIFF
--- a/features/features/package_managers/mix_spec.rb
+++ b/features/features/package_managers/mix_spec.rb
@@ -13,4 +13,13 @@ describe 'Mix Dependencies' do
     expect(elixir_developer).to be_seeing_line 'fs, 0.9.1, ISC'
     expect(elixir_developer).to be_seeing_line 'uuid, 1.1.5, "Apache 2.0"'
   end
+
+  specify 'do not include in_umbrella: true dependencies internal to an umbrella project' do
+    LicenseFinder::TestingDSL::MixUmbrellaProject.create
+    puts 'mix umbrella project created'
+    elixir_developer.run_license_finder
+    expect(elixir_developer).not_to be_seeing_something_like /awesome/
+    expect(elixir_developer).to be_seeing_line 'fs, 0.9.1, ISC'
+    expect(elixir_developer).to be_seeing_line 'uuid, 1.1.5, "Apache 2.0"'
+  end
 end

--- a/features/fixtures/mix_umbrella/apps/awesome/.formatter.exs
+++ b/features/fixtures/mix_umbrella/apps/awesome/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/features/fixtures/mix_umbrella/apps/awesome/.gitignore
+++ b/features/fixtures/mix_umbrella/apps/awesome/.gitignore
@@ -1,0 +1,24 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+awesome-*.tar
+

--- a/features/fixtures/mix_umbrella/apps/awesome/README.md
+++ b/features/fixtures/mix_umbrella/apps/awesome/README.md
@@ -1,0 +1,21 @@
+# Awesome
+
+**TODO: Add description**
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+by adding `awesome` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:awesome, "~> 0.1.0"}
+  ]
+end
+```
+
+Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
+and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
+be found at [https://hexdocs.pm/awesome](https://hexdocs.pm/awesome).
+

--- a/features/fixtures/mix_umbrella/apps/awesome/config/config.exs
+++ b/features/fixtures/mix_umbrella/apps/awesome/config/config.exs
@@ -1,0 +1,30 @@
+# This file is responsible for configuring your application
+# and its dependencies with the aid of the Mix.Config module.
+use Mix.Config
+
+# This configuration is loaded before any dependency and is restricted
+# to this project. If another project depends on this project, this
+# file won't be loaded nor affect the parent project. For this reason,
+# if you want to provide default values for your application for
+# 3rd-party users, it should be done in your "mix.exs" file.
+
+# You can configure your application as:
+#
+#     config :awesome, key: :value
+#
+# and access this configuration in your application as:
+#
+#     Application.get_env(:awesome, :key)
+#
+# You can also configure a 3rd-party app:
+#
+#     config :logger, level: :info
+#
+
+# It is also possible to import configuration files, relative to this
+# directory. For example, you can emulate configuration per environment
+# by uncommenting the line below and defining dev.exs, test.exs and such.
+# Configuration from the imported file will override the ones defined
+# here (which is why it is important to import them last).
+#
+#     import_config "#{Mix.env}.exs"

--- a/features/fixtures/mix_umbrella/apps/awesome/lib/awesome.ex
+++ b/features/fixtures/mix_umbrella/apps/awesome/lib/awesome.ex
@@ -1,0 +1,18 @@
+defmodule Awesome do
+  @moduledoc """
+  Documentation for Awesome.
+  """
+
+  @doc """
+  Hello world.
+
+  ## Examples
+
+      iex> Awesome.hello
+      :world
+
+  """
+  def hello do
+    :world
+  end
+end

--- a/features/fixtures/mix_umbrella/apps/awesome/mix.exs
+++ b/features/fixtures/mix_umbrella/apps/awesome/mix.exs
@@ -1,0 +1,31 @@
+defmodule Awesome.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :awesome,
+      version: "0.1.0",
+      build_path: "../../_build",
+      config_path: "../../config/config.exs",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      elixir: "~> 1.6",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      {:fs, "0.9.1"}
+    ]
+  end
+end

--- a/features/fixtures/mix_umbrella/apps/awesome/test/awesome_test.exs
+++ b/features/fixtures/mix_umbrella/apps/awesome/test/awesome_test.exs
@@ -1,0 +1,8 @@
+defmodule AwesomeTest do
+  use ExUnit.Case
+  doctest Awesome
+
+  test "greets the world" do
+    assert Awesome.hello() == :world
+  end
+end

--- a/features/fixtures/mix_umbrella/apps/awesome/test/test_helper.exs
+++ b/features/fixtures/mix_umbrella/apps/awesome/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/features/fixtures/mix_umbrella/apps/awesomer/.formatter.exs
+++ b/features/fixtures/mix_umbrella/apps/awesomer/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/features/fixtures/mix_umbrella/apps/awesomer/.gitignore
+++ b/features/fixtures/mix_umbrella/apps/awesomer/.gitignore
@@ -1,0 +1,24 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+awesomer-*.tar
+

--- a/features/fixtures/mix_umbrella/apps/awesomer/README.md
+++ b/features/fixtures/mix_umbrella/apps/awesomer/README.md
@@ -1,0 +1,21 @@
+# Awesomer
+
+**TODO: Add description**
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+by adding `awesomer` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:awesomer, "~> 0.1.0"}
+  ]
+end
+```
+
+Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
+and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
+be found at [https://hexdocs.pm/awesomer](https://hexdocs.pm/awesomer).
+

--- a/features/fixtures/mix_umbrella/apps/awesomer/config/config.exs
+++ b/features/fixtures/mix_umbrella/apps/awesomer/config/config.exs
@@ -1,0 +1,30 @@
+# This file is responsible for configuring your application
+# and its dependencies with the aid of the Mix.Config module.
+use Mix.Config
+
+# This configuration is loaded before any dependency and is restricted
+# to this project. If another project depends on this project, this
+# file won't be loaded nor affect the parent project. For this reason,
+# if you want to provide default values for your application for
+# 3rd-party users, it should be done in your "mix.exs" file.
+
+# You can configure your application as:
+#
+#     config :awesomer, key: :value
+#
+# and access this configuration in your application as:
+#
+#     Application.get_env(:awesomer, :key)
+#
+# You can also configure a 3rd-party app:
+#
+#     config :logger, level: :info
+#
+
+# It is also possible to import configuration files, relative to this
+# directory. For example, you can emulate configuration per environment
+# by uncommenting the line below and defining dev.exs, test.exs and such.
+# Configuration from the imported file will override the ones defined
+# here (which is why it is important to import them last).
+#
+#     import_config "#{Mix.env}.exs"

--- a/features/fixtures/mix_umbrella/apps/awesomer/lib/awesomer.ex
+++ b/features/fixtures/mix_umbrella/apps/awesomer/lib/awesomer.ex
@@ -1,0 +1,18 @@
+defmodule Awesomer do
+  @moduledoc """
+  Documentation for Awesomer.
+  """
+
+  @doc """
+  Hello world.
+
+  ## Examples
+
+      iex> Awesomer.hello
+      :world
+
+  """
+  def hello do
+    :world
+  end
+end

--- a/features/fixtures/mix_umbrella/apps/awesomer/mix.exs
+++ b/features/fixtures/mix_umbrella/apps/awesomer/mix.exs
@@ -1,0 +1,32 @@
+defmodule Awesomer.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :awesomer,
+      version: "0.1.0",
+      build_path: "../../_build",
+      config_path: "../../config/config.exs",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      elixir: "~> 1.6",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      {:awesome, in_umbrella: true},
+      {:uuid, "1.1.5"}
+    ]
+  end
+end

--- a/features/fixtures/mix_umbrella/apps/awesomer/test/awesomer_test.exs
+++ b/features/fixtures/mix_umbrella/apps/awesomer/test/awesomer_test.exs
@@ -1,0 +1,8 @@
+defmodule AwesomerTest do
+  use ExUnit.Case
+  doctest Awesomer
+
+  test "greets the world" do
+    assert Awesomer.hello() == :world
+  end
+end

--- a/features/fixtures/mix_umbrella/apps/awesomer/test/test_helper.exs
+++ b/features/fixtures/mix_umbrella/apps/awesomer/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/features/fixtures/mix_umbrella/config/config.exs
+++ b/features/fixtures/mix_umbrella/config/config.exs
@@ -1,0 +1,17 @@
+# This file is responsible for configuring your application
+# and its dependencies with the aid of the Mix.Config module.
+use Mix.Config
+
+# By default, the umbrella project as well as each child
+# application will require this configuration file, ensuring
+# they all use the same configuration. While one could
+# configure all applications here, we prefer to delegate
+# back to each application for organization purposes.
+import_config "../apps/*/config/config.exs"
+
+# Sample configuration (overrides the imported configuration above):
+#
+#     config :logger, :console,
+#       level: :info,
+#       format: "$date $time [$level] $metadata$message\n",
+#       metadata: [:user_id]

--- a/features/fixtures/mix_umbrella/mix.exs
+++ b/features/fixtures/mix_umbrella/mix.exs
@@ -1,0 +1,20 @@
+defmodule MixUmbrella.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      apps_path: "apps",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Dependencies listed here are available only for this
+  # project and cannot be accessed from applications inside
+  # the apps folder.
+  #
+  # Run "mix help deps" for examples and options.
+  defp deps do
+    []
+  end
+end

--- a/features/support/testing_dsl.rb
+++ b/features/support/testing_dsl.rb
@@ -384,6 +384,12 @@ module LicenseFinder
       end
     end
 
+    class MixUmbrellaProject < MixProject
+      def add_dep
+        FileUtils.copy_entry(Paths.fixtures.join('mix_umbrella'), Paths.my_app)
+      end
+    end
+
     class NugetProject < Project
       def add_dep
         clone('nuget')


### PR DESCRIPTION
Fixes #475

Don't assume that all dependencies have the same number of lines and instead group package lines together first and then extract the name and version for each package.  `in_umbrella: true` dependencies are completely ignored since they will be under the project's license and are not true dependencies.