### PR TITLE
Fix documentation for whitelisting by license

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ blanket policies about which packages are approved.  To tell `license_finder`
 that any package with the MIT license should be approved, run:
 
 ``` sh
-$ license_finder permitted_licenses add MIT
+$ license_finder whitelist add MIT
 ```
 
 Any current or future packages with the MIT license will be excluded from the


### PR DESCRIPTION
`license_finder permitted_licenses add MIT` is no longer valid. Updating documentation to reflect the new command to use