### PR TITLE
[Fixed] Separate lines in license text with LF when exported to JSON

### DIFF
--- a/lib/license_finder/reports/csv_report.rb
+++ b/lib/license_finder/reports/csv_report.rb
@@ -3,6 +3,7 @@ require 'csv'
 module LicenseFinder
   class CsvReport < Report
     COMMA_SEP = ','.freeze
+    NEWLINE_SEP = '\@NL'.freeze
     AVAILABLE_COLUMNS = %w[name version authors licenses license_links approved summary description homepage install_path package_manager groups texts notice].freeze
     MISSING_DEPENDENCY_TEXT = 'This package is not installed. Please install to determine licenses.'.freeze
 
@@ -30,11 +31,13 @@ module LicenseFinder
     end
 
     def format_texts(dep)
-      dep.license_files.map { |file| file.text.split(/[\n\r]+/).join("\\@NL") }.join("\\@NL").force_encoding("ISO-8859-1").encode("UTF-8")
+      dep.license_files.map { |file| file.text.split(/[\n\r]+/).join(self.class::NEWLINE_SEP) }
+          .join(self.class::NEWLINE_SEP).force_encoding("ISO-8859-1").encode("UTF-8")
     end
 
     def format_notice(dep)
-      dep.notice_files.map { |file| file.text.split(/[\n\r]+/).join("\\@NL") }.join("\\@NL").force_encoding("ISO-8859-1").encode("UTF-8")
+      dep.notice_files.map { |file| file.text.split(/[\n\r]+/).join(self.class::NEWLINE_SEP) }
+          .join(self.class::NEWLINE_SEP).force_encoding("ISO-8859-1").encode("UTF-8")
     end
 
     def format_name(dep)

--- a/lib/license_finder/reports/json_report.rb
+++ b/lib/license_finder/reports/json_report.rb
@@ -2,6 +2,8 @@ require 'csv'
 
 module LicenseFinder
   class JsonReport < CsvReport
+    NEWLINE_SEP = "\n".freeze
+
     def initialize(dependencies, options)
       super(dependencies, options)
     end

--- a/spec/lib/license_finder/reports/json_report_spec.rb
+++ b/spec/lib/license_finder/reports/json_report_spec.rb
@@ -25,5 +25,21 @@ module LicenseFinder
 
       expect(subject.to_s).to eq(expected)
     end
+
+    it 'supports multiple license texts and joins lines with line feed' do
+      install_path = fixture_path('license_directory')
+      dep = Package.new('gem_a', '1.0', install_path: install_path)
+      subject = described_class.new([dep], columns: %w[name version texts])
+      expected = {
+        dependencies:
+          [
+            {
+              name: 'gem_a', version: '1.0', texts: "The MIT License\nThe MIT License"
+            }
+          ]
+      }.to_json
+
+      expect(subject.to_s).to eq(expected)
+    end
   end
 end


### PR DESCRIPTION
Fixes #736 by changing the newline separator character for the JSON reporter.