### PR TITLE
Decision Applier: Merge manual and system packages

### DIFF
--- a/lib/license_finder/decision_applier.rb
+++ b/lib/license_finder/decision_applier.rb
@@ -4,7 +4,7 @@ module LicenseFinder
   class DecisionApplier
     def initialize(options)
       @decisions = options.fetch(:decisions)
-      @all_packages = decisions.packages + options.fetch(:packages)
+      @all_packages = options.fetch(:packages).to_set + @decisions.packages.to_set
       @acknowledged = apply_decisions
     end
 
@@ -28,10 +28,14 @@ module LicenseFinder
 
     def apply_decisions
       all_packages
-        .map { |package| with_decided_licenses(package) }
-        .map { |package| with_approval(package) }
-        .map { |package| with_homepage(package) }
         .reject { |package| ignored?(package) }
+        .map do |package|
+          with_homepage(
+            with_approval(
+              with_decided_licenses(package)
+            )
+          )
+        end
     end
 
     def ignored?(package)

--- a/spec/lib/license_finder/decision_applier_spec.rb
+++ b/spec/lib/license_finder/decision_applier_spec.rb
@@ -15,6 +15,15 @@ module LicenseFinder
     describe '#acknowledged' do
       it 'combines manual and system packages' do
         decision_applier = described_class.new(
+          decisions: Decisions.new.add_package('system', nil).license('system', 'MIT'),
+          packages: [Package.new('system', '1.0.0')]
+        )
+        package = decision_applier.acknowledged.first
+        expect([package.name, package.version, package.licenses.first.name]).to match_array %w[system 1.0.0 MIT]
+      end
+
+      it 'merges manual packages with system packages' do
+        decision_applier = described_class.new(
           decisions: Decisions.new.add_package('manual', nil),
           packages: [Package.new('system')]
         )


### PR DESCRIPTION
This will enable merging manual added dependencies with
detected dependencies. This is usefull if a package will
be detected but e.g. license information is missing.
This change will use data from decision (homepage, approval, license)
and apply it to system package matching the manual one.
Currently manual decisions override the whole system package
which results in losing information (e.g. package_manager)