### PR TITLE
Added support for licenses with AND and OR

### DIFF
--- a/lib/license_finder/decisions.rb
+++ b/lib/license_finder/decisions.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'open-uri'
+require 'license_finder/license'
 
 module LicenseFinder
   class Decisions
@@ -39,6 +40,12 @@ module LicenseFinder
     end
 
     def permitted?(lic)
+      if lic.is_a?AndLicense
+        return lic.sub_licenses.all? {|lic| @permitted.include?(lic) }
+      end
+      if lic.is_a?OrLicense
+        return lic.sub_licenses.any? {|lic| @permitted.include?(lic) }
+      end
       @permitted.include?(lic)
     end
 

--- a/lib/license_finder/decisions.rb
+++ b/lib/license_finder/decisions.rb
@@ -40,11 +40,11 @@ module LicenseFinder
     end
 
     def permitted?(lic)
-      if lic.is_a?AndLicense
-        return lic.sub_licenses.all? {|lic| @permitted.include?(lic) }
-      end
       if lic.is_a?OrLicense
         return lic.sub_licenses.any? {|lic| @permitted.include?(lic) }
+      end
+      if lic.is_a?AndLicense
+        return lic.sub_licenses.all? {|lic| @permitted.include?(lic) }
       end
       @permitted.include?(lic)
     end

--- a/lib/license_finder/decisions.rb
+++ b/lib/license_finder/decisions.rb
@@ -40,12 +40,9 @@ module LicenseFinder
     end
 
     def permitted?(lic)
-      if lic.is_a?OrLicense
-        return lic.sub_licenses.any? {|lic| @permitted.include?(lic) }
-      end
-      if lic.is_a?AndLicense
-        return lic.sub_licenses.all? {|lic| @permitted.include?(lic) }
-      end
+      return lic.sub_licenses.any? { |sub_lic| @permitted.include?(sub_lic) } if lic.is_a?(OrLicense)
+      return lic.sub_licenses.all? { |sub_lic| @permitted.include?(sub_lic) } if lic.is_a?(AndLicense)
+
       @permitted.include?(lic)
     end
 

--- a/lib/license_finder/license.rb
+++ b/lib/license_finder/license.rb
@@ -19,12 +19,9 @@ module LicenseFinder
 
       def find_by_name(name)
         name ||= 'unknown'
-        if name.include?OrLicense.operator
-          return OrLicense.new(name)
-        end
-        if name.include?AndLicense.operator
-          return AndLicense.new(name)
-        end
+        return OrLicense.new(name) if name.include?(OrLicense.operator)
+        return AndLicense.new(name) if name.include?(AndLicense.operator)
+
         all.detect { |l| l.matches_name? l.stripped_name(name) } || Definitions.build_unrecognized(name)
       end
 
@@ -81,9 +78,11 @@ module LicenseFinder
     end
   end
   class AndLicense < License
+
     def self.operator
-      " AND "
-    end 
+      ' AND '
+    end
+
     def initialize(name,operator = AndLicense.operator)
       @short_name = name
       @pretty_name = name
@@ -91,19 +90,21 @@ module LicenseFinder
       @matcher = NoneMatcher.new
       # removes heading and trailing parentesis and splits
       names = name[1..-2].split(operator)
-      @sub_licenses = names.map do |name|
-        License.find_by_name(name)
+      @sub_licenses = names.map do |sub_name|
+        License.find_by_name(sub_name)
       end
     end
-    def sub_licenses
-      @sub_licenses
-    end
+
+    attr_reader :sub_licenses
+
   end
-  
+
   class OrLicense < AndLicense
+
     def self.operator
-      " OR "
-    end 
+      ' OR '
+    end
+
     def initialize(name,operator = AndLicense.operator)
       super(name, OrLicense.operator)
     end

--- a/lib/license_finder/license.rb
+++ b/lib/license_finder/license.rb
@@ -78,12 +78,11 @@ module LicenseFinder
     end
   end
   class AndLicense < License
-
     def self.operator
       ' AND '
     end
 
-    def initialize(name,operator = AndLicense.operator)
+    def initialize(name, operator = AndLicense.operator)
       @short_name = name
       @pretty_name = name
       @url = nil
@@ -96,16 +95,14 @@ module LicenseFinder
     end
 
     attr_reader :sub_licenses
