### PR TITLE
Go15VendorExperiment: Detect go only if vendor includes go files

### DIFF
--- a/lib/license_finder/package_managers/go_15vendorexperiment.rb
+++ b/lib/license_finder/package_managers/go_15vendorexperiment.rb
@@ -14,7 +14,7 @@ module LicenseFinder
     end
 
     def go_files_exist?
-      !Dir[project_path.join('**/*.go')].empty?
+      !Dir[project_path.join('**/*.go')].empty? && !Dir[project_path.join('vendor/**/*.go')].empty?
     end
 
     def possible_package_paths

--- a/spec/lib/license_finder/package_managers/go_15vendorexperiment_spec.rb
+++ b/spec/lib/license_finder/package_managers/go_15vendorexperiment_spec.rb
@@ -37,6 +37,7 @@ module LicenseFinder
         FileUtils.touch File.join(project_path, 'main.go')
         FileUtils.mkdir_p File.join(project_path, 'vendor', 'github.com', 'foo', 'bar')
         FileUtils.mkdir_p File.join(project_path, 'vendor', 'golang.org', 'bar', 'baz')
+        FileUtils.touch File.join(project_path, 'vendor', 'github.com', 'foo', 'bar', 'utils.go')
       end
 
       it 'detects the project as go vendor project' do


### PR DESCRIPTION
I don't think it is necessary to detect `Go15VendorExperiment` when there are go files in the project but no go files in the vendor folder. We do have this case because we have a little tiny go script in scripts folder but our default vendor rails folder. And there should only be vendor go dependencies if there are go files in the vendor folder I believe.

This adjustment will solve this issue we have in one project and keep the functionality in another where we have go files and a go vendor folder.