### PR TITLE
Package: add package url

### DIFF
--- a/lib/license_finder/package.rb
+++ b/lib/license_finder/package.rb
@@ -43,6 +43,7 @@ module LicenseFinder
       @summary = options[:summary] || ''
       @description = options[:description] || ''
       @homepage = options[:homepage] || ''
+      @package_url = options[:package_url] || ''
       @children = options[:children] || []
       @parents = Set.new # will be figured out later by package manager
       @groups = options[:groups] || []
@@ -61,7 +62,7 @@ module LicenseFinder
 
     ## DESCRIPTION
 
-    attr_accessor :homepage
+    attr_accessor :homepage, :package_url
 
     attr_reader :name, :version, :authors,
                 :summary, :description,

--- a/lib/license_finder/package.rb
+++ b/lib/license_finder/package.rb
@@ -43,7 +43,7 @@ module LicenseFinder
       @summary = options[:summary] || ''
       @description = options[:description] || ''
       @homepage = options[:homepage] || ''
-      @package_url = options[:package_url] || ''
+      @package_url = options[:package_url].to_s
       @children = options[:children] || []
       @parents = Set.new # will be figured out later by package manager
       @groups = options[:groups] || []

--- a/lib/license_finder/packages/bower_package.rb
+++ b/lib/license_finder/packages/bower_package.rb
@@ -31,5 +31,9 @@ module LicenseFinder
     def package_manager
       'Bower'
     end
+
+    def package_url
+      "https://bower.io/search/?q=#{name}"
+    end
   end
 end

--- a/lib/license_finder/packages/bower_package.rb
+++ b/lib/license_finder/packages/bower_package.rb
@@ -33,7 +33,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://bower.io/search/?q=#{URI.escape(name)}"
+      "https://bower.io/search/?q=#{CGI.escape(name)}"
     end
   end
 end

--- a/lib/license_finder/packages/bower_package.rb
+++ b/lib/license_finder/packages/bower_package.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'open-uri'
+
 module LicenseFinder
   class BowerPackage < Package
     def initialize(bower_module, options = {})
@@ -33,7 +35,8 @@ module LicenseFinder
     end
 
     def package_url
-      "https://bower.io/search/?q=#{CGI.escape(name)}"
+      meta = JSON.parse(open("https://registry.bower.io/packages/#{CGI.escape(name)}").read)
+      meta['url']
     end
   end
 end

--- a/lib/license_finder/packages/bower_package.rb
+++ b/lib/license_finder/packages/bower_package.rb
@@ -33,7 +33,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://bower.io/search/?q=#{name}"
+      "https://bower.io/search/?q=#{URI.escape(name)}"
     end
   end
 end

--- a/lib/license_finder/packages/bundler_package.rb
+++ b/lib/license_finder/packages/bundler_package.rb
@@ -27,7 +27,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://rubygems.org/gems/#{URI.escape(name)}/versions/#{URI.escape(version)}"
+      "https://rubygems.org/gems/#{CGI.escape(name)}/versions/#{CGI.escape(version)}"
     end
   end
 end

--- a/lib/license_finder/packages/bundler_package.rb
+++ b/lib/license_finder/packages/bundler_package.rb
@@ -27,7 +27,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://rubygems.org/gems/#{name}/versions/#{version}"
+      "https://rubygems.org/gems/#{URI.escape(name)}/versions/#{URI.escape(version)}"
     end
   end
 end

--- a/lib/license_finder/packages/bundler_package.rb
+++ b/lib/license_finder/packages/bundler_package.rb
@@ -25,5 +25,9 @@ module LicenseFinder
     def package_manager
       'Bundler'
     end
+
+    def package_url
+      "https://rubygems.org/gems/#{name}/versions/#{version}"
+    end
   end
 end

--- a/lib/license_finder/packages/cargo_package.rb
+++ b/lib/license_finder/packages/cargo_package.rb
@@ -20,5 +20,9 @@ module LicenseFinder
     def package_manager
       'Cargo'
     end
+
+    def package_url
+      "https://crates.io/crates/#{name}/#{version}"
+    end
   end
 end

--- a/lib/license_finder/packages/cargo_package.rb
+++ b/lib/license_finder/packages/cargo_package.rb
@@ -22,7 +22,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://crates.io/crates/#{name}/#{version}"
+      "https://crates.io/crates/#{URI.escape(name)}/#{URI.escape(version)}"
     end
   end
 end

--- a/lib/license_finder/packages/cargo_package.rb
+++ b/lib/license_finder/packages/cargo_package.rb
@@ -22,7 +22,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://crates.io/crates/#{URI.escape(name)}/#{URI.escape(version)}"
+      "https://crates.io/crates/#{CGI.escape(name)}/#{CGI.escape(version)}"
     end
   end
 end

--- a/lib/license_finder/packages/cocoa_pods_package.rb
+++ b/lib/license_finder/packages/cocoa_pods_package.rb
@@ -14,5 +14,9 @@ module LicenseFinder
     def package_manager
       'CocoaPods'
     end
+
+    def package_url
+      "https://cocoapods.org/pods/#{URI.escape(name)}"
+    end
   end
 end

--- a/lib/license_finder/packages/cocoa_pods_package.rb
+++ b/lib/license_finder/packages/cocoa_pods_package.rb
@@ -16,7 +16,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://cocoapods.org/pods/#{URI.escape(name)}"
+      "https://cocoapods.org/pods/#{CGI.escape(name)}"
     end
   end
 end

