### PR TITLE
Feature: Decision inheritance

### DIFF
--- a/lib/license_finder/cli.rb
+++ b/lib/license_finder/cli.rb
@@ -8,6 +8,7 @@ end
 require 'license_finder/cli/patched_thor'
 require 'license_finder/cli/base'
 require 'license_finder/cli/makes_decisions'
+require 'license_finder/cli/inherited_decisions'
 require 'license_finder/cli/permitted_licenses'
 require 'license_finder/cli/restricted_licenses'
 require 'license_finder/cli/dependencies'

--- a/lib/license_finder/cli/inherited_decisions.rb
+++ b/lib/license_finder/cli/inherited_decisions.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module LicenseFinder
+  module CLI
+    class InheritedDecisions < Base
+      extend Subcommand
+      include MakesDecisions
+
+      desc 'list', 'List all the inherited decision files'
+      def list
+        say 'Inherited Decision Files:', :blue
+        say_each(decisions.inherited_decisions)
+      end
+
+      auditable
+      desc 'add DECISION_FILE...', 'Add one or more decision files to the inherited decisions'
+      def add(*decision_files)
+        assert_some decision_files
+        modifying { decision_files.each { |filepath| decisions.inherit_from(filepath) } }
+        say "Added #{decision_files.join(', ')} to the inherited decisions"
+      end
+
+      auditable
+      desc 'remove DECISION_FILE...', 'Remove one or more decision files from the inherited decisions'
+      def remove(*decision_files)
+        assert_some decision_files
+        modifying { decision_files.each { |filepath| decisions.remove_inheritance(filepath) } }
+        say "Removed #{decision_files.join(', ')} from the inherited decisions"
+      end
+    end
+  end
+end

--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -172,6 +172,7 @@ module LicenseFinder
       subcommand 'permitted_licenses', PermittedLicenses, 'Automatically approve any dependency that has a permitted license'
       subcommand 'restricted_licenses', RestrictedLicenses, 'Forbid approval of any dependency whose licenses are all restricted'
       subcommand 'project_name', ProjectName, 'Set the project name, for display in reports'
+      subcommand 'inherited_decisions', InheritedDecisions, 'Add or remove decision files you want to inherit from'
 
       private
 