-
   end
 
   class OrLicense < AndLicense
-
     def self.operator
       ' OR '
     end
 
-    def initialize(name,operator = AndLicense.operator)
+    def initialize(name)
       super(name, OrLicense.operator)
     end
   end

--- a/spec/lib/license_finder/decision_applier_spec.rb
+++ b/spec/lib/license_finder/decision_applier_spec.rb
@@ -243,6 +243,7 @@ module LicenseFinder
                              .license('manual', 'GPLv3')
                              .permit('GPLv3')
         decision_applier = described_class.new(decisions: decisions, packages: [dep])
+        dep = decision_applier.acknowledged.last
         expect(dep).to be_approved
         expect(dep).to be_permitted
       end
@@ -253,6 +254,7 @@ module LicenseFinder
                              .license('manual', 'GPLv3')
                              .permit('GPLv3')
         decision_applier = described_class.new(decisions: decisions, packages: [dep])
+        dep = decision_applier.acknowledged.last
         expect(dep).not_to be_approved
         expect(dep).not_to be_permitted
       end
@@ -265,6 +267,7 @@ module LicenseFinder
                              .license('manual', 'GPLv3')
                              .permit('GPLv3')
         decision_applier = described_class.new(decisions: decisions, packages: [dep])
+        dep = decision_applier.acknowledged.last
         expect(dep).to be_approved
         expect(dep).to be_permitted
       end
@@ -273,6 +276,7 @@ module LicenseFinder
         decisions = Decisions.new
                              .add_package('manual', nil)
         decision_applier = described_class.new(decisions: decisions, packages: [dep])
+        dep = decision_applier.acknowledged.last
         expect(dep).not_to be_approved
         expect(dep).not_to be_permitted
       end

--- a/spec/lib/license_finder/decision_applier_spec.rb
+++ b/spec/lib/license_finder/decision_applier_spec.rb
@@ -233,5 +233,49 @@ module LicenseFinder
         expect(decision_applier.restricted).to be_empty
       end
     end
+    describe 'AND compound licenses' do
+      it 'checks all AND condition: success case' do
+        dep = Package.new('dep', nil, spec_licenses: ['(GPLv3 AND MIT)'])
+        decisions = Decisions.new
+                             .add_package('manual', nil)
+                             .license('manual', 'MIT')
+                             .permit('MIT')
+                             .license('manual', 'GPLv3')
+                             .permit('GPLv3')
+        decision_applier = described_class.new(decisions: decisions, packages: [dep])
+        expect(dep).to be_approved
+        expect(dep).to be_permitted
+      end
+      it 'checks all AND condition: fail case' do
+        dep = Package.new('dep', nil, spec_licenses: ['(GPLv3 AND MIT)'])
+        decisions = Decisions.new
+                             .add_package('manual', nil)
+                             .license('manual', 'GPLv3')
+                             .permit('GPLv3')
+        decision_applier = described_class.new(decisions: decisions, packages: [dep])
+        expect(dep).not_to be_approved
+        expect(dep).not_to be_permitted
+      end
+    end
+    describe 'OR compound licenses' do
+      it 'checks at least one OR condition: success case' do
+        dep = Package.new('dep', nil, spec_licenses: ['(GPLv3 OR MIT)'])
+        decisions = Decisions.new
+                             .add_package('manual', nil)
+                             .license('manual', 'GPLv3')
+                             .permit('GPLv3')
+        decision_applier = described_class.new(decisions: decisions, packages: [dep])
+        expect(dep).to be_approved
+        expect(dep).to be_permitted
+      end
+      it 'checks failure when no OR condition' do
+        dep = Package.new('dep', nil, spec_licenses: ['(GPLv3 OR MIT)'])
+        decisions = Decisions.new
+                             .add_package('manual', nil)
+        decision_applier = described_class.new(decisions: decisions, packages: [dep])
+        expect(dep).not_to be_approved
+        expect(dep).not_to be_permitted
+      end
+    end
   end
 end

--- a/spec/lib/license_finder/decision_applier_spec.rb
+++ b/spec/lib/license_finder/decision_applier_spec.rb
@@ -242,8 +242,7 @@ module LicenseFinder
                              .permit('MIT')
                              .license('manual', 'GPLv3')
                              .permit('GPLv3')
