### PR TITLE
docs(upgrade): add note to upgrade to 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,8 @@ licenseConfigurations := Set("compile", "provided")
 
 ## Upgrading
 
+To upgrade to `license_finder` version >= 6.0, you have to replace the terminology `whitelist` with `permit` in your `dependency_decisions.yml`. See [Changelog](https://github.com/pivotal/LicenseFinder/blob/master/CHANGELOG.md#600--2020-01-22) for more details.
+
 To upgrade from `license_finder` version 1.2 to 2.0, see
 [`license_finder_upgrade`](https://github.com/mainej/license_finder_upgrade).
 To upgrade to 2.0 from a version lower than 1.2, first upgrade to 1.2, and run


### PR DESCRIPTION
due to the breaking changes in https://github.com/pivotal/LicenseFinder/blob/master/CHANGELOG.md#600--2020-01-22 you have to make sure to replace the `whitelist` terminology.