--- a/lib/license_finder/packages/composer_package.rb
+++ b/lib/license_finder/packages/composer_package.rb
@@ -7,7 +7,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://packagist.org/packages/#{URI.escape(name)}##{URI.escape(version)}"
+      "https://packagist.org/packages/#{CGI.escape(name)}##{CGI.escape(version)}"
     end
   end
 end

--- a/lib/license_finder/packages/composer_package.rb
+++ b/lib/license_finder/packages/composer_package.rb
@@ -5,5 +5,9 @@ module LicenseFinder
     def package_manager
       'Composer'
     end
+
+    def package_url
+      "https://packagist.org/packages/#{name}##{version}"
+    end
   end
 end

--- a/lib/license_finder/packages/composer_package.rb
+++ b/lib/license_finder/packages/composer_package.rb
@@ -7,7 +7,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://packagist.org/packages/#{name}##{version}"
+      "https://packagist.org/packages/#{URI.escape(name)}##{URI.escape(version)}"
     end
   end
 end

--- a/lib/license_finder/packages/conan_package.rb
+++ b/lib/license_finder/packages/conan_package.rb
@@ -17,7 +17,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://conan.io/center/#{name}/#{version}"
+      "https://conan.io/center/#{URI.escape(name)}/#{URI.escape(version)}"
     end
   end
 end

--- a/lib/license_finder/packages/conan_package.rb
+++ b/lib/license_finder/packages/conan_package.rb
@@ -17,7 +17,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://conan.io/center/#{URI.escape(name)}/#{URI.escape(version)}"
+      "https://conan.io/center/#{CGI.escape(name)}/#{CGI.escape(version)}"
     end
   end
 end

--- a/lib/license_finder/packages/conan_package.rb
+++ b/lib/license_finder/packages/conan_package.rb
@@ -15,5 +15,9 @@ module LicenseFinder
     def package_manager
       'Conan'
     end
+
+    def package_url
+      "https://conan.io/center/#{name}/#{version}"
+    end
   end
 end

--- a/lib/license_finder/packages/go_package.rb
+++ b/lib/license_finder/packages/go_package.rb
@@ -9,7 +9,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://pkg.go.dev/#{name}@#{version}"
+      "https://pkg.go.dev/#{URI.escape(name)}@#{URI.escape(version)}"
     end
 
     class << self

--- a/lib/license_finder/packages/go_package.rb
+++ b/lib/license_finder/packages/go_package.rb
@@ -8,6 +8,10 @@ module LicenseFinder
       'Go'
     end
 
+    def package_url
+      "https://pkg.go.dev/#{name}@#{version}"
+    end
+
     class << self
       def from_dependency(hash, prefix, full_version)
         name = hash['ImportPath']

--- a/lib/license_finder/packages/go_package.rb
+++ b/lib/license_finder/packages/go_package.rb
@@ -9,7 +9,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://pkg.go.dev/#{URI.escape(name)}@#{URI.escape(version)}"
+      "https://pkg.go.dev/#{CGI.escape(name)}@#{CGI.escape(version)}"
     end
 
     class << self

--- a/lib/license_finder/packages/gradle_package.rb
+++ b/lib/license_finder/packages/gradle_package.rb
@@ -24,7 +24,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://plugins.gradle.org/plugin/#{URI.escape(name)}/#{URI.escape(version)}"
+      "https://plugins.gradle.org/plugin/#{CGI.escape(name)}/#{CGI.escape(version)}"
     end
   end
 end

--- a/lib/license_finder/packages/gradle_package.rb
+++ b/lib/license_finder/packages/gradle_package.rb
@@ -22,5 +22,9 @@ module LicenseFinder
     def package_manager
       'Gradle'
     end
+
+    def package_url
+      "https://plugins.gradle.org/plugin/#{name}/#{version}"
+    end
   end
 end

--- a/lib/license_finder/packages/gradle_package.rb
+++ b/lib/license_finder/packages/gradle_package.rb
@@ -24,7 +24,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://plugins.gradle.org/plugin/#{name}/#{version}"
+      "https://plugins.gradle.org/plugin/#{URI.escape(name)}/#{URI.escape(version)}"
     end
   end
 end

--- a/lib/license_finder/packages/maven_package.rb
+++ b/lib/license_finder/packages/maven_package.rb
@@ -21,7 +21,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://search.maven.org/artifact/#{groups.first}/#{name.split(':').last}/#{version}/jar"
+      "https://search.maven.org/artifact/#{URI.escape(groups.first)}/#{URI.escape(name.split(':').last)}/#{URI.escape(version)}/jar"
     end
   end
 end

--- a/lib/license_finder/packages/maven_package.rb
+++ b/lib/license_finder/packages/maven_package.rb
@@ -21,7 +21,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://search.maven.org/artifact/#{URI.escape(groups.first)}/#{URI.escape(name.split(':').last)}/#{URI.escape(version)}/jar"
+      "https://search.maven.org/artifact/#{CGI.escape(groups.first)}/#{CGI.escape(name.split(':').last)}/#{CGI.escape(version)}/jar"
     end
   end
 end

--- a/lib/license_finder/packages/maven_package.rb
+++ b/lib/license_finder/packages/maven_package.rb
@@ -19,5 +19,9 @@ module LicenseFinder
     def package_manager
       'Maven'
     end
