### PR TITLE
[Changed] Run glide install in folder containing glide.lock

### DIFF
--- a/features/features/package_managers/glide_spec.rb
+++ b/features/features/package_managers/glide_spec.rb
@@ -7,22 +7,35 @@ describe 'Glide Dependencies' do
 
   context 'when project is in src directory' do
     specify 'are shown in reports for a project' do
-      project = LicenseFinder::TestingDSL::GlideProject.create
-      ENV['GOPATH'] = "#{project.project_dir}/gopath_glide"
+      LicenseFinder::TestingDSL::GlideProject.create
 
-      go_developer.run_license_finder('gopath_glide')
+      go_developer.run_license_finder('src/gopath_glide/src')
       expect(go_developer).to be_seeing_line 'github.com/Masterminds/semver, 517734cc7d6470c0d07130e40fd40bdeb9bcd3fd, MIT'
       expect(go_developer).to be_seeing_line 'github.com/Masterminds/cookoo, 78aa11ce75e257c51be7ea945edb84cf19c4a6de, MIT'
     end
   end
 
-  context 'when projecy is not in src directory' do
+  context 'when project in root directory' do
     specify 'are shown in reports for a project' do
       LicenseFinder::TestingDSL::GlideProjectWithoutSrc.create
 
-      go_developer.run_license_finder('gopath_glide_without_src')
+      go_developer.run_license_finder('src/gopath_glide_without_src')
       expect(go_developer).to be_seeing_line 'github.com/Masterminds/semver, 517734cc7d6470c0d07130e40fd40bdeb9bcd3fd, MIT'
       expect(go_developer).to be_seeing_line 'github.com/Masterminds/cookoo, 78aa11ce75e257c51be7ea945edb84cf19c4a6de, MIT'
+    end
+  end
+
+  context 'when project in both root and src directory' do
+    specify 'are shown in reports for a project' do
+      LicenseFinder::TestingDSL::GlideProjectWithRootAndSrc.create
+
+      go_developer.run_license_finder('src/gopath_glide_in_root_and_src')
+      expect(go_developer).to be_seeing_line 'github.com/Masterminds/semver, 517734cc7d6470c0d07130e40fd40bdeb9bcd3fd, MIT'
+      expect(go_developer).to be_seeing_line 'github.com/Masterminds/cookoo, 78aa11ce75e257c51be7ea945edb84cf19c4a6de, MIT'
+
+      go_developer.run_license_finder('src/gopath_glide_in_root_and_src/src')
+      expect(go_developer).to be_seeing_line 'github.com/googollee/go-socket.io, 5447e71f36d394766bf855d5714a487596809f0d, unknown'
+      expect(go_developer).to be_seeing_line 'github.com/gorilla/mux, bcd8bc72b08df0f70df986b97f95590779502d31, "New BSD"'
     end
   end
 end

--- a/features/fixtures/gopath_glide_in_root_and_src/glide.lock
+++ b/features/fixtures/gopath_glide_in_root_and_src/glide.lock
@@ -1,0 +1,9 @@
+hash: 4765849129e9fbb9f7ebc620df51f27b6999f1a06bba4ecf92193ffffcf1d684
+updated: 2017-09-27T22:42:02.817609367Z
+imports:
+- name: github.com/Masterminds/cookoo
+  version: 78aa11ce75e257c51be7ea945edb84cf19c4a6de
+  repo: https://github.com/Masterminds/cookoo.git
+- name: github.com/Masterminds/semver
+  version: 517734cc7d6470c0d07130e40fd40bdeb9bcd3fd
+testImports: []

--- a/features/fixtures/gopath_glide_in_root_and_src/glide.yaml
+++ b/features/fixtures/gopath_glide_in_root_and_src/glide.yaml
@@ -1,0 +1,6 @@
+package: github.com/Masterminds/glide
+import:
+  - package: github.com/Masterminds/semver
+  - package: github.com/Masterminds/cookoo
+    version: ^1.2.0
+    repo: https://github.com/Masterminds/cookoo.git

