### PR TITLE
Replace httparty with http library for pypi fetches

### DIFF
--- a/lib/license_finder/package_managers/pip.rb
+++ b/lib/license_finder/package_managers/pip.rb
@@ -1,5 +1,5 @@
 require 'json'
-require 'httparty'
+require 'http'
 
 module LicenseFinder
   class Pip < PackageManager
@@ -55,7 +55,7 @@ module LicenseFinder
     end
 
     def pypi_def(name, version)
-      response = HTTParty.get("https://pypi.python.org/pypi/#{name}/#{version}/json")
+      response = HTTP.follow.get("https://pypi.python.org/pypi/#{name}/#{version}/json")
       if response.code == 200
         JSON.parse(response.body).fetch('info', {})
       else

--- a/license_finder.gemspec
+++ b/license_finder.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency 'bundler'
-  s.add_dependency 'httparty'
+  s.add_dependency 'http'
   s.add_dependency 'rubyzip'
   s.add_dependency 'thor'
   s.add_dependency 'toml', '0.2.0'

--- a/spec/dummy_app/Gemfile
+++ b/spec/dummy_app/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 ruby '2.1.5'
 
 gem 'bundler'
-gem 'httparty'
+gem 'http'


### PR DESCRIPTION
This avoid the obnoxious party message displaying when installing
LicenseFinder, which seems like the right thing to do.

See https://github.com/jnunemaker/httparty/pull/321 for many attempts to
have this fixed upstream in httparty, which have gone unheard and ignored.