+
+    def package_url
+      "https://search.maven.org/artifact/#{groups.first}/#{name.split(':').last}/#{version}/jar"
+    end
   end
 end

--- a/lib/license_finder/packages/merged_package.rb
+++ b/lib/license_finder/packages/merged_package.rb
@@ -11,7 +11,7 @@ module LicenseFinder
       super(package.name, package.version)
     end
 
-    def_delegators :@dependency, :name, :version, :authors, :summary, :description, :homepage, :children, :parents,
+    def_delegators :@dependency, :name, :version, :authors, :summary, :description, :homepage, :package_url, :children, :parents,
                    :groups, :permitted, :restricted, :manual_approval, :install_path, :licenses, :approved_manually?,
                    :approved_manually!, :approved?, :permitted!, :permitted?, :restricted!, :restricted?, :hash,
                    :activations, :missing, :license_names_from_spec, :decided_licenses, :licensing, :decide_on_license,

--- a/lib/license_finder/packages/mix_package.rb
+++ b/lib/license_finder/packages/mix_package.rb
@@ -5,5 +5,9 @@ module LicenseFinder
     def package_manager
       'Mix'
     end
+
+    def package_url
+      "https://hex.pm/packages/#{name}/#{version}"
+    end
   end
 end

--- a/lib/license_finder/packages/mix_package.rb
+++ b/lib/license_finder/packages/mix_package.rb
@@ -7,7 +7,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://hex.pm/packages/#{URI.escape(name)}/#{URI.escape(version)}"
+      "https://hex.pm/packages/#{CGI.escape(name)}/#{CGI.escape(version)}"
     end
   end
 end

--- a/lib/license_finder/packages/mix_package.rb
+++ b/lib/license_finder/packages/mix_package.rb
@@ -7,7 +7,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://hex.pm/packages/#{name}/#{version}"
+      "https://hex.pm/packages/#{URI.escape(name)}/#{URI.escape(version)}"
     end
   end
 end

--- a/lib/license_finder/packages/npm_package.rb
+++ b/lib/license_finder/packages/npm_package.rb
@@ -90,7 +90,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://www.npmjs.com/package/#{URI.escape(name)}/v/#{URI.escape(version)}"
+      "https://www.npmjs.com/package/#{CGI.escape(name)}/v/#{CGI.escape(version)}"
     end
 
     private

--- a/lib/license_finder/packages/npm_package.rb
+++ b/lib/license_finder/packages/npm_package.rb
@@ -89,6 +89,10 @@ module LicenseFinder
       'Npm'
     end
 
+    def package_url
+      "https://www.npmjs.com/package/#{name}/v/#{version}"
+    end
+
     private
 
     def deps_from_json

--- a/lib/license_finder/packages/npm_package.rb
+++ b/lib/license_finder/packages/npm_package.rb
@@ -90,7 +90,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://www.npmjs.com/package/#{name}/v/#{version}"
+      "https://www.npmjs.com/package/#{URI.escape(name)}/v/#{URI.escape(version)}"
     end
 
     private

--- a/lib/license_finder/packages/nuget_package.rb
+++ b/lib/license_finder/packages/nuget_package.rb
@@ -7,7 +7,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://www.nuget.org/packages/#{URI.escape(name)}/#{URI.escape(version)}"
+      "https://www.nuget.org/packages/#{CGI.escape(name)}/#{CGI.escape(version)}"
     end
   end
 end

--- a/lib/license_finder/packages/nuget_package.rb
+++ b/lib/license_finder/packages/nuget_package.rb
@@ -5,5 +5,9 @@ module LicenseFinder
     def package_manager
       'Nuget'
     end
+
+    def package_url
+      "https://www.nuget.org/packages/#{name}/#{version}"
+    end
   end
 end

--- a/lib/license_finder/packages/nuget_package.rb
+++ b/lib/license_finder/packages/nuget_package.rb
@@ -7,7 +7,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://www.nuget.org/packages/#{name}/#{version}"
+      "https://www.nuget.org/packages/#{URI.escape(name)}/#{URI.escape(version)}"
     end
   end
 end

--- a/lib/license_finder/packages/pip_package.rb
+++ b/lib/license_finder/packages/pip_package.rb
@@ -37,7 +37,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://pypi.org/project/#{URI.escape(name)}/#{URI.escape(version)}/"
+      "https://pypi.org/project/#{CGI.escape(name)}/#{CGI.escape(version)}/"
     end
   end
 end

--- a/lib/license_finder/packages/pip_package.rb
+++ b/lib/license_finder/packages/pip_package.rb
@@ -35,5 +35,9 @@ module LicenseFinder
     def package_manager
       'Pip'
     end
+
+    def package_url
+      "https://pypi.org/project/#{name}/#{version}/"
+    end
   end
 end

--- a/lib/license_finder/packages/pip_package.rb
+++ b/lib/license_finder/packages/pip_package.rb
@@ -37,7 +37,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://pypi.org/project/#{name}/#{version}/"
+      "https://pypi.org/project/#{URI.escape(name)}/#{URI.escape(version)}/"
     end
   end
 end

--- a/lib/license_finder/packages/rebar_package.rb
+++ b/lib/license_finder/packages/rebar_package.rb
@@ -7,7 +7,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://hex.pm/packages/#{URI.escape(name)}/#{URI.escape(version)}"
+      "https://hex.pm/packages/#{CGI.escape(name)}/#{CGI.escape(version)}"
     end
   end
 end

