### PR TITLE
Create output dir if not existent

### DIFF
--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -192,6 +192,12 @@ module LicenseFinder
       end
 
       def save_report(content, file_name)
+        require 'fileutils'
+        dir = File.dirname(file_name)
+        unless Dir.exist?(dir)
+          FileUtils.mkdir_p(dir)
+        end
+
         File.open(file_name, 'w') do |f|
           f.write(content)
         end

--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -192,11 +192,8 @@ module LicenseFinder
       end
 
       def save_report(content, file_name)
-        require 'fileutils'
         dir = File.dirname(file_name)
-        unless Dir.exist?(dir)
-          FileUtils.mkdir_p(dir)
-        end
+        FileUtils.mkdir_p(dir) unless Dir.exist?(dir)
 
         File.open(file_name, 'w') do |f|
           f.write(content)

--- a/spec/lib/license_finder/cli/main_spec.rb
+++ b/spec/lib/license_finder/cli/main_spec.rb
@@ -196,6 +196,22 @@ module LicenseFinder
               subject.report
             end
           end
+
+          context 'when folder does not exist, it is being created' do
+            let(:save) { 'output/subfolder/license_report.txt' }
+
+            after do
+              # cleanup to remove the created directory again
+              FileUtils.rm_rf('output')
+            end
+
+            it 'calls `FileUtils` which creates the directory' do
+              subject.options = { 'save' => save }
+              expect(FileUtils).to receive(:mkdir_p).with('output/subfolder').and_call_original
+
+              subject.report
+            end
+          end
         end
 
         context 'when the --save option is not passed' do


### PR DESCRIPTION
We where running into this error on our CI:
`Errno::ENOENT: No such file or directory @ rb_sysopen - ./audit/licenses.html`

As we are using `--save=./audit/licenses.html` and the directory is not present, this failed.

With this change, the needed directories will be created even when there are multiple ones, i.e. `--save=./audit/in/sub/folder/licenses.html` will create all needed directories.