### PR TITLE
Match license names from pypi api call with known licenses

### DIFF
--- a/features/features/package_managers/pip_spec.rb
+++ b/features/features/package_managers/pip_spec.rb
@@ -12,7 +12,7 @@ describe 'Pip Dependencies' do
   specify 'are shown in reports' do
     LicenseFinder::TestingDSL::PipProject.create
     python_developer.run_license_finder
-    expect(python_developer).to be_seeing_line 'rsa, 3.1.4, "ASL 2"'
+    expect(python_developer).to be_seeing_line 'rsa, 3.1.4, "Apache 2.0"'
   end
 
   context 'when there are platform markers' do

--- a/lib/license_finder/license.rb
+++ b/lib/license_finder/license.rb
@@ -61,6 +61,10 @@ module LicenseFinder
       name.hash
     end
 
+    def unrecognized_matcher?
+      matcher.is_a?(NoneMatcher)
+    end
+
     private
 
     attr_reader :short_name, :pretty_name, :other_names

--- a/lib/license_finder/packages/pip_package.rb
+++ b/lib/license_finder/packages/pip_package.rb
@@ -9,13 +9,15 @@ module LicenseFinder
 
     def self.license_names_from_spec(spec)
       license_names = spec['license'].to_s.strip.split(' or ')
+      has_unrecognized_license = false
 
-      license_name_validity = license_names.map do |license_name|
+      license_names.each do |license_name|
         license = License.find_by_name(license_name.strip)
-        license.unrecognized_matcher?
+
+        has_unrecognized_license = has_unrecognized_license || license.unrecognized_matcher?
       end
 
-      return license_names if !license_name_validity.empty? && license_name_validity.include?(false)
+      return license_names if !license_names.empty? && !has_unrecognized_license
 
       spec
         .fetch('classifiers', [])

--- a/lib/license_finder/packages/pip_package.rb
+++ b/lib/license_finder/packages/pip_package.rb
@@ -14,7 +14,7 @@ module LicenseFinder
       license_names.each do |license_name|
         license = License.find_by_name(license_name.strip)
 
-        has_unrecognized_license = has_unrecognized_license || license.unrecognized_matcher?
+        has_unrecognized_license ||= license.unrecognized_matcher?
       end
 
       return license_names if !license_names.empty? && !has_unrecognized_license

--- a/lib/license_finder/packages/pip_package.rb
+++ b/lib/license_finder/packages/pip_package.rb
@@ -8,9 +8,14 @@ module LicenseFinder
     INVALID_LICENSES = ['', 'UNKNOWN'].to_set
 
     def self.license_names_from_spec(spec)
-      license = spec['license'].to_s.strip
+      license_names = spec['license'].to_s.strip.split(' or ')
 
-      return [license] unless INVALID_LICENSES.include?(license)
+      license_name_validity = license_names.map do |license_name|
+        license = License.find_by_name(license_name.strip)
+        license.unrecognized_matcher?
+      end
+
+      return license_names if !license_name_validity.empty? && license_name_validity.include?(false)
 
       spec
         .fetch('classifiers', [])

--- a/spec/lib/license_finder/license_spec.rb
+++ b/spec/lib/license_finder/license_spec.rb
@@ -110,4 +110,22 @@ module LicenseFinder
       expect(make_license.name).to eq('Default Short Name')
     end
   end
+
+  describe '.unrecognized_matcher?' do
+    context 'when the license has unrecognized matcher' do
+      let(:license) { License::Definitions.build_unrecognized('unknown') }
+
+      it 'should return true' do
+        expect(license.unrecognized_matcher?).to be_truthy
+      end
+    end
+
+    context 'when the license does not have unrecognized matcher' do
+      let(:license) { License.find_by_name('The MIT License') }
+
+      it 'should return false' do
+        expect(license.unrecognized_matcher?).to be_falsy
+      end
+    end
+  end
 end

--- a/spec/lib/license_finder/package_managers/pipenv_spec.rb
+++ b/spec/lib/license_finder/package_managers/pipenv_spec.rb
@@ -42,6 +42,20 @@ module LicenseFinder
         ]
       end
 
