### PR TITLE
[FIXED] Replace toml parser with tomlrb

### DIFF
--- a/features/features/report/composite_spec.rb
+++ b/features/features/report/composite_spec.rb
@@ -24,6 +24,6 @@ describe 'Composite project' do
     project = LicenseFinder::TestingDSL::BundlerProject.create
     project.install
     developer.execute_command('license_finder report --recursive --format csv --columns name version install_path licenses')
-    expect(developer).to be_seeing_something_like(%r{toml,0.\d+.\d+,.*\/gems\/toml-0.\d+.\d+,MIT})
+    expect(developer).to be_seeing_something_like(%r{tomlrb,1.\d+.\d+,.*\/gems\/tomlrb-1.\d+.\d+,MIT})
   end
 end

--- a/features/support/testing_dsl.rb
+++ b/features/support/testing_dsl.rb
@@ -482,7 +482,7 @@ module LicenseFinder
     class BundlerProject < Project
       def add_dep
         add_to_gemfile("source 'https://rubygems.org'")
-        add_to_gemfile("gem 'license_finder'")
+        add_to_gemfile("gem 'license_finder', path: #{Paths.root.to_s.inspect}")
       end
 
       def install

--- a/lib/license_finder/package_managers/dep.rb
+++ b/lib/license_finder/package_managers/dep.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'toml'
+require 'tomlrb'
 
 module LicenseFinder
   class Dep < PackageManager
@@ -9,7 +9,7 @@ module LicenseFinder
     end
 
     def current_packages
-      toml = TOML.load_file(detected_package_path)
+      toml = Tomlrb.load_file(detected_package_path)
       projects = toml['projects']
 
       return [] if projects.nil?

--- a/license_finder.gemspec
+++ b/license_finder.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'bundler'
   s.add_dependency 'rubyzip', '>=1', '<3'
   s.add_dependency 'thor', '~> 1.0.1'
-  s.add_dependency 'toml', '0.2.0'
+  s.add_dependency 'tomlrb', '~> 1.3.0'
   s.add_dependency 'with_env', '1.1.0'
   s.add_dependency 'xml-simple', '~> 1.1.5'
 

--- a/spec/lib/license_finder/package_managers/dep_spec.rb
+++ b/spec/lib/license_finder/package_managers/dep_spec.rb
@@ -33,7 +33,7 @@ module LicenseFinder
 
       context 'the package does not have any projects in its toml' do
         before do
-          allow(TOML).to receive(:load_file).and_return({})
+          allow(Tomlrb).to receive(:load_file).and_return({})
         end
 
         it 'should return an empty array' do


### PR DESCRIPTION
The toml gem depends on an old version of parslet, which can cause conflicts if license_finder is included in a Gemfile. On the other hand, tomlrb has no extra dependencies and seems more maintained.