--- a/lib/license_finder/packages/rebar_package.rb
+++ b/lib/license_finder/packages/rebar_package.rb
@@ -5,5 +5,9 @@ module LicenseFinder
     def package_manager
       'Rebar'
     end
+
+    def package_url
+      "https://hex.pm/packages/#{name}/#{version}"
+    end
   end
 end

--- a/lib/license_finder/packages/rebar_package.rb
+++ b/lib/license_finder/packages/rebar_package.rb
@@ -7,7 +7,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://hex.pm/packages/#{name}/#{version}"
+      "https://hex.pm/packages/#{URI.escape(name)}/#{URI.escape(version)}"
     end
   end
 end

--- a/lib/license_finder/packages/yarn_package.rb
+++ b/lib/license_finder/packages/yarn_package.rb
@@ -7,7 +7,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://yarn.pm/#{name}"
+      "https://yarn.pm/#{URI.escape(name)}"
     end
   end
 end

--- a/lib/license_finder/packages/yarn_package.rb
+++ b/lib/license_finder/packages/yarn_package.rb
@@ -5,5 +5,9 @@ module LicenseFinder
     def package_manager
       'Yarn'
     end
+
+    def package_url
+      "https://yarn.pm/#{name}"
+    end
   end
 end

--- a/lib/license_finder/packages/yarn_package.rb
+++ b/lib/license_finder/packages/yarn_package.rb
@@ -7,7 +7,7 @@ module LicenseFinder
     end
 
     def package_url
-      "https://yarn.pm/#{URI.escape(name)}"
+      "https://yarn.pm/#{CGI.escape(name)}"
     end
   end
 end

--- a/spec/lib/license_finder/package_spec.rb
+++ b/spec/lib/license_finder/package_spec.rb
@@ -13,6 +13,7 @@ module LicenseFinder
         summary: 'a summary',
         description: 'a description',
         homepage: 'a homepage',
+        package_url: 'a package_url',
         groups: %w[dev test],
         children: %w[child-1 child2],
         install_path: 'some/package/path',
@@ -27,6 +28,7 @@ module LicenseFinder
     its(:summary) { should == 'a summary' }
     its(:description) { should == 'a description' }
     its(:homepage) { should == 'a homepage' }
+    its(:package_url) { should == 'a package_url' }
     its(:groups) { should == %w[dev test] }
     its(:children) { should == %w[child-1 child2] }
     its(:install_path) { should eq 'some/package/path' }
@@ -39,6 +41,7 @@ module LicenseFinder
       expect(subject.summary).to eq ''
       expect(subject.description).to eq ''
       expect(subject.homepage).to eq ''
+      expect(subject.package_url).to eq ''
       expect(subject.groups).to eq []
       expect(subject.children).to eq []
       expect(subject.install_path).to be_nil

--- a/spec/lib/license_finder/packages/bower_package_spec.rb
+++ b/spec/lib/license_finder/packages/bower_package_spec.rb
@@ -7,6 +7,11 @@ module LicenseFinder
     let(:bower_module) { { pkgMeta: { name: 'a package', version: '1.1.1' } } }
     subject { described_class.new(JSON.parse(bower_module.to_json)) }
 
-    its(:package_url) { should == 'https://bower.io/search/?q=a+package' }
+    before do
+      stub_request(:get, 'https://registry.bower.io/packages/a+package')
+        .to_return(status: 200, body: { url: 'https://github.com/owner/package' }.to_json, headers: {})
+    end
+
+    its(:package_url) { should == 'https://github.com/owner/package' }
   end
 end

--- a/spec/lib/license_finder/packages/bower_package_spec.rb
+++ b/spec/lib/license_finder/packages/bower_package_spec.rb
@@ -7,6 +7,6 @@ module LicenseFinder
     let(:bower_module) { { pkgMeta: { name: 'a package', version: '1.1.1' } } }
     subject { described_class.new(JSON.parse(bower_module.to_json)) }
 
-    its(:package_url) { should == 'https://bower.io/search/?q=a%20package' }
+    its(:package_url) { should == 'https://bower.io/search/?q=a+package' }
   end
 end

--- a/spec/lib/license_finder/packages/bower_package_spec.rb
+++ b/spec/lib/license_finder/packages/bower_package_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module LicenseFinder
+  describe BowerPackage do
+    let(:bower_module) { {pkgMeta: { name: "a package", version: "1.1.1" }} }
+    subject { described_class.new(JSON.parse(bower_module.to_json)) }
+
+    its(:package_url) { should == "https://bower.io/search/?q=a%20package" }
+  end
+end

--- a/spec/lib/license_finder/packages/bower_package_spec.rb
+++ b/spec/lib/license_finder/packages/bower_package_spec.rb
@@ -4,9 +4,9 @@ require 'spec_helper'
 
 module LicenseFinder
   describe BowerPackage do
-    let(:bower_module) { {pkgMeta: { name: "a package", version: "1.1.1" }} }
+    let(:bower_module) { { pkgMeta: { name: 'a package', version: '1.1.1' } } }
     subject { described_class.new(JSON.parse(bower_module.to_json)) }
 
-    its(:package_url) { should == "https://bower.io/search/?q=a%20package" }
+    its(:package_url) { should == 'https://bower.io/search/?q=a%20package' }
   end
 end