+      let(:expected_dependencies) do
+        [
+          { name: 'attrs', version: '19.3.0', licenses: ['MIT'], groups: ['develop'] },
+          { name: 'more-itertools', version: '8.0.2', licenses: ['MIT'], groups: ['develop'] },
+          { name: 'packaging', version: '20.0', licenses: ['Apache 2.0', 'BSD'], groups: ['develop'] },
+          { name: 'pluggy', version: '0.13.1', licenses: ['MIT'], groups: ['develop'] },
+          { name: 'py', version: '1.8.1', licenses: ['MIT'], groups: ['develop'] },
+          { name: 'pyparsing', version: '2.4.6', licenses: ['MIT'], groups: ['develop'] },
+          { name: 'pytest', version: '5.3.2', licenses: ['MIT'], groups: ['develop'] },
+          { name: 'six', version: '1.13.0', licenses: ['MIT'], groups: %w[default develop] },
+          { name: 'wcwidth', version: '0.1.8', licenses: ['MIT'], groups: ['develop'] }
+        ]
+      end
+
       before do
         dependencies.each do |item|
           url = url_for(item[:name], item[:version])
@@ -54,8 +68,8 @@ module LicenseFinder
         actual = subject.current_packages.map do |package|
           [package.name, package.version, package.licenses.map(&:name), package.groups]
         end
-        expected = dependencies.map do |package|
-          [package[:name], package[:version], [package[:license]], package[:groups]]
+        expected = expected_dependencies.map do |package|
+          [package[:name], package[:version], package[:licenses], package[:groups]]
         end
         expect(actual).to match_array(expected)
       end

--- a/spec/lib/license_finder/packages/pip_package_spec.rb
+++ b/spec/lib/license_finder/packages/pip_package_spec.rb
@@ -7,5 +7,68 @@ module LicenseFinder
     subject { described_class.new('a package', '1.1.1', {}) }
 
     its(:package_url) { should == 'https://pypi.org/project/a+package/1.1.1/' }
+
+    describe '.license_names_from_spec' do
+      before do
+        allow(License).to receive(:find_by_name).and_return(license)
+      end
+
+      context 'when license name is supported' do
+        let(:spec) { { 'license' => 'some-license' } }
+        let(:license) { instance_double(LicenseFinder::License, unrecognized_matcher?: false) }
+
+        it 'should return license name from license parameter' do
+          expect(described_class.license_names_from_spec(spec)).to eq(['some-license'])
+        end
+      end
+
+      context 'when license name is not supported' do
+        let(:spec) do
+          {
+            'license' => 'some-license',
+            'classifiers' => [
+              'some-info',
+              'License :: OSI Approved :: Apache Software License'
+            ]
+
+          }
+        end
+        let(:license) { instance_double(LicenseFinder::License, unrecognized_matcher?: true) }
+
+        it 'should return license name from classifier parameter' do
+          expect(described_class.license_names_from_spec(spec)).to eq(['Apache Software License'])
+        end
+      end
+
+      context 'when multiple licenses are provided' do
+        context 'when all licenses are supported' do
+          let(:spec) { { 'license' => 'some-license or some-other-license' } }
+          let(:license) { instance_double(LicenseFinder::License, unrecognized_matcher?: false) }
+
+          it 'should return license name from license parameter' do
+            expect(described_class.license_names_from_spec(spec)).to eq(%w[some-license some-other-license])
+          end
+        end
+
+        context 'when any of the licenses are unsupported' do
+          let(:spec) do
+            {
+              'license' => 'some-license or some-other-license',
+              'classifiers' => [
+                'some-info',
+                'License :: OSI Approved :: Apache Software License',
+                'License :: OSI Approved :: BSD License'
+              ]
+
+            }
+          end
+          let(:license) { instance_double(LicenseFinder::License, unrecognized_matcher?: true) }
+
+          it 'should return license name from classifier parameter' do
+            expect(described_class.license_names_from_spec(spec)).to eq(['Apache Software License', 'BSD License'])
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
[CHANGED] matches license names from `pypi api` call with known licenses to avoid returning mis-formatted licenses in the report


[#173421573]

Signed-off-by: Jeff Jun <jjun@pivotal.io>