-        decision_applier = described_class.new(decisions: decisions, packages: [dep])
-        dep = decision_applier.acknowledged.last
+        described_class.new(decisions: decisions, packages: [dep])
         expect(dep).to be_approved
         expect(dep).to be_permitted
       end
@@ -253,8 +252,7 @@ module LicenseFinder
                              .add_package('manual', nil)
                              .license('manual', 'GPLv3')
                              .permit('GPLv3')
-        decision_applier = described_class.new(decisions: decisions, packages: [dep])
-        dep = decision_applier.acknowledged.last
+        described_class.new(decisions: decisions, packages: [dep])
         expect(dep).not_to be_approved
         expect(dep).not_to be_permitted
       end
@@ -266,8 +264,7 @@ module LicenseFinder
                              .add_package('manual', nil)
                              .license('manual', 'GPLv3')
                              .permit('GPLv3')
-        decision_applier = described_class.new(decisions: decisions, packages: [dep])
-        dep = decision_applier.acknowledged.last
+        described_class.new(decisions: decisions, packages: [dep])
         expect(dep).to be_approved
         expect(dep).to be_permitted
       end
@@ -275,8 +272,7 @@ module LicenseFinder
         dep = Package.new('dep', nil, spec_licenses: ['(GPLv3 OR MIT)'])
         decisions = Decisions.new
                              .add_package('manual', nil)
-        decision_applier = described_class.new(decisions: decisions, packages: [dep])
-        dep = decision_applier.acknowledged.last
+        described_class.new(decisions: decisions, packages: [dep])
         expect(dep).not_to be_approved
         expect(dep).not_to be_permitted
       end

--- a/spec/lib/license_finder/license_spec.rb
+++ b/spec/lib/license_finder/license_spec.rb
@@ -8,7 +8,7 @@ module LicenseFinder
       it 'should create a compound OR license' do
         license = License.find_by_name('(MIT AND CC0-1.0)')
         expect(license.name).to eq '(MIT AND CC0-1.0)'
-        expect(license.is_a?AndLicense).to eq true
+        expect(license.is_a?(AndLicense)).to eq true
       end
       it 'should create populate sub licenses for compound AND' do
         license = License.find_by_name('(MIT AND CC0-1.0)')
@@ -23,7 +23,7 @@ module LicenseFinder
       it 'should create a compound OR license' do
         license = License.find_by_name('MIT OR CC0-1.0')
         expect(license.name).to eq 'MIT OR CC0-1.0'
-        expect(license.is_a?OrLicense).to eq true
+        expect(license.is_a?(OrLicense)).to eq true
       end
     end
   end

--- a/spec/lib/license_finder/license_spec.rb
+++ b/spec/lib/license_finder/license_spec.rb
@@ -3,6 +3,30 @@
 require 'spec_helper'
 
 module LicenseFinder
+  describe AndLicense do
+    describe '.find_by_name' do
+      it 'should create a compound OR license' do
+        license = License.find_by_name('(MIT AND CC0-1.0)')
+        expect(license.name).to eq '(MIT AND CC0-1.0)'
+        expect(license.is_a?AndLicense).to eq true
+      end
+      it 'should create populate sub licenses for compound AND' do
+        license = License.find_by_name('(MIT AND CC0-1.0)')
+        expect(license.sub_licenses[0].name).to eq 'MIT'
+        expect(license.sub_licenses[1].name).to eq 'CC0-1.0'
+      end
+    end
+  end
+  describe AndLicense do
+    describe '.find_by_name' do
+      # sub licenses case already tested on and, since this is subclass
+      it 'should create a compound OR license' do
+        license = License.find_by_name('MIT OR CC0-1.0')
+        expect(license.name).to eq 'MIT OR CC0-1.0'
+        expect(license.is_a?OrLicense).to eq true
+      end
+    end
+  end
   describe License do
     describe '.find_by_name' do
       it 'should find a registered license' do


### PR DESCRIPTION
Should be a solution for https://github.com/pivotal/LicenseFinder/issues/728

Althouhg for now only working when using `find_by_name`. Probably should be done for `find_by_text` too.
Anyway, for `find_by_text` it will still return the same result as it did before, thus failing in the AND/OR case, but will not cause errors. 