--- a/spec/lib/license_finder/packages/bundler_package_spec.rb
+++ b/spec/lib/license_finder/packages/bundler_package_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module LicenseFinder
+  describe BundlerPackage do
+    let(:spec) do
+      Struct
+        .new(:name, :version, :authors, :dependencies, :summary, :description, :homepage, :licenses, :full_gem_path)
+        .new("a package", "1.1.1", [], [], "", "", "", [], "")
+    end
+    subject { described_class.new(spec, nil) }
+
+    its(:package_url) { should == "https://rubygems.org/gems/a%20package/versions/1.1.1" }
+  end
+end

--- a/spec/lib/license_finder/packages/bundler_package_spec.rb
+++ b/spec/lib/license_finder/packages/bundler_package_spec.rb
@@ -7,10 +7,10 @@ module LicenseFinder
     let(:spec) do
       Struct
         .new(:name, :version, :authors, :dependencies, :summary, :description, :homepage, :licenses, :full_gem_path)
-        .new("a package", "1.1.1", [], [], "", "", "", [], "")
+        .new('a package', '1.1.1', [], [], '', '', '', [], '')
     end
     subject { described_class.new(spec, nil) }
 
-    its(:package_url) { should == "https://rubygems.org/gems/a%20package/versions/1.1.1" }
+    its(:package_url) { should == 'https://rubygems.org/gems/a%20package/versions/1.1.1' }
   end
 end

--- a/spec/lib/license_finder/packages/bundler_package_spec.rb
+++ b/spec/lib/license_finder/packages/bundler_package_spec.rb
@@ -11,6 +11,6 @@ module LicenseFinder
     end
     subject { described_class.new(spec, nil) }
 
-    its(:package_url) { should == 'https://rubygems.org/gems/a%20package/versions/1.1.1' }
+    its(:package_url) { should == 'https://rubygems.org/gems/a+package/versions/1.1.1' }
   end
 end

--- a/spec/lib/license_finder/packages/cargo_package_spec.rb
+++ b/spec/lib/license_finder/packages/cargo_package_spec.rb
@@ -4,9 +4,9 @@ require 'spec_helper'
 
 module LicenseFinder
   describe CargoPackage do
-    let(:crate) { { name: "a package", version: "1.1.1" } }
+    let(:crate) { { name: 'a package', version: '1.1.1' } }
     subject { described_class.new(JSON.parse(crate.to_json)) }
 
-    its(:package_url) { should == "https://crates.io/crates/a%20package/1.1.1" }
+    its(:package_url) { should == 'https://crates.io/crates/a%20package/1.1.1' }
   end
 end

--- a/spec/lib/license_finder/packages/cargo_package_spec.rb
+++ b/spec/lib/license_finder/packages/cargo_package_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module LicenseFinder
+  describe CargoPackage do
+    let(:crate) { { name: "a package", version: "1.1.1" } }
+    subject { described_class.new(JSON.parse(crate.to_json)) }
+
+    its(:package_url) { should == "https://crates.io/crates/a%20package/1.1.1" }
+  end
+end

--- a/spec/lib/license_finder/packages/cargo_package_spec.rb
+++ b/spec/lib/license_finder/packages/cargo_package_spec.rb
@@ -7,6 +7,6 @@ module LicenseFinder
     let(:crate) { { name: 'a package', version: '1.1.1' } }
     subject { described_class.new(JSON.parse(crate.to_json)) }
 
-    its(:package_url) { should == 'https://crates.io/crates/a%20package/1.1.1' }
+    its(:package_url) { should == 'https://crates.io/crates/a+package/1.1.1' }
   end
 end

--- a/spec/lib/license_finder/packages/cocoa_pods_package_spec.rb
+++ b/spec/lib/license_finder/packages/cocoa_pods_package_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module LicenseFinder
+  describe CocoaPodsPackage do
+    subject { described_class.new("a package", "1.1.1", "") }
+
+    its(:package_url) { should == "https://cocoapods.org/pods/a%20package" }
+  end
+end

--- a/spec/lib/license_finder/packages/cocoa_pods_package_spec.rb
+++ b/spec/lib/license_finder/packages/cocoa_pods_package_spec.rb
@@ -6,6 +6,6 @@ module LicenseFinder
   describe CocoaPodsPackage do
     subject { described_class.new('a package', '1.1.1', '') }
 
-    its(:package_url) { should == 'https://cocoapods.org/pods/a%20package' }
+    its(:package_url) { should == 'https://cocoapods.org/pods/a+package' }
   end
 end

--- a/spec/lib/license_finder/packages/cocoa_pods_package_spec.rb
+++ b/spec/lib/license_finder/packages/cocoa_pods_package_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 
 module LicenseFinder
   describe CocoaPodsPackage do
-    subject { described_class.new("a package", "1.1.1", "") }
+    subject { described_class.new('a package', '1.1.1', '') }
 
-    its(:package_url) { should == "https://cocoapods.org/pods/a%20package" }
+    its(:package_url) { should == 'https://cocoapods.org/pods/a%20package' }
   end
 end

--- a/spec/lib/license_finder/packages/composer_package_spec.rb
+++ b/spec/lib/license_finder/packages/composer_package_spec.rb
@@ -6,6 +6,6 @@ module LicenseFinder
   describe ComposerPackage do
     subject { described_class.new('a package', '1.1.1') }
 
-    its(:package_url) { should == 'https://packagist.org/packages/a%20package#1.1.1' }
+    its(:package_url) { should == 'https://packagist.org/packages/a+package#1.1.1' }
   end
 end

