### PR TITLE
[Fixed] Testing dsl now correctly creates gem project

### DIFF
--- a/features/features/report/diff_spec.rb
+++ b/features/features/report/diff_spec.rb
@@ -166,12 +166,12 @@ describe 'Diff report' do
 
         diff = IO.read(project.project_dir.join('diff.csv'))
         expect(diff).to include("unchanged,bar,2.0.0,GPLv2,#{project1.project_dir}")
-        expect(diff).to include("removed,foo,1.0.0,MIT,\"#{project1.project_dir},#{project2.project_dir}\"")
-        expect(diff).to include("added,foo,2.0.0,BSD,\"#{project1.project_dir},#{project2.project_dir}\"")
+        expect(diff).to include("unchanged,foo,1.0.0,MIT,#{project2.project_dir}")
+        expect(diff).to include("added,foo,2.0.0,BSD,#{project1.project_dir}")
         expect(diff).to include("added,baz,3.0.0,BSD,#{project2.project_dir}")
       end
 
-      xspecify 'show licenses change when files do not contain exact copies of a dep' do
+      specify 'show licenses change when files do not contain exact copies of a dep' do
         project = developer.create_empty_project
         # First multi-project report
         project1 = developer.create_ruby_app('project_1')
@@ -193,10 +193,7 @@ describe 'Diff report' do
 
         diff = IO.read(project.project_dir.join('diff.csv'))
         expect(diff).to include("removed,foo,1.0.0,MIT,#{project1.project_dir}")
-        # expect(diff).to include("removed,foo,,2.0.0,BSD,#{project2.project_dir}")
-        expect(diff).to include("added,foo,2.0.0,BSD,\"#{project1.project_dir},#{project2.project_dir}\"")
-        expect(diff).to include("removed,foo,1.0.0,BSD,\"#{project1.project_dir},#{project2.project_dir}\"")
-
+        expect(diff).to include("unchanged,foo,2.0.0,BSD,\"#{project1.project_dir},#{project2.project_dir}\"")
         expect(diff).to include("unchanged,bar,2.0.0,GPLv2,#{project1.project_dir}")
         expect(diff).to include("added,baz,3.0.0,BSD,#{project2.project_dir}")
       end


### PR DESCRIPTION
An old feature test was being skipped as test behaviour and actual cli behaviour were different for `license_finder diff`.
This behaviour was caused because during feature test, gem for a project was being overwritten by a gem for another project when they had same gem name .
Testing dsl now takes gem version into account upon creation to avoid unwanted deletion of gem.

[#170772369]