### PR TITLE
GoModules: fix compute with vendor mod

### DIFF
--- a/lib/license_finder/package_managers/go_modules.rb
+++ b/lib/license_finder/package_managers/go_modules.rb
@@ -23,7 +23,7 @@ module LicenseFinder
     def current_packages
       packages = packages_info.map do |package|
         name, version, install_path = package.split(',')
-        read_package(install_path, name, version) if install_path.to_s != ""
+        read_package(install_path, name, version) if install_path.to_s != ''
       end.compact
       packages.reject do |package|
         Pathname(package.install_path).cleanpath == Pathname(project_path).cleanpath
@@ -34,9 +34,7 @@ module LicenseFinder
 
     def packages_info
       info_output, stderr, _status = Cmd.run("GO111MODULE=on go list -m -mod=vendor -f '{{.Path}},{{.Version}},{{.Dir}}' all")
-      if stderr =~ Regexp.compile("can't compute 'all' using the vendor directory")
-        info_output, _stderr, _status = Cmd.run("GO111MODULE=on go list -m -f '{{.Path}},{{.Version}},{{.Dir}}' all")
-      end
+      info_output, _stderr, _status = Cmd.run("GO111MODULE=on go list -m -f '{{.Path}},{{.Version}},{{.Dir}}' all") if stderr =~ Regexp.compile("can't compute 'all' using the vendor directory")
 
       info_output.split("\n")
     end

--- a/lib/license_finder/package_managers/go_modules.rb
+++ b/lib/license_finder/package_managers/go_modules.rb
@@ -21,18 +21,25 @@ module LicenseFinder
     end
 
     def current_packages
-      info_output, _stderr, _status = Cmd.run("GO111MODULE=on go list -m -mod=vendor -f '{{.Path}},{{.Version}},{{.Dir}}' all")
-      packages_info = info_output.split("\n")
       packages = packages_info.map do |package|
         name, version, install_path = package.split(',')
-        read_package(install_path, name, version)
-      end
+        read_package(install_path, name, version) if install_path.to_s != ""
+      end.compact
       packages.reject do |package|
         Pathname(package.install_path).cleanpath == Pathname(project_path).cleanpath
       end
     end
 
     private
+
+    def packages_info
+      info_output, stderr, _status = Cmd.run("GO111MODULE=on go list -m -mod=vendor -f '{{.Path}},{{.Version}},{{.Dir}}' all")
+      if stderr =~ Regexp.compile("can't compute 'all' using the vendor directory")
+        info_output, _stderr, _status = Cmd.run("GO111MODULE=on go list -m -f '{{.Path}},{{.Version}},{{.Dir}}' all")
+      end
+
+      info_output.split("\n")
+    end
 
     def sum_files?
       sum_file_paths.any?

--- a/spec/lib/license_finder/package_managers/go_modules_spec.rb
+++ b/spec/lib/license_finder/package_managers/go_modules_spec.rb
@@ -57,8 +57,12 @@ module LicenseFinder
 
       context 'when compute is not allowed on vendor' do
         before do
-          allow(SharedHelpers::Cmd).to receive(:run).with("GO111MODULE=on go list -m -mod=vendor -f '{{.Path}},{{.Version}},{{.Dir}}' all").and_return(["", "go list -m: can't compute 'all' using the vendor directory\n\t(Use -mod=mod or -mod=readonly to bypass.)\n", 1])
-          allow(SharedHelpers::Cmd).to receive(:run).with("GO111MODULE=on go list -m -f '{{.Path}},{{.Version}},{{.Dir}}' all").and_return(go_list_string)
+          allow(SharedHelpers::Cmd).to receive(:run)
+            .with("GO111MODULE=on go list -m -mod=vendor -f '{{.Path}},{{.Version}},{{.Dir}}' all")
+            .and_return(['', "go list -m: can't compute 'all' using the vendor directory\n\t(Use -mod=mod or -mod=readonly to bypass.)\n", 1])
+          allow(SharedHelpers::Cmd).to receive(:run)
+            .with("GO111MODULE=on go list -m -f '{{.Path}},{{.Version}},{{.Dir}}' all")
+            .and_return(go_list_string)
         end
 
         it 'finds all the packages all go.sum files' do


### PR DESCRIPTION
We get a compute error for GoModules when `vendor` mod is given. 
Go version used: `go version go1.14.2 linux/amd64`

> go list -m: can't compute 'all' using the vendor directory
(Use -mod=mod or -mod=readonly to bypass.)

By simply not use the `mod` parameter everything works fine.
I thought handling the error might be better if the current solution works for others but when it comes to the same issue the fallback will be used.