### PR TITLE
[Changed] project_roots will skip maven subprojects

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,13 @@ xml-simple, 1.1.1, unknown
 You can customize the format of the output in the same way that you customize
 [output from `report`](#output-from-report).
 
+### Output from `project_roots`
+
+The `license_finder project_roots` command will output the current working directory as a string in an array.
+
+Using the `--recursive` option means the array will include subdirectories that contain a known package manager. With the exception that Gradle and Maven subprojects will not be included.
+
+
 ### Output from `report`
 
 The `license_finder report` command will output human-readable reports that you
@@ -429,8 +436,6 @@ downloadLicenses {
   dependencyConfiguration "compile"
 }
 ```
-
-**A note on Gradle Subprojects**: `license_finder` does not report Gradle subprojects as project roots when generating reports. However, if there is a non-Gradle package definition file in a subproject, then it will be included in the report.
 
 ### Conan Projects
 

--- a/lib/license_finder/package_managers/maven.rb
+++ b/lib/license_finder/package_managers/maven.rb
@@ -47,5 +47,19 @@ module LicenseFinder
     def possible_package_paths
       [project_path.join('pom.xml')]
     end
+
+    def project_root?
+      active? && root_module?
+    end
+
+    private
+
+    def root_module?
+      command = "#{package_management_command} help:evaluate -Dexpression=project.parent -q -DforceStdout"
+      stdout, stderr, status = Dir.chdir(project_path) { Cmd.run(command) }
+      raise "Command '#{command}' failed to execute: #{stderr}" unless status.success?
+
+      stdout.include?('null object or invalid expression')
+    end
   end
 end

--- a/spec/fixtures/maven-with-subprojects/notsubprojectC/pom.xml
+++ b/spec/fixtures/maven-with-subprojects/notsubprojectC/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>isolated</groupId>
+  <artifactId>notsubprojectC</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/spec/fixtures/maven-with-subprojects/pom.xml
+++ b/spec/fixtures/maven-with-subprojects/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <packaging>pom</packaging>
+
+  <groupId>dummy</groupId>
+  <artifactId>dummy</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <modules>
+    <module>subprojectA</module>
+    <module>subprojectB</module>
+  </modules>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/spec/fixtures/maven-with-subprojects/subprojectA/pom.xml
+++ b/spec/fixtures/maven-with-subprojects/subprojectA/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>dummy</groupId>
+  <artifactId>subprojectA</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <parent>
+    <groupId>dummy</groupId>
+    <artifactId>dummy</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/spec/fixtures/maven-with-subprojects/subprojectB/pom.xml
+++ b/spec/fixtures/maven-with-subprojects/subprojectB/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>dummy</groupId>
+  <artifactId>subprojectB</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <parent>
+    <groupId>dummy</groupId>
+    <artifactId>dummy</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/spec/lib/license_finder/package_managers/maven_spec.rb
+++ b/spec/lib/license_finder/package_managers/maven_spec.rb
@@ -74,8 +74,8 @@ module LicenseFinder
 
         before do
           expect(SharedHelpers::Cmd).to receive(:run)
-            .with(command)
-            .and_return(['', '', cmd_success])
+                                          .with(command)
+                                          .and_return(['', '', cmd_success])
         end
 
         it 'uses skips the specified groups' do
@@ -131,6 +131,37 @@ module LicenseFinder
         ")
 
         expect(subject.current_packages.first.licenses.map(&:name)).to eq ['unknown']
+      end
+    end
+    describe '.project_root?' do
+      context 'when dealing with root maven project' do
+        subject { Maven.new(options.merge(project_path: Pathname(fixture_path('maven-with-subprojects').to_s))) }
+
+        it 'returns true' do
+          expect(subject.project_root?).to be true
+        end
+      end
+      context 'when dealing with a maven subproject' do
+        subject { Maven.new(options.merge(project_path: Pathname(fixture_path('maven-with-subprojects/subprojectB').to_s))) }
+
+        it 'returns false' do
+          expect(subject.project_root?).to eq(false)
+        end
+      end
+      context 'when fetching module properties fail' do
+        it 'raises an error' do
+          FakeFS do
+            FileUtils.mkdir_p '/fake/path'
+            FileUtils.touch '/fake/path/pom.xml'
+
+            expect(SharedHelpers::Cmd).to receive(:run)
+              .with('mvn help:evaluate -Dexpression=project.parent -q -DforceStdout')
+              .and_return([nil, 'error', cmd_failure])
+
+            expect { subject.project_root? }
+              .to raise_error(/Command 'mvn help:evaluate -Dexpression=project.parent -q -DforceStdout' failed to execute: error/)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This PR updated the behaviour of `project_roots` to skip maven subprojects. It is based off of the PR #629 

It also updates Scanner tests to be generic for all skipping behaviour of package managers

This is in draft mode until #629 is merged.