### PR TITLE
Pin rubyzip to be v1, because rubyzip v2 doesn't support Ruby v2.3

### DIFF
--- a/license_finder.gemspec
+++ b/license_finder.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency 'bundler'
-  s.add_dependency 'rubyzip'
+  s.add_dependency 'rubyzip', '~>1'
   s.add_dependency 'thor'
   s.add_dependency 'toml', '0.2.0'
   s.add_dependency 'with_env', '1.1.0'


### PR DESCRIPTION
* No new tests added because it should be covered by existing tests