### PR TITLE
Add shim to inject gradle plugin for all projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+### Added
+* Install `license-gradle-plugin` via a `gradle` init script.- [ef275df](https://github.com/pivotal/LicenseFinder/pull/681/commits/ef275df186be31f7c2adef2408c0ccc72bff234a) - mokhan
+
 # [6.1.0] / 2020-02-21
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,7 @@ RUN curl -L -o gradle.zip https://services.gradle.org/distributions/gradle-$GRAD
     unzip -q gradle.zip && \
     rm gradle.zip && \
     mv gradle-$GRADLE_VERSION /root/gradle
+COPY config/.gradle /root/.gradle
 ENV PATH=/root/gradle/bin:$PATH
 
 #install go

--- a/config/.gradle/init.gradle
+++ b/config/.gradle/init.gradle
@@ -1,0 +1,14 @@
+initscript {
+  repositories {
+    maven {
+      url "https://plugins.gradle.org/m2/"
+    }
+  }
+  dependencies {
+    classpath "gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.15.0"
+  }
+}
+allprojects {
+  project.apply plugin: com.hierynomus.gradle.license.LicenseBasePlugin
+  project.apply plugin: com.hierynomus.gradle.license.LicenseReportingPlugin
+}

--- a/features/fixtures/kts-build-file-gradle/build.gradle.kts
+++ b/features/fixtures/kts-build-file-gradle/build.gradle.kts
@@ -4,7 +4,6 @@ gradle.startParameter.excludedTaskNames += "licenseTest"
 plugins {
     application
     kotlin("jvm") version "1.2.61"
-    id ("com.github.hierynomus.license") version "0.15.0"
 }
 
 application {


### PR DESCRIPTION
For `gradle` projects, LicenseFinder depends on the [license-gradle-plugin](https://github.com/hierynomus/license-gradle-plugin). If a project author does not add this plugin to the gradle build plugins then LicenseFinder is unable to scan the gradle project.

The change in this PR, inserts a `~/.gradle/init.gradle` which inserts a hook to install the plugin without requiring the gradle project to explicitly add it to their plugins list. The effect of this change is that the docker image is then able to scan gradle projects that do not include this plugin.

Documentation on using gradle initialization scripts can be found [here](https://docs.gradle.org/current/userguide/init_scripts.html#sec:using_an_init_script).

It's a little bit difficult for me to add a unit/integration/feature test because this change is dependent on running the test suite in the context of the docker image. I'm open to suggestions on how to add a test for this change.