### PR TITLE
Change version to be required for `dependency add` and updated cli options

### DIFF
--- a/features/features/configure/add_dependencies_spec.rb
+++ b/features/features/configure/add_dependencies_spec.rb
@@ -26,14 +26,14 @@ describe 'Manually Added Dependencies' do
   end
 
   specify 'can be simultaneously homepaged' do
-    developer.execute_command 'license_finder dependencies add manual Whatever --homepage=some-homepage'
+    developer.execute_command 'license_finder dependencies add manual Whatever 1.2 --homepage=some-homepage'
 
     developer.run_license_finder(nil, '--columns="name" "homepage"')
     expect(developer).to be_seeing 'manual, some-homepage'
   end
 
   specify 'appear in the CLI' do
-    developer.execute_command 'license_finder dependencies add manual_dep Whatever'
+    developer.execute_command 'license_finder dependencies add manual_dep Whatever 1.2'
     expect(developer).to be_seeing 'manual_dep'
 
     developer.execute_command 'license_finder dependencies list'

--- a/features/features/configure/restricted_licenses_spec.rb
+++ b/features/features/configure/restricted_licenses_spec.rb
@@ -13,7 +13,7 @@ describe 'Restricted licenses' do
   before do
     developer.create_empty_project
     lawyer.execute_command 'license_finder restricted_licenses add BSD'
-    developer.execute_command 'license_finder dependencies add restricted_dep BSD'
+    developer.execute_command 'license_finder dependencies add restricted_dep BSD 1.2'
   end
 
   specify 'prevent packages from being approved' do

--- a/features/features/report/html_spec.rb
+++ b/features/features/report/html_spec.rb
@@ -37,8 +37,8 @@ describe 'HTML report' do
 
   specify 'shows approval status of dependencies' do
     developer.create_empty_project
-    developer.execute_command 'license_finder dependencies add gpl_dep GPL'
-    developer.execute_command 'license_finder dependencies add mit_dep MIT'
+    developer.execute_command 'license_finder dependencies add gpl_dep GPL 1.2'
+    developer.execute_command 'license_finder dependencies add mit_dep MIT 2.3'
     developer.execute_command 'license_finder permitted_licenses add MIT'
 
     html = product_owner.view_html

--- a/lib/license_finder/cli/approvals.rb
+++ b/lib/license_finder/cli/approvals.rb
@@ -7,6 +7,7 @@ module LicenseFinder
       include MakesDecisions
 
       auditable
+      approvable
       desc 'add DEPENDENCY...', 'Approve one or more dependencies by name'
       def add(*names)
         assert_some names

--- a/lib/license_finder/cli/dependencies.rb
+++ b/lib/license_finder/cli/dependencies.rb
@@ -8,9 +8,10 @@ module LicenseFinder
 
       method_option :approve, type: :boolean, desc: 'Approve the added dependency'
       method_option :homepage, type: :string, desc: 'Source of the added dependency'
+
       auditable
-      desc 'add DEPENDENCY LICENSE [VERSION] [--homepage=HOMEPAGE] [--approve]', 'Add a dependency that is not managed by a package manager, optionally approving it at the same time'
-      def add(name, license, version = nil)
+      desc 'add DEPENDENCY LICENSE VERSION [--homepage=HOMEPAGE] [--approve]', 'Add a dependency that is not managed by a package manager, optionally approving it at the same time'
+      def add(name, license, version)
         modifying do
           decisions
             .add_package(name, version, txn)

--- a/lib/license_finder/cli/makes_decisions.rb
+++ b/lib/license_finder/cli/makes_decisions.rb
@@ -11,6 +11,9 @@ module LicenseFinder
         def auditable
           method_option :who, desc: 'The person making this decision'
           method_option :why, desc: 'The reason for making this decision'
+        end
+
+        def approvable
           method_option :version, desc: 'The version that will be approved'
         end
       end

--- a/spec/lib/license_finder/cli/dependencies_spec.rb
+++ b/spec/lib/license_finder/cli/dependencies_spec.rb
@@ -24,18 +24,16 @@ module LicenseFinder
           expect(subject.decisions.licenses_of('js_dep')).to eq [License.find_by_name('MIT')].to_set
         end
 
-        it 'does not require a version' do
-          silence_stdout do
+        it 'does require a version' do
+          expect do
             subject.add('js_dep', 'MIT')
-          end
-          package = subject.decisions.packages.first
-          expect(package.version).to be_nil
+          end.to raise_error(ArgumentError)
         end
 
         it 'has an --approve option to approve the added dependency' do
           subject.options = { approve: true, who: 'Julian', why: 'We really need this' }
           silence_stdout do
-            subject.add('js_dep', 'MIT')
+            subject.add('js_dep', 'MIT', '1.2.3')
           end
           approval = subject.decisions.approval_of('js_dep')
           expect(approval.who).to eq 'Julian'
@@ -45,7 +43,7 @@ module LicenseFinder
         it 'has an --approve option to approve the added dependency & version combination' do
           subject.options = { approve: true, who: 'Julian', why: 'We really need this', version: '1.0.0.RELEASE' }
           silence_stdout do
-            subject.add('js_dep', 'MIT')
+            subject.add('js_dep', 'MIT', '1.2.3')
           end
           approval = subject.decisions.approval_of('js_dep', '1.0.0.RELEASE')
           expect(approval.who).to eq 'Julian'
@@ -56,7 +54,7 @@ module LicenseFinder
         it 'has a --homepage=HOMEPAGE option to add a homepage to the added dependency' do
           subject.options = { homepage: 'some-homepage' }
           silence_stdout do
-            subject.add('js_dep', 'MIT')
+            subject.add('js_dep', 'MIT', '1.2.3')
           end
           homepage = subject.decisions.homepage_of('js_dep')
           expect(homepage).to eq 'some-homepage'
@@ -66,7 +64,7 @@ module LicenseFinder
       describe 'remove' do
         it 'removes a dependency' do
           silence_stdout do
-            subject.add('js_dep', 'MIT')
+            subject.add('js_dep', 'MIT', '1.2.3')
             subject.remove('js_dep')
           end
           expect(subject.decisions.packages).to be_empty


### PR DESCRIPTION
Created to address: 
- https://github.com/pivotal/LicenseFinder/issues/223
- https://github.com/pivotal/LicenseFinder/issues/257