### PR TITLE
Quick and dirty support for flat file license manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ features/fixtures/maven-wrapper/target
 features/fixtures/sbt/target
 features/fixtures/sbt/project/target
 features/fixtures/sbt/project/project
+*.gem

--- a/lib/license_finder/package.rb
+++ b/lib/license_finder/package.rb
@@ -177,6 +177,7 @@ module LicenseFinder
   end
 end
 
+require 'license_finder/packages/flat_file_package'
 require 'license_finder/packages/manual_package'
 require 'license_finder/packages/bower_package'
 require 'license_finder/packages/go_package'

--- a/lib/license_finder/package_manager.rb
+++ b/lib/license_finder/package_manager.rb
@@ -135,6 +135,7 @@ module LicenseFinder
   end
 end
 
+require 'license_finder/package_managers/flat_file'
 require 'license_finder/package_managers/bower'
 require 'license_finder/package_managers/go_workspace'
 require 'license_finder/package_managers/go_15vendorexperiment'

--- a/lib/license_finder/package_managers/flat_file.rb
+++ b/lib/license_finder/package_managers/flat_file.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module LicenseFinder
+  class FlatFile < PackageManager
+    def initialize(options = {})
+      super
+    end
+
+    def current_packages
+      deps.map do |dep|
+        FlatFilePackage.new(
+          dep[:name],
+          nil,
+          dep[:text],
+          homepage: dep[:url]
+        )
+      end
+    end
+
+    def self.package_management_command; end
+
+    def self.prepare_command; end
+
+    def possible_package_paths
+      [project_path.join('LICENSES.txt')]
+    end
+
+    private
+
+    def deps
+      dependencies = []
+      File.foreach('LICENSES.txt') do |line|
+        if line.start_with?('Package: ')
+          dependencies << { name: line.gsub('Package: ', '').chomp, url: '', text: '' }
+        elsif line.start_with?('License URL: ')
+          dependencies.last[:url] = line.gsub('License URL: ', '').chomp
+        elsif line.start_with?('--------') || dependencies.empty?
+          next
+        else
+          dependencies.last[:text] += line
+        end
+      end
+      dependencies
+    end
+  end
+end

--- a/lib/license_finder/packages/flat_file_package.rb
+++ b/lib/license_finder/packages/flat_file_package.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module LicenseFinder
+  class FlatFilePackage < Package
+    def initialize(name, version, license_text, options = {})
+      super(name, version, options)
+      @license = License.find_by_text(license_text.to_s)
+    end
+
+    def licenses_from_spec
+      [@license].compact
+    end
+
+    def package_manager
+      'FlatFile'
+    end
+  end
+end

--- a/lib/license_finder/scanner.rb
+++ b/lib/license_finder/scanner.rb
@@ -2,7 +2,7 @@
 
 module LicenseFinder
   class Scanner
-    PACKAGE_MANAGERS = [GoModules, GoDep, GoWorkspace, Go15VendorExperiment, Glide, Gvt, Govendor, Trash, Dep, Bundler, NPM, Pip,
+    PACKAGE_MANAGERS = [FlatFile, GoModules, GoDep, GoWorkspace, Go15VendorExperiment, Glide, Gvt, Govendor, Trash, Dep, Bundler, NPM, Pip,
                         Yarn, Bower, Maven, Gradle, CocoaPods, Rebar, Nuget, Carthage, Mix, Conan, Sbt, Cargo, Dotnet, Composer].freeze
 
     def initialize(config = { project_path: Pathname.new('') })


### PR DESCRIPTION
Here's something I hacked together during a meeting to support flat license files like the ones Istio provides as part of their official container images. 

Doing something like this would allow us to quickly generate the report for an official container image, instead of rebuilding the image on our own and solving the problem of how to distribute them.

Here's an example file: [LICENSES.txt](https://github.com/pivotal/LicenseFinder/files/3522850/LICENSES.txt)

It's not tested and probably not ready to merge, but I'm out for the rest of the week and wanted to drop this off in case someone was interested in taking over while I'm out.

We are 100% going to need this for the KNative effort moving forward.