### PR TITLE
Readme: update list of packages support ignored_groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ $ license_finder dependencies remove my_js_dep
 Sometimes a project will have development or test dependencies which
 you don't want to track.  You can exclude theses dependencies by running
 `license_finder ignored_groups`.  (Currently this only works for packages
-managed by Bundler, NPM, and Nuget.)
+managed by Bundler, NPM, Yarn, Maven, Pip2, Pip3, and Nuget.)
 
 On rare occasions a package manager will report an individual dependency
 that you want to exclude from all reports, even though it is approved.


### PR DESCRIPTION
I have recognized that some package managers are not mentioned in the supported list for ignored groups. I can confirm that it works for `Yarn`, but we do not have Maven or Python projects so I just relay on the source code where ignored groups are handled (See pipenv.rb and maven.rb).
