### PR TITLE
Fix crash when handling certain python dependencies conditions

### DIFF
--- a/bin/license_finder_pip.py
+++ b/bin/license_finder_pip.py
@@ -15,8 +15,12 @@ except ImportError:
 from pip._vendor import pkg_resources
 from pip._vendor.six import print_
 
-requirements = [pkg_resources.Requirement.parse(str(req.req)) for req
-                in parse_requirements(sys.argv[1], session=PipSession()) if req.req != None]
+reqs = []
+for req in parse_requirements(sys.argv[1], session=PipSession()):
+    if req.req == None or (req.markers != None and not req.markers.evaluate()): continue
+    reqs.append(req)
+
+requirements = [pkg_resources.Requirement.parse(str(req.req)) for req in reqs]
 
 transform = lambda dist: {
         'name': dist.project_name,

--- a/features/features/package_managers/pip_spec.rb
+++ b/features/features/package_managers/pip_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../../support/feature_helper'
+require_relative '../../../lib/license_finder/platform'
 
 describe 'Pip Dependencies' do
   # As a Python developer
@@ -12,5 +13,37 @@ describe 'Pip Dependencies' do
     LicenseFinder::TestingDSL::PipProject.create
     python_developer.run_license_finder
     expect(python_developer).to be_seeing_line 'rsa, 3.1.4, "ASL 2"'
+  end
+
+  context 'when there are platform markers' do
+    context 'when platform markers match the current system OS' do
+      it 'should show up in the report' do
+        platform = if LicenseFinder::Platform.darwin?
+                     'Darwin'
+                   elsif LicenseFinder::Platform.windows?
+                     'Windows'
+                   else
+                     'Linux' # Internal test uses Linux platform
+                   end
+
+        project = LicenseFinder::TestingDSL::PipProject.new
+        project.add_dep_with_platform(platform)
+        project.add_dep
+        project.install
+        python_developer.run_license_finder
+        expect(python_developer).to be_seeing_line 'colorama, 0.3.9, BSD'
+      end
+    end
+
+    context 'when platform markers do not match the current system OS' do
+      it 'should not show up in the report' do
+        project = LicenseFinder::TestingDSL::PipProject.new
+        project.add_dep_with_platform('different-platform')
+        project.add_dep
+        project.install
+        python_developer.run_license_finder
+        expect(python_developer).to_not be_seeing_line 'colorama, 0.3.9, BSD'
+      end
+    end
   end
 end

--- a/features/support/testing_dsl.rb
+++ b/features/support/testing_dsl.rb
@@ -112,6 +112,10 @@ module LicenseFinder
         add_to_file('requirements.txt', 'rsa==3.1.4')
       end
 
+      def add_dep_with_platform(platform)
+        add_to_file('requirements.txt', "colorama==0.3.9;platform_system==\"#{platform}\"")
+      end
+
       def install
         shell_out('pip install -r requirements.txt --user')
       end

--- a/lib/license_finder/package_managers/pip.rb
+++ b/lib/license_finder/package_managers/pip.rb
@@ -65,7 +65,7 @@ module LicenseFinder
         end
       else
         log_errors "LicenseFinder command '#{command}' failed:\n\t#{stderr}"
-        return []
+        []
       end
     end
   end

--- a/lib/license_finder/package_managers/pip.rb
+++ b/lib/license_finder/package_managers/pip.rb
@@ -56,9 +56,16 @@ module LicenseFinder
     private
 
     def pip_output
-      output = `python#{@python_version == '2' ? '' : '3'} #{LicenseFinder::BIN_PATH.join('license_finder_pip.py')} #{detected_package_path}`
-      JSON(output).map do |package|
-        package.values_at('name', 'version', 'dependencies', 'location')
+      command = "python#{@python_version == '2' ? '' : '3'} #{LicenseFinder::BIN_PATH.join('license_finder_pip.py')} #{detected_package_path}"
+      stdout, stderr, status = Cmd.run(command)
+
+      if status.success?
+        JSON(stdout).map do |package|
+          package.values_at('name', 'version', 'dependencies', 'location')
+        end
+      else
+        log_errors "LicenseFinder command '#{command}' failed:\n\t#{stderr}"
+        return []
       end
     end
   end

--- a/spec/lib/license_finder/cli/main_spec.rb
+++ b/spec/lib/license_finder/cli/main_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+
 module LicenseFinder
   module CLI
     describe Main do
@@ -34,9 +35,6 @@ module LicenseFinder
       before do
         logger = double('Logger', info: true, debug: true)
         allow(LicenseFinder::Logger).to receive(:new).and_return(logger)
-      end
-
-      before do
         allow(DecisionsFactory).to receive(:decisions) { decisions }
         allow(DecisionApplier).to receive(:new) { decision_applier }
       end


### PR DESCRIPTION
This fixes two issues:
1. License Finder now exits properly when it fails to find an installed python dependency. Originally, it would crash due to python script license_finder_pip.py would return a non-json response when failing to find a dependency.

2. License Finder now recognizes pip requirement markers. License Finder ignored any pip requirement markers and assumed all dependencies found in the requirement file to be mandatory. This caused issues as certain markers indicated dependencies to be excluded for certain platforms. In turn, License Finder would fail due to wanting to include these excluded dependencies.

Related Issue: https://github.com/pivotal/LicenseFinder/issues/621 
[#170771446]