### PR TITLE
CSV: Add --write-headers option for csv exports

### DIFF
--- a/lib/license_finder/cli/base.rb
+++ b/lib/license_finder/cli/base.rb
@@ -44,6 +44,7 @@ module LicenseFinder
           :elixir_command,
           :mix_command,
           :mix_deps_dir,
+          :write_headers,
           :save,
           :prepare,
           :prepare_no_fail,

--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -140,6 +140,7 @@ module LicenseFinder
       desc 'report', "Print a report of the project's dependencies to stdout"
       shared_options
       format_option
+      method_option :write_headers, type: :boolean, desc: 'Write exported columns as header row (csv).', default: false, required: false
       method_option :save, desc: "Save report to a file. Default: 'license_report.csv' in project root.", lazy_default: 'license_report'
 
       def report
@@ -203,7 +204,7 @@ module LicenseFinder
       def report_of(content)
         report = FORMATS[config.format] || FORMATS['text']
         report = MergedReport if report == CsvReport && config.aggregate_paths
-        report.of(content, columns: config.columns, project_name: decisions.project_name || config.project_path.basename.to_s)
+        report.of(content, columns: config.columns, project_name: decisions.project_name || config.project_path.basename.to_s, write_headers: config.write_headers)
       end
 
       def save?

--- a/lib/license_finder/configuration.rb
+++ b/lib/license_finder/configuration.rb
@@ -109,6 +109,10 @@ module LicenseFinder
       get(:prepare_no_fail)
     end
 
+    def write_headers
+      get(:write_headers)
+    end
+
     def save_file
       get(:save)
     end

--- a/lib/license_finder/reports/csv_report.rb
+++ b/lib/license_finder/reports/csv_report.rb
@@ -10,10 +10,11 @@ module LicenseFinder
       super
       options[:columns] ||= %w[name version licenses]
       @columns = Array(options[:columns]) & self.class::AVAILABLE_COLUMNS
+      @write_headers = options[:write_headers] || false
     end
 
     def to_s
-      CSV.generate(col_sep: self.class::COMMA_SEP) do |csv|
+      CSV.generate(col_sep: self.class::COMMA_SEP, headers: @columns, write_headers: @write_headers) do |csv|
         sorted_dependencies.each do |s|
           csv << format_dependency(s)
         end

--- a/spec/lib/license_finder/cli/main_spec.rb
+++ b/spec/lib/license_finder/cli/main_spec.rb
@@ -93,7 +93,7 @@ module LicenseFinder
 
         it 'passes the config options to the new LicenseFinder::LicenseAggregator instance' do
           stubs = { valid_project_path?: true, project_path: Pathname('../other_project'),
-                    decisions_file_path: Pathname('../other_project'), aggregate_paths: nil, recursive: false, format: nil, columns: nil, strict_matching: false }
+                    decisions_file_path: Pathname('../other_project'), aggregate_paths: nil, recursive: false, format: nil, columns: nil, strict_matching: false, write_headers: false }
           configuration = double(:configuration, stubs)
           allow(LicenseFinder::Configuration).to receive(:with_optional_saved_config).and_return(configuration)
           expect(LicenseFinder::LicenseAggregator).to receive(:new).with(configuration, anything).and_return(license_finder_instance)

--- a/spec/lib/license_finder/reports/csv_report_spec.rb
+++ b/spec/lib/license_finder/reports/csv_report_spec.rb
@@ -10,6 +10,12 @@ module LicenseFinder
       expect(subject.to_s).to eq("gem_a,1.0\n")
     end
 
+    it 'accepts write headers option' do
+      dep = Package.new('gem_a', '1.0')
+      subject = described_class.new([dep], columns: %w[name version], write_headers: true)
+      expect(subject.to_s).to eq("name,version\ngem_a,1.0\n")
+    end
+
     it 'understands many columns' do
       dep = Package.new('gem_a', '1.0', authors: 'the authors', description: 'A description', summary: 'A summary', homepage: 'http://homepage.example.com')
       dep.decide_on_license(License.find_by_name('MIT'))


### PR DESCRIPTION
This will enable a header row within csv exports naming
exported columns