### PR TITLE
Yarn: Fix install path fallback

### DIFF
--- a/lib/license_finder/package_managers/yarn.rb
+++ b/lib/license_finder/package_managers/yarn.rb
@@ -87,7 +87,7 @@ module LicenseFinder
       return @modules_folder if @modules_folder
 
       stdout, _stderr, status = Cmd.run('yarn config get modules-folder')
-      @modules_folder = 'node_modules' if !status.success? || stdout == 'undefined'
+      @modules_folder = 'node_modules' if !status.success? || stdout.strip == 'undefined'
       @modules_folder ||= stdout.strip
     end
 

--- a/spec/lib/license_finder/package_managers/yarn_spec.rb
+++ b/spec/lib/license_finder/package_managers/yarn_spec.rb
@@ -48,7 +48,7 @@ module LicenseFinder
 
       it 'displays packages as returned from "yarn list"' do
         allow(SharedHelpers::Cmd).to receive(:run).with('yarn config get modules-folder') do
-          ['yarn_modules', '', cmd_success]
+          ["yarn_modules\n", '', cmd_success]
         end
         allow(SharedHelpers::Cmd).to receive(:run).with(Yarn::SHELL_COMMAND + " --cwd #{Pathname(root)}") do
           [yarn_shell_command_output, '', cmd_success]
@@ -61,6 +61,17 @@ module LicenseFinder
         expect(subject.current_packages.first.homepage).to eq 'sindresorhus.com'
         expect(subject.current_packages.first.authors).to eq 'Sindre Sorhus'
         expect(subject.current_packages.first.install_path).to eq Pathname(root).join('yarn_modules', 'yn')
+      end
+
+      it 'uses node_modules as fallback for install path' do
+        allow(SharedHelpers::Cmd).to receive(:run).with('yarn config get modules-folder') do
+          ["undefined\n", '', cmd_success]
+        end
+        allow(SharedHelpers::Cmd).to receive(:run).with(Yarn::SHELL_COMMAND + " --cwd #{Pathname(root)}") do
+          [yarn_shell_command_output, '', cmd_success]
+        end
+
+        expect(subject.current_packages.first.install_path).to eq Pathname(root).join('node_modules', 'yn')
       end
 
       it 'displays incompatible packages with license type unknown' do


### PR DESCRIPTION
command returns folder with newline at the end,
so we have to strip that also if output is undefined
folder name

Sorry for not testing this before