--- a/spec/lib/license_finder/packages/composer_package_spec.rb
+++ b/spec/lib/license_finder/packages/composer_package_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 
 module LicenseFinder
   describe ComposerPackage do
-    subject { described_class.new("a package", "1.1.1") }
+    subject { described_class.new('a package', '1.1.1') }
 
-    its(:package_url) { should == "https://packagist.org/packages/a%20package#1.1.1" }
+    its(:package_url) { should == 'https://packagist.org/packages/a%20package#1.1.1' }
   end
 end

--- a/spec/lib/license_finder/packages/composer_package_spec.rb
+++ b/spec/lib/license_finder/packages/composer_package_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module LicenseFinder
+  describe ComposerPackage do
+    subject { described_class.new("a package", "1.1.1") }
+
+    its(:package_url) { should == "https://packagist.org/packages/a%20package#1.1.1" }
+  end
+end

--- a/spec/lib/license_finder/packages/conan_package_spec.rb
+++ b/spec/lib/license_finder/packages/conan_package_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 
 module LicenseFinder
   describe ConanPackage do
-    subject { described_class.new("a package", "1.1.1", "", "") }
+    subject { described_class.new('a package', '1.1.1', '', '') }
 
-    its(:package_url) { should == "https://conan.io/center/a%20package/1.1.1" }
+    its(:package_url) { should == 'https://conan.io/center/a%20package/1.1.1' }
   end
 end

--- a/spec/lib/license_finder/packages/conan_package_spec.rb
+++ b/spec/lib/license_finder/packages/conan_package_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module LicenseFinder
+  describe ConanPackage do
+    subject { described_class.new("a package", "1.1.1", "", "") }
+
+    its(:package_url) { should == "https://conan.io/center/a%20package/1.1.1" }
+  end
+end

--- a/spec/lib/license_finder/packages/conan_package_spec.rb
+++ b/spec/lib/license_finder/packages/conan_package_spec.rb
@@ -6,6 +6,6 @@ module LicenseFinder
   describe ConanPackage do
     subject { described_class.new('a package', '1.1.1', '', '') }
 
-    its(:package_url) { should == 'https://conan.io/center/a%20package/1.1.1' }
+    its(:package_url) { should == 'https://conan.io/center/a+package/1.1.1' }
   end
 end

--- a/spec/lib/license_finder/packages/go_package_spec.rb
+++ b/spec/lib/license_finder/packages/go_package_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module LicenseFinder
+  describe GoPackage do
+    subject { described_class.new("a package", "1.1.1") }
+
+    its(:package_url) { should == "https://pkg.go.dev/a%20package@1.1.1" }
+  end
+end

--- a/spec/lib/license_finder/packages/go_package_spec.rb
+++ b/spec/lib/license_finder/packages/go_package_spec.rb
@@ -6,6 +6,6 @@ module LicenseFinder
   describe GoPackage do
     subject { described_class.new('a package', '1.1.1') }
 
-    its(:package_url) { should == 'https://pkg.go.dev/a%20package@1.1.1' }
+    its(:package_url) { should == 'https://pkg.go.dev/a+package@1.1.1' }
   end
 end

--- a/spec/lib/license_finder/packages/go_package_spec.rb
+++ b/spec/lib/license_finder/packages/go_package_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 
 module LicenseFinder
   describe GoPackage do
-    subject { described_class.new("a package", "1.1.1") }
+    subject { described_class.new('a package', '1.1.1') }
 
-    its(:package_url) { should == "https://pkg.go.dev/a%20package@1.1.1" }
+    its(:package_url) { should == 'https://pkg.go.dev/a%20package@1.1.1' }
   end
 end

--- a/spec/lib/license_finder/packages/gradle_package_spec.rb
+++ b/spec/lib/license_finder/packages/gradle_package_spec.rb
@@ -4,9 +4,9 @@ require 'spec_helper'
 
 module LicenseFinder
   describe GradlePackage do
-    let(:spec) { { name: "group:a package:1.1.1" }}
+    let(:spec) { { name: 'group:a package:1.1.1' } }
     subject { described_class.new(JSON.parse(spec.to_json)) }
 
-    its(:package_url) { should == "https://plugins.gradle.org/plugin/a%20package/1.1.1" }
+    its(:package_url) { should == 'https://plugins.gradle.org/plugin/a%20package/1.1.1' }
   end
 end

--- a/spec/lib/license_finder/packages/gradle_package_spec.rb
+++ b/spec/lib/license_finder/packages/gradle_package_spec.rb
@@ -7,6 +7,6 @@ module LicenseFinder
     let(:spec) { { name: 'group:a package:1.1.1' } }
     subject { described_class.new(JSON.parse(spec.to_json)) }
 
-    its(:package_url) { should == 'https://plugins.gradle.org/plugin/a%20package/1.1.1' }
+    its(:package_url) { should == 'https://plugins.gradle.org/plugin/a+package/1.1.1' }
   end
 end

--- a/spec/lib/license_finder/packages/gradle_package_spec.rb
+++ b/spec/lib/license_finder/packages/gradle_package_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module LicenseFinder
+  describe GradlePackage do
+    let(:spec) { { name: "group:a package:1.1.1" }}
+    subject { described_class.new(JSON.parse(spec.to_json)) }
+
+    its(:package_url) { should == "https://plugins.gradle.org/plugin/a%20package/1.1.1" }
+  end
+end