--- a/features/fixtures/gopath_glide_in_root_and_src/src/glide.lock
+++ b/features/fixtures/gopath_glide_in_root_and_src/src/glide.lock
@@ -1,0 +1,8 @@
+hash: 4765849129e9fbb9f7ebc620df51f27b6999f1a06bba4ecf92193ffffcf1d684
+updated: 2017-09-27T22:42:02.817609367Z
+imports:
+- name: github.com/googollee/go-socket.io
+  version: 5447e71f36d394766bf855d5714a487596809f0d
+- name: github.com/gorilla/mux
+  version: bcd8bc72b08df0f70df986b97f95590779502d31
+testImports: []

--- a/features/fixtures/gopath_glide_in_root_and_src/src/glide.yaml
+++ b/features/fixtures/gopath_glide_in_root_and_src/src/glide.yaml
@@ -1,0 +1,5 @@
+package: github.com/Masterminds/glide
+import:
+  - package: github.com/googollee/go-socket.io
+  - package: github.com/gorilla/mux
+    version: ^1.4.0

--- a/features/support/testing_dsl.rb
+++ b/features/support/testing_dsl.rb
@@ -98,6 +98,10 @@ module LicenseFinder
         Paths.project(name)
       end
 
+      def cloneGoProject(fixture_name)
+        FileUtils.mkpath(Paths.project.join('src', fixture_name))
+        FileUtils.cp_r(Paths.fixtures.join(fixture_name), Paths.project.join('src')) end
+
       def clone(fixture_name)
         FileUtils.mkpath(Paths.project.join(fixture_name))
         FileUtils.cp_r(Paths.fixtures.join(fixture_name), Paths.project)
@@ -281,40 +285,58 @@ module LicenseFinder
 
     class GlideProject < Project
       def add_dep
-        clone('gopath_glide')
+        cloneGoProject('gopath_glide')
       end
 
       def install
         orig_gopath = ENV['GOPATH']
-        ENV['GOPATH'] = "#{project_dir}/gopath_glide"
+        ENV['GOPATH'] = "#{project_dir}"
         shell_out('glide install')
         ENV['GOPATH'] = orig_gopath
       end
 
       def shell_out(command)
-        ProjectDir.new(Paths.project.join('gopath_glide', 'src')).shell_out(command)
+        ProjectDir.new(Paths.project.join('src', 'gopath_glide', 'src')).shell_out(command)
       end
     end
 
     class GlideProjectWithoutSrc < Project
       def add_dep
-        clone('gopath_glide_without_src')
+        cloneGoProject('gopath_glide_without_src')
       end
 
       def install
-        src_path = File.join(project_dir, 'gopath_glide_without_src', 'src')
-        FileUtils.mkdir_p(src_path)
-
         orig_gopath = ENV['GOPATH']
-        ENV['GOPATH'] = "#{project_dir}/gopath_glide_without_src"
+        ENV['GOPATH'] = "#{project_dir}"
         shell_out('glide install')
         ENV['GOPATH'] = orig_gopath
-
-        FileUtils.rmdir(src_path)
       end
 
       def shell_out(command)
-        ProjectDir.new(Paths.project.join('gopath_glide_without_src')).shell_out(command)
+        ProjectDir.new(Paths.project.join('src', 'gopath_glide_without_src')).shell_out(command)
+      end
+    end
+
+
+    class GlideProjectWithRootAndSrc < Project
+      def add_dep
+        cloneGoProject('gopath_glide_in_root_and_src')
+      end
+
+      def install
+        orig_gopath = ENV['GOPATH']
+        ENV['GOPATH'] = "#{project_dir}"
+        shell_out_root('glide install')
+        shell_out_src('glide install')
+        ENV['GOPATH'] = orig_gopath
+      end
+
+      def shell_out_root(command)
+        ProjectDir.new(Paths.project.join('src', 'gopath_glide_in_root_and_src')).shell_out(command)
+      end
+
+      def shell_out_src(command)
+        ProjectDir.new(Paths.project.join('src', 'gopath_glide_in_root_and_src', 'src')).shell_out(command)
       end
     end
 

