### PR TITLE
 #715 LicenseFinder does not report Groups for Maven package manager

### DIFF
--- a/lib/license_finder/packages/maven_package.rb
+++ b/lib/license_finder/packages/maven_package.rb
@@ -10,7 +10,8 @@ module LicenseFinder
         name,
         spec['version'],
         options.merge(
-          spec_licenses: Array(spec['licenses']).map { |l| l['name'] }
+          spec_licenses: Array(spec['licenses']).map { |l| l['name'] },
+          groups: Array(spec['groupId'])
         )
       )
     end

--- a/spec/lib/license_finder/package_managers/maven_package_spec.rb
+++ b/spec/lib/license_finder/package_managers/maven_package_spec.rb
@@ -22,7 +22,7 @@ module LicenseFinder
     its(:summary) { should == '' }
     its(:description) { should == '' }
     its(:homepage) { should == '' }
-    its(:groups) { should == ["org.hamcrest"] } # no way to get groups from maven?
+    its(:groups) { should == ['org.hamcrest'] } # no way to get groups from maven?
     its(:children) { should == [] } # no way to get children from maven?
     its(:install_path) { should be_nil }
     its(:package_manager) { should eq 'Maven' }

--- a/spec/lib/license_finder/package_managers/maven_package_spec.rb
+++ b/spec/lib/license_finder/package_managers/maven_package_spec.rb
@@ -22,7 +22,7 @@ module LicenseFinder
     its(:summary) { should == '' }
     its(:description) { should == '' }
     its(:homepage) { should == '' }
-    its(:groups) { should == [] } # no way to get groups from maven?
+    its(:groups) { should == ["org.hamcrest"] } # no way to get groups from maven?
     its(:children) { should == [] } # no way to get children from maven?
     its(:install_path) { should be_nil }
     its(:package_manager) { should eq 'Maven' }


### PR DESCRIPTION
After Fixing this code CSV report output prints Groups info with --columns=groups