--- a/spec/lib/license_finder/packages/maven_package_spec.rb
+++ b/spec/lib/license_finder/packages/maven_package_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module LicenseFinder
+  describe MavenPackage do
+    let(:spec) { { groupId: "group", artifactId: "a package", version: "1.1.1" }}
+    subject { described_class.new(JSON.parse(spec.to_json)) }
+
+    its(:package_url) { should == "https://search.maven.org/artifact/group/a%20package/1.1.1/jar" }
+  end
+end

--- a/spec/lib/license_finder/packages/maven_package_spec.rb
+++ b/spec/lib/license_finder/packages/maven_package_spec.rb
@@ -7,6 +7,6 @@ module LicenseFinder
     let(:spec) { { groupId: 'group', artifactId: 'a package', version: '1.1.1' } }
     subject { described_class.new(JSON.parse(spec.to_json)) }
 
-    its(:package_url) { should == 'https://search.maven.org/artifact/group/a%20package/1.1.1/jar' }
+    its(:package_url) { should == 'https://search.maven.org/artifact/group/a+package/1.1.1/jar' }
   end
 end

--- a/spec/lib/license_finder/packages/maven_package_spec.rb
+++ b/spec/lib/license_finder/packages/maven_package_spec.rb
@@ -4,9 +4,9 @@ require 'spec_helper'
 
 module LicenseFinder
   describe MavenPackage do
-    let(:spec) { { groupId: "group", artifactId: "a package", version: "1.1.1" }}
+    let(:spec) { { groupId: 'group', artifactId: 'a package', version: '1.1.1' } }
     subject { described_class.new(JSON.parse(spec.to_json)) }
 
-    its(:package_url) { should == "https://search.maven.org/artifact/group/a%20package/1.1.1/jar" }
+    its(:package_url) { should == 'https://search.maven.org/artifact/group/a%20package/1.1.1/jar' }
   end
 end

--- a/spec/lib/license_finder/packages/mix_package_spec.rb
+++ b/spec/lib/license_finder/packages/mix_package_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 
 module LicenseFinder
   describe MixPackage do
-    subject { described_class.new("a package", "1.1.1") }
+    subject { described_class.new('a package', '1.1.1') }
 
-    its(:package_url) { should == "https://hex.pm/packages/a%20package/1.1.1" }
+    its(:package_url) { should == 'https://hex.pm/packages/a%20package/1.1.1' }
   end
 end

--- a/spec/lib/license_finder/packages/mix_package_spec.rb
+++ b/spec/lib/license_finder/packages/mix_package_spec.rb
@@ -6,6 +6,6 @@ module LicenseFinder
   describe MixPackage do
     subject { described_class.new('a package', '1.1.1') }
 
-    its(:package_url) { should == 'https://hex.pm/packages/a%20package/1.1.1' }
+    its(:package_url) { should == 'https://hex.pm/packages/a+package/1.1.1' }
   end
 end

--- a/spec/lib/license_finder/packages/mix_package_spec.rb
+++ b/spec/lib/license_finder/packages/mix_package_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module LicenseFinder
+  describe MixPackage do
+    subject { described_class.new("a package", "1.1.1") }
+
+    its(:package_url) { should == "https://hex.pm/packages/a%20package/1.1.1" }
+  end
+end

--- a/spec/lib/license_finder/packages/npm_package_spec.rb
+++ b/spec/lib/license_finder/packages/npm_package_spec.rb
@@ -7,6 +7,6 @@ module LicenseFinder
     let(:spec) { { name: 'a package', version: '1.1.1' } }
     subject { described_class.new(JSON.parse(spec.to_json)) }
 
-    its(:package_url) { should == 'https://www.npmjs.com/package/a%20package/v/1.1.1' }
+    its(:package_url) { should == 'https://www.npmjs.com/package/a+package/v/1.1.1' }
   end
 end

--- a/spec/lib/license_finder/packages/npm_package_spec.rb
+++ b/spec/lib/license_finder/packages/npm_package_spec.rb
@@ -4,9 +4,9 @@ require 'spec_helper'
 
 module LicenseFinder
   describe NpmPackage do
-    let(:spec) { { name: "a package", version: "1.1.1" }}
+    let(:spec) { { name: 'a package', version: '1.1.1' } }
     subject { described_class.new(JSON.parse(spec.to_json)) }
 
-    its(:package_url) { should == "https://www.npmjs.com/package/a%20package/v/1.1.1" }
+    its(:package_url) { should == 'https://www.npmjs.com/package/a%20package/v/1.1.1' }
   end
 end

--- a/spec/lib/license_finder/packages/npm_package_spec.rb
+++ b/spec/lib/license_finder/packages/npm_package_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module LicenseFinder
+  describe NpmPackage do
+    let(:spec) { { name: "a package", version: "1.1.1" }}
+    subject { described_class.new(JSON.parse(spec.to_json)) }
+
+    its(:package_url) { should == "https://www.npmjs.com/package/a%20package/v/1.1.1" }
+  end
+end

--- a/spec/lib/license_finder/packages/nuget_package_spec.rb
+++ b/spec/lib/license_finder/packages/nuget_package_spec.rb
@@ -6,6 +6,6 @@ module LicenseFinder
   describe NugetPackage do
     subject { described_class.new('a package', '1.1.1') }
 
