### PR TITLE
License: Change pretty name of WTFPL

### DIFF
--- a/lib/license_finder/license/definitions.rb
+++ b/lib/license_finder/license/definitions.rb
@@ -294,9 +294,10 @@ module LicenseFinder
       def wtfpl
         License.new(
           short_name: 'WTFPL',
-          pretty_name: 'Do What The Fuck You Want To Public License',
+          pretty_name: 'WTFPL',
           other_names: [
-            'WTFPL V2'
+            'WTFPL V2',
+            'Do What The Fuck You Want To Public License'
           ],
           url: 'http://www.wtfpl.net/'
         )

--- a/spec/lib/license_finder/license/definitions_spec.rb
+++ b/spec/lib/license_finder/license/definitions_spec.rb
@@ -192,6 +192,7 @@ end
 
 describe LicenseFinder::License, 'WTFPL' do
   it 'should be recognized' do
+    expect(described_class.find_by_name('WTFPL').name).to eq('WTFPL')
     expect(described_class.find_by_name('WTFPL').url).to be
     expect(described_class.find_by_name('WTFPL V2').url).to be
     expect(described_class.find_by_name('Do What The Fuck You Want To Public License').url).to be


### PR DESCRIPTION
License name should be short version WTFPL
instead of long version (Do What the Fuck You Want To Public License)

Sorry for that mistake in introduction, but when it comes to printing reports (e.g. csv) it should
use short version as it does for the others.