--- a/lib/license_finder/decisions.rb
+++ b/lib/license_finder/decisions.rb
@@ -186,10 +186,7 @@ module LicenseFinder
     def inherit_from(filepath)
       decisions =
         if filepath =~ %r{^https?://}
-          # ruby < 2.5.0 URI.open is private
-          # rubocop:disable Security/Open
-          open(filepath).read
-          # rubocop:enable Security/Open
+          open_uri(filepath).read
         else
           Pathname(filepath).read
         end
@@ -214,6 +211,17 @@ module LicenseFinder
       self.class.restore(decisions, self)
       @inherited = false
       self
+    end
+
+    def open_uri(uri)
+      # ruby < 2.5.0 URI.open is private
+      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.5.0')
+        # rubocop:disable Security/Open
+        open(uri)
+        # rubocop:enable Security/Open
+      else
+        URI.open(uri)
+      end
     end
 
     #########

--- a/lib/license_finder/decisions.rb
+++ b/lib/license_finder/decisions.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'open-uri'
+
 module LicenseFinder
   class Decisions
     ######
@@ -75,37 +77,37 @@ module LicenseFinder
     end
 
     def add_package(name, version, txn = {})
-      @decisions << [:add_package, name, version, txn]
+      add_decision [:add_package, name, version, txn]
       @packages << ManualPackage.new(name, version)
       self
     end
 
     def remove_package(name, txn = {})
-      @decisions << [:remove_package, name, txn]
+      add_decision [:remove_package, name, txn]
       @packages.delete(ManualPackage.new(name))
       self
     end
 
     def license(name, lic, txn = {})
-      @decisions << [:license, name, lic, txn]
+      add_decision [:license, name, lic, txn]
       @licenses[name] << License.find_by_name(lic)
       self
     end
 
     def unlicense(name, lic, txn = {})
-      @decisions << [:unlicense, name, lic, txn]
+      add_decision [:unlicense, name, lic, txn]
       @licenses[name].delete(License.find_by_name(lic))
       self
     end
 
     def homepage(name, homepage, txn = {})
-      @decisions << [:homepage, name, homepage, txn]
+      add_decision [:homepage, name, homepage, txn]
       @homepages[name] = homepage
       self
     end
 
     def approve(name, txn = {})
-      @decisions << [:approve, name, txn]
+      add_decision [:approve, name, txn]
 
       versions = []
       versions = @approvals[name][:safe_versions] if @approvals.key?(name)
@@ -115,68 +117,91 @@ module LicenseFinder
     end
 
     def unapprove(name, txn = {})
-      @decisions << [:unapprove, name, txn]
+      add_decision [:unapprove, name, txn]
       @approvals.delete(name)
       self
     end
 
     def permit(lic, txn = {})
-      @decisions << [:permit, lic, txn]
+      add_decision [:permit, lic, txn]
       @permitted << License.find_by_name(lic)
       self
     end
 
     def unpermit(lic, txn = {})
-      @decisions << [:unpermit, lic, txn]
+      add_decision [:unpermit, lic, txn]
       @permitted.delete(License.find_by_name(lic))
       self
     end
 
     def restrict(lic, txn = {})
-      @decisions << [:restrict, lic, txn]
+      add_decision [:restrict, lic, txn]
       @restricted << License.find_by_name(lic)
       self
     end
 
     def unrestrict(lic, txn = {})
-      @decisions << [:unrestrict, lic, txn]
+      add_decision [:unrestrict, lic, txn]
       @restricted.delete(License.find_by_name(lic))
       self
     end
 
     def ignore(name, txn = {})
-      @decisions << [:ignore, name, txn]
+      add_decision [:ignore, name, txn]
       @ignored << name
       self
     end
 
     def heed(name, txn = {})
-      @decisions << [:heed, name, txn]
+      add_decision [:heed, name, txn]
       @ignored.delete(name)
       self
     end
 
     def ignore_group(name, txn = {})
-      @decisions << [:ignore_group, name, txn]
+      add_decision [:ignore_group, name, txn]
       @ignored_groups << name
       self
     end
 
     def heed_group(name, txn = {})
-      @decisions << [:heed_group, name, txn]
+      add_decision [:heed_group, name, txn]
       @ignored_groups.delete(name)
       self
     end
 
     def name_project(name, txn = {})
-      @decisions << [:name_project, name, txn]
+      add_decision [:name_project, name, txn]
       @project_name = name
       self
     end
 
     def unname_project(txn = {})
-      @decisions << [:unname_project, txn]
+      add_decision [:unname_project, txn]
       @project_name = nil
+      self
+    end
+
+    def inherit_from(filepath)
+      decisions =
+        if filepath =~ %r{^https?://}
+          open(filepath).read
+        else
+          Pathname(filepath).read
+        end
+
+      add_decision [:inherit_from, filepath]
+      restore_inheritance(decisions)
+    end
+
+    def add_decision(decision)
+      @decisions << decision unless @inherited
+    end
+
+    def restore_inheritance(decisions)
+      @inherited = true
+      self.class.restore(decisions, self)
+      @inherited = false
       self
     end
 
@@ -192,8 +217,7 @@ module LicenseFinder
       write!(persist, file)
     end
 
-    def self.restore(persisted)
-      result = new
+    def self.restore(persisted, result = new)
       return result unless persisted
 
       actions = YAML.load(persisted)

--- a/lib/license_finder/decisions.rb
+++ b/lib/license_finder/decisions.rb
@@ -8,7 +8,7 @@ module LicenseFinder
     # READ
     ######
 
-    attr_reader :packages, :permitted, :restricted, :ignored, :ignored_groups, :project_name
+    attr_reader :packages, :permitted, :restricted, :ignored, :ignored_groups, :project_name, :inherited_decisions
 
     def licenses_of(name)
       @licenses[name]
@@ -74,6 +74,7 @@ module LicenseFinder
       @restricted = Set.new
       @ignored = Set.new
       @ignored_groups = Set.new
+      @inherited_decisions = Set.new
     end
 
     def add_package(name, version, txn = {})
@@ -191,7 +192,13 @@ module LicenseFinder
         end
 
       add_decision [:inherit_from, filepath]
+      @inherited_decisions << filepath
       restore_inheritance(decisions)
+    end
+
+    def remove_inheritance(filepath)
+      @decisions = @decisions - [[:inherit_from, filepath]]
+      self
     end
 
     def add_decision(decision)

--- a/lib/license_finder/decisions.rb
+++ b/lib/license_finder/decisions.rb
@@ -186,7 +186,7 @@ module LicenseFinder
     def inherit_from(filepath)
       decisions =
         if filepath =~ %r{^https?://}
-          open(filepath).read
+          URI.open(filepath).read
         else
           Pathname(filepath).read
         end
@@ -197,7 +197,8 @@ module LicenseFinder
     end
 
     def remove_inheritance(filepath)
-      @decisions = @decisions - [[:inherit_from, filepath]]
+      @decisions -= [[:inherit_from, filepath]]
+      @inherited_decisions.delete(filepath)
       self
     end
 

--- a/lib/license_finder/decisions.rb
+++ b/lib/license_finder/decisions.rb
@@ -186,7 +186,10 @@ module LicenseFinder
     def inherit_from(filepath)
       decisions =
         if filepath =~ %r{^https?://}
-          URI.open(filepath).read
+          # ruby < 2.5.0 URI.open is private
+          # rubocop:disable Security/Open
+          open(filepath).read
+          # rubocop:enable Security/Open
         else
           Pathname(filepath).read
         end

--- a/spec/lib/license_finder/decisions_spec.rb
+++ b/spec/lib/license_finder/decisions_spec.rb
@@ -280,6 +280,22 @@ module LicenseFinder
       end
     end
 
+    describe '.inherit_from' do
+      let(:yml) { YAML.dump([[:permit, 'MIT']]) }
+
+      it 'inheritates rules from local decision file' do
+        allow_any_instance_of(Pathname).to receive(:read).and_return(yml)
+        decisions = subject.inherit_from('./config/inherit.yml')
+        expect(decisions).to be_permitted(License.find_by_name('MIT'))
+      end
+
+      it 'inheritates rules from remote decision file' do
+        stub_request(:get, 'https://example.com/config/inherit.yml').to_return(status: 200, body: yml, headers: {})
+        decisions = subject.inherit_from('https://example.com/config/inherit.yml')
+        expect(decisions).to be_permitted(License.find_by_name('MIT'))
+      end
+    end
+
     describe 'persistence' do
       def roundtrip(decisions)
         described_class.restore(decisions.persist)
@@ -444,6 +460,12 @@ module LicenseFinder
             .unname_project
         )
         expect(decisions.project_name).to be_nil
+      end
+
+      it 'does not store decisions from inheritance' do
+        allow_any_instance_of(Pathname).to receive(:read).and_return(YAML.dump([[:permit, 'MIT']]))
+        decisions = subject.inherit_from('./config/inherit.yml')
+        expect(decisions.persist).to eql(YAML.dump([[:inherit_from, './config/inherit.yml']]))
       end
 
       it 'ignores empty or missing persisted decisions' do

--- a/spec/lib/license_finder/decisions_spec.rb
+++ b/spec/lib/license_finder/decisions_spec.rb
@@ -296,6 +296,17 @@ module LicenseFinder
       end
     end
 
+    describe '.remove_inheritance' do
+      it 'reports inheritanced decisions' do
+        allow_any_instance_of(Pathname).to receive(:read).and_return('---')
+        decisions = subject.inherit_from('./config/inherit.yml')
+        expect(decisions.inherited_decisions).to include('./config/inherit.yml')
+
+        decisions = subject.remove_inheritance('./config/inherit.yml')
+        expect(decisions.inherited_decisions).to be_empty
+      end
+    end
+
     describe 'persistence' do
       def roundtrip(decisions)
         described_class.restore(decisions.persist)
@@ -460,6 +471,15 @@ module LicenseFinder
             .unname_project
         )
         expect(decisions.project_name).to be_nil
+      end
+
+      it 'can restore inherited decisions' do
+        allow_any_instance_of(Pathname).to receive(:read).and_return(YAML.dump([[:permit, 'MIT']]))
+        decisions = roundtrip(
+          subject
+            .inherit_from('./config/inherit.yml')
+        )
+        expect(decisions.inherited_decisions).to include('./config/inherit.yml')
       end
 
       it 'does not store decisions from inheritance' do


### PR DESCRIPTION
## Decision Inheritance

- Add possibility to inherite from other decision files (solves https://github.com/pivotal/LicenseFinder/issues/587)
- Lookup decision from url (kinda solves https://github.com/pivotal/LicenseFinder/issues/702 by adding this for the inheritance feature)

Introducing new `inherited_decisions` command

```
license_finder inherited_decisions [list|add|remove]   # Add or remove decision files you want to inherit from - see `license_finder inherited_decisions help` for more information
```

```
Commands:
  license_finder inherited_decisions add DECISION_FILE...     # Add one or more decision files to the inherited decisions
  license_finder inherited_decisions list                     # List all the inherited decision files
  license_finder inherited_decisions remove DECISION_FILE...  # Remove one or more decision files from the inherited decisions
```

By providing this feature you could e.g. have a centralized decision file for approved/restricted licenses. If you have multiple projects it's way easier to have one single place where you approved or restricted licenses defined.