-    its(:package_url) { should == 'https://www.nuget.org/packages/a%20package/1.1.1' }
+    its(:package_url) { should == 'https://www.nuget.org/packages/a+package/1.1.1' }
   end
 end

--- a/spec/lib/license_finder/packages/nuget_package_spec.rb
+++ b/spec/lib/license_finder/packages/nuget_package_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 
 module LicenseFinder
   describe NugetPackage do
-    subject { described_class.new("a package", "1.1.1") }
+    subject { described_class.new('a package', '1.1.1') }
 
-    its(:package_url) { should == "https://www.nuget.org/packages/a%20package/1.1.1" }
+    its(:package_url) { should == 'https://www.nuget.org/packages/a%20package/1.1.1' }
   end
 end

--- a/spec/lib/license_finder/packages/nuget_package_spec.rb
+++ b/spec/lib/license_finder/packages/nuget_package_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module LicenseFinder
+  describe NugetPackage do
+    subject { described_class.new("a package", "1.1.1") }
+
+    its(:package_url) { should == "https://www.nuget.org/packages/a%20package/1.1.1" }
+  end
+end

--- a/spec/lib/license_finder/packages/pip_package_spec.rb
+++ b/spec/lib/license_finder/packages/pip_package_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 
 module LicenseFinder
   describe PipPackage do
-    subject { described_class.new("a package", "1.1.1", {}) }
+    subject { described_class.new('a package', '1.1.1', {}) }
 
-    its(:package_url) { should == "https://pypi.org/project/a%20package/1.1.1/" }
+    its(:package_url) { should == 'https://pypi.org/project/a%20package/1.1.1/' }
   end
 end

--- a/spec/lib/license_finder/packages/pip_package_spec.rb
+++ b/spec/lib/license_finder/packages/pip_package_spec.rb
@@ -6,6 +6,6 @@ module LicenseFinder
   describe PipPackage do
     subject { described_class.new('a package', '1.1.1', {}) }
 
-    its(:package_url) { should == 'https://pypi.org/project/a%20package/1.1.1/' }
+    its(:package_url) { should == 'https://pypi.org/project/a+package/1.1.1/' }
   end
 end

--- a/spec/lib/license_finder/packages/pip_package_spec.rb
+++ b/spec/lib/license_finder/packages/pip_package_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module LicenseFinder
+  describe PipPackage do
+    subject { described_class.new("a package", "1.1.1", {}) }
+
+    its(:package_url) { should == "https://pypi.org/project/a%20package/1.1.1/" }
+  end
+end

--- a/spec/lib/license_finder/packages/rebar_package_spec.rb
+++ b/spec/lib/license_finder/packages/rebar_package_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module LicenseFinder
+  describe RebarPackage do
+    subject { described_class.new("a package", "1.1.1") }
+
+    its(:package_url) { should == "https://hex.pm/packages/a%20package/1.1.1" }
+  end
+end

--- a/spec/lib/license_finder/packages/rebar_package_spec.rb
+++ b/spec/lib/license_finder/packages/rebar_package_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 
 module LicenseFinder
   describe RebarPackage do
-    subject { described_class.new("a package", "1.1.1") }
+    subject { described_class.new('a package', '1.1.1') }
 
-    its(:package_url) { should == "https://hex.pm/packages/a%20package/1.1.1" }
+    its(:package_url) { should == 'https://hex.pm/packages/a%20package/1.1.1' }
   end
 end

--- a/spec/lib/license_finder/packages/rebar_package_spec.rb
+++ b/spec/lib/license_finder/packages/rebar_package_spec.rb
@@ -6,6 +6,6 @@ module LicenseFinder
   describe RebarPackage do
     subject { described_class.new('a package', '1.1.1') }
 
-    its(:package_url) { should == 'https://hex.pm/packages/a%20package/1.1.1' }
+    its(:package_url) { should == 'https://hex.pm/packages/a+package/1.1.1' }
   end
 end

--- a/spec/lib/license_finder/packages/yarn_package_spec.rb
+++ b/spec/lib/license_finder/packages/yarn_package_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 
 module LicenseFinder
   describe YarnPackage do
-    subject { described_class.new("a package", "1.1.1") }
+    subject { described_class.new('a package', '1.1.1') }
 
-    its(:package_url) { should == "https://yarn.pm/a%20package" }
+    its(:package_url) { should == 'https://yarn.pm/a%20package' }
   end
 end

--- a/spec/lib/license_finder/packages/yarn_package_spec.rb
+++ b/spec/lib/license_finder/packages/yarn_package_spec.rb
@@ -6,6 +6,6 @@ module LicenseFinder
   describe YarnPackage do
     subject { described_class.new('a package', '1.1.1') }
 
-    its(:package_url) { should == 'https://yarn.pm/a%20package' }
+    its(:package_url) { should == 'https://yarn.pm/a+package' }
   end
 end

--- a/spec/lib/license_finder/packages/yarn_package_spec.rb
+++ b/spec/lib/license_finder/packages/yarn_package_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module LicenseFinder
+  describe YarnPackage do
+    subject { described_class.new("a package", "1.1.1") }
+
+    its(:package_url) { should == "https://yarn.pm/a%20package" }
+  end
+end


### PR DESCRIPTION
I would like to introduce `package_url` to packages which will hold the url to the package details.
I tried to introduce it for every package manager, could not find a package registry for carthage and stb packages.

In a second step I would like to enable csv export of the `package_url` as a new column. An additional PR for this will follow when this one will be merged.