### PR TITLE
Update Nuget Package Manager prepare command

### DIFF
--- a/lib/license_finder/logger.rb
+++ b/lib/license_finder/logger.rb
@@ -36,6 +36,8 @@ module LicenseFinder
         "\e[31m#{string}\e[0m"
       when :green
         "\e[32m#{string}\e[0m"
+      when :magenta
+        "\e[35m#{string}\e[0m"
       else
         string
       end

--- a/lib/license_finder/package_manager.rb
+++ b/lib/license_finder/package_manager.rb
@@ -119,8 +119,12 @@ module LicenseFinder
     attr_reader :logger, :project_path
 
     def log_errors(stderr)
-      logger.info prepare_command, 'did not succeed.', color: :red
-      logger.info prepare_command, stderr, color: :red
+      log_errors_with_cmd(prepare_command, stderr)
+    end
+
+    def log_errors_with_cmd(prep_cmd, stderr)
+      logger.info prep_cmd, 'did not succeed.', color: :red
+      logger.info prep_cmd, stderr, color: :red
       log_to_file stderr
     end
 

--- a/spec/lib/license_finder/package_managers/nuget_spec.rb
+++ b/spec/lib/license_finder/package_managers/nuget_spec.rb
@@ -242,17 +242,73 @@ Restoring NuGet package ObscureDependency.1.3.15.
 Restoring NuGet package CoolNewDependency.2.4.2.
         CMDOUTPUT
 
+        nuget_restore_error = <<-CMDOUTPUT
+Cannot determine the packages folder to restore NuGet packages. Please specify either -PackagesDirectory or -SolutionDirectory.
+        CMDOUTPUT
+
         include FakeFS::SpecHelpers
+        let(:log_directory) { '/path/to/project/logs/project' }
+        let(:quiet_logger) { double(:logger) }
+        let(:nuget) {Nuget.new project_path: Pathname.new('app'), log_directory: log_directory, logger: quiet_logger }
+
         before do
-          FileUtils.mkdir_p 'app'
-          FileUtils.touch 'app/MyApp.sln'
+          allow(quiet_logger).to receive(:info)
         end
 
-        it 'should call nuget restore' do
-          nuget = Nuget.new project_path: Pathname.new('app')
-          expect(SharedHelpers::Cmd).to receive(:run).with("#{nuget_cmd} restore")
-                                                     .and_return([nuget_restore_output, '', cmd_success])
-          nuget.prepare
+        context 'for project with a .sln file' do
+          before do
+            FileUtils.mkdir_p 'app'
+            FileUtils.touch 'app/MyApp.sln'
+          end
+
+          it 'should call nuget restore' do
+            expect(SharedHelpers::Cmd).to receive(:run).with("#{nuget_cmd} restore")
+                                                       .and_return([nuget_restore_output, '', cmd_success])
+            expect(SharedHelpers::Cmd).to_not receive(:run).with("#{nuget_cmd} restore -PackagesDirectory .")
+            expect{nuget.prepare}.to_not raise_error
+          end
+
+          context 'if all nuget calls fails' do
+            it 'should raise an error' do
+              # For this scenario, assume bad .sln file, so no matter what, nuget spits out the same error
+              # regardless of parameters being passed
+              expect(SharedHelpers::Cmd).to receive(:run).with("#{nuget_cmd} restore")
+                                                .and_return(['', 'nuget called failed', cmd_failure])
+              expect(SharedHelpers::Cmd).to receive(:run).with("#{nuget_cmd} restore -PackagesDirectory .")
+                                                  .and_return(['', 'nuget called failed', cmd_failure])
+
+              expected_err_msg = "Prepare command '#{nuget_cmd} restore -PackagesDirectory .' failed\nnuget called failed"
+              expect{nuget.prepare}.to raise_error(/#{expected_err_msg}/)
+            end
+          end
+        end
+
+        context 'for project with a packages.config file' do
+          before do
+            FileUtils.mkdir_p 'app'
+            FileUtils.touch 'app/packages.config'
+          end
+
+          it 'should call nuget restore -PackagesDirectory .' do
+            expect(SharedHelpers::Cmd).to receive(:run).with("#{nuget_cmd} restore")
+                                              .and_return(['', nuget_restore_error, cmd_failure])
+            expect(SharedHelpers::Cmd).to receive(:run).with("#{nuget_cmd} restore -PackagesDirectory .")
+                                               .and_return([nuget_restore_output, '', cmd_success])
+            expect{nuget.prepare}.to_not raise_error
+          end
+
+          context 'if all nuget calls fails' do
+            it 'should raise an error' do
+              expect(SharedHelpers::Cmd).to receive(:run).with("#{nuget_cmd} restore")
+                                                .and_return(['', nuget_restore_error, cmd_failure])
+              expect(SharedHelpers::Cmd).to receive(:run).with("#{nuget_cmd} restore -PackagesDirectory .")
+                                                .and_return(['some output', 'nuget called failed', cmd_failure])
+
+              expected_err_msg = "Prepare command '#{nuget_cmd} restore -PackagesDirectory .' failed\nnuget called failed\nsome output\n"
+              expect{nuget.prepare}.to raise_error(/#{expected_err_msg}/)
+
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Nuget failed to 'restore' projects when it only contained the
'packages.config' file. Nuget would complain that it did not know where
to download the packages to.

So, the Nuget package manager has been updated to try the original
command, and if that fails, it would try again but this time providing
an -PackagesDirectory which is set to the current directory.

[#173420224]

Signed-off-by: Jason Smith <jsmith@pivotal.io>