### PR TITLE
[Fixes] License files case insensitive detection

### DIFF
--- a/lib/license_finder/package_utils/license_files.rb
+++ b/lib/license_finder/package_utils/license_files.rb
@@ -4,7 +4,7 @@ require 'license_finder/package_utils/possible_license_file'
 
 module LicenseFinder
   class LicenseFiles
-    CANDIDATE_FILE_NAMES = %w[LICENSE License LICENCE Licence COPYING README Readme ReadMe].freeze
+    CANDIDATE_FILE_NAMES = %w[License Licence COPYING README].freeze
     CANDIDATE_PATH_WILDCARD = "*{#{CANDIDATE_FILE_NAMES.join(',')}}*"
 
     def self.find(install_path, options = {})
@@ -35,7 +35,7 @@ module LicenseFinder
     def candidate_files_and_dirs
       return [] if install_path.nil?
 
-      Pathname.glob(install_path.join('**', CANDIDATE_PATH_WILDCARD))
+      Pathname.glob(install_path.join('**', CANDIDATE_PATH_WILDCARD), File::FNM_CASEFOLD)
     end
   end
 end

--- a/spec/fixtures/license_names/licence
+++ b/spec/fixtures/license_names/licence
@@ -1,0 +1,1 @@
+The MIT License

--- a/spec/lib/license_finder/packages/license_files_spec.rb
+++ b/spec/lib/license_finder/packages/license_files_spec.rb
@@ -44,7 +44,7 @@ module LicenseFinder
 
       it 'includes files with names like LICENSE, README or COPYING' do
         expect(files_in('license_names')).to match_array(
-          %w[COPYING.txt LICENSE LICENCE.md Mit-License README.rdoc Licence.rdoc]
+          %w[COPYING.txt LICENSE LICENCE.md Mit-License README.rdoc Licence.rdoc licence]
         )
       end
 


### PR DESCRIPTION
I recognized that the detection only matches files with same case, I think it would be better if we ignore the case at all. We have several libraries using `license` as file name which was not detected.