--- a/features/support/testing_dsl.rb
+++ b/features/support/testing_dsl.rb
@@ -98,9 +98,10 @@ module LicenseFinder
         Paths.project(name)
       end
 
-      def cloneGoProject(fixture_name)
+      def clone_go_project(fixture_name)
         FileUtils.mkpath(Paths.project.join('src', fixture_name))
-        FileUtils.cp_r(Paths.fixtures.join(fixture_name), Paths.project.join('src')) end
+        FileUtils.cp_r(Paths.fixtures.join(fixture_name), Paths.project.join('src'))
+      end
 
       def clone(fixture_name)
         FileUtils.mkpath(Paths.project.join(fixture_name))
@@ -285,12 +286,12 @@ module LicenseFinder
 
     class GlideProject < Project
       def add_dep
-        cloneGoProject('gopath_glide')
+        clone_go_project('gopath_glide')
       end
 
       def install
         orig_gopath = ENV['GOPATH']
-        ENV['GOPATH'] = "#{project_dir}"
+        ENV['GOPATH'] = project_dir.to_s
         shell_out('glide install')
         ENV['GOPATH'] = orig_gopath
       end
@@ -302,12 +303,12 @@ module LicenseFinder
 
     class GlideProjectWithoutSrc < Project
       def add_dep
-        cloneGoProject('gopath_glide_without_src')
+        clone_go_project('gopath_glide_without_src')
       end
 
       def install
         orig_gopath = ENV['GOPATH']
-        ENV['GOPATH'] = "#{project_dir}"
+        ENV['GOPATH'] = project_dir.to_s
         shell_out('glide install')
         ENV['GOPATH'] = orig_gopath
       end
@@ -317,15 +318,14 @@ module LicenseFinder
       end
     end
 
-
     class GlideProjectWithRootAndSrc < Project
       def add_dep
-        cloneGoProject('gopath_glide_in_root_and_src')
+        clone_go_project('gopath_glide_in_root_and_src')
       end
 
       def install
         orig_gopath = ENV['GOPATH']
-        ENV['GOPATH'] = "#{project_dir}"
+        ENV['GOPATH'] = project_dir.to_s
         shell_out_root('glide install')
         shell_out_src('glide install')
         ENV['GOPATH'] = orig_gopath

--- a/lib/license_finder/package_managers/glide.rb
+++ b/lib/license_finder/package_managers/glide.rb
@@ -3,7 +3,7 @@
 module LicenseFinder
   class Glide < PackageManager
     def possible_package_paths
-      [project_path.join('src', 'glide.lock'), project_path.join('glide.lock')]
+      [project_path.join('glide.lock')]
     end
 
     def current_packages
@@ -11,12 +11,7 @@ module LicenseFinder
 
       YAML.load_file(detected_path).fetch('imports').map do |package_hash|
         import_path = package_hash.fetch('name')
-        license_path =
-          if detected_path == possible_package_paths.first
-            project_path.join('src', 'vendor', import_path)
-          else
-            project_path.join('vendor', import_path)
-          end
+        license_path = project_path.join('vendor', import_path)
 
         GoPackage.from_dependency({
                                     'ImportPath' => import_path,

--- a/spec/lib/license_finder/package_managers/glide_spec.rb
+++ b/spec/lib/license_finder/package_managers/glide_spec.rb
@@ -23,7 +23,7 @@ module LicenseFinder
       it 'should return inactive' do
         FakeFS.with_fresh do
           FileUtils.mkdir_p '/app'
-          File.write(Pathname('/app/glide.lock').to_s, '')
+
           expect(subject.active?).to be_falsey
         end
       end


### PR DESCRIPTION
When glide.lock file is located inside src sub directory, run glide
install in that directory instead of project root directory.

[#171957675]