### PR TITLE
Fix Go modules package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ languages, as long as that language has a package definition in the project dire
 * `glide.lock` file (for `glide`)
 * `vendor/vendor.json` file (for `govendor`)
 * `Gopkg.lock` file (for `dep`)
-* `go.sum` file (for `go mod`)
+* `go.mod` file (for `go mod`)
 * `vendor.conf` file (for `trash`)
 * `yarn.lock` file (for `yarn`)
 * `conanfile.txt` file (for `conan`)

--- a/lib/license_finder/package_managers/go_modules.rb
+++ b/lib/license_finder/package_managers/go_modules.rb
@@ -4,7 +4,7 @@ require 'license_finder/packages/go_package'
 
 module LicenseFinder
   class GoModules < PackageManager
-    PACKAGES_FILE = 'go.sum'
+    PACKAGES_FILE = 'go.mod'
 
     class << self
       def takes_priority_over
@@ -17,7 +17,7 @@ module LicenseFinder
     end
 
     def active?
-      sum_files?
+      mod_files?
     end
 
     def current_packages
@@ -41,11 +41,11 @@ module LicenseFinder
       info_output.split("\n")
     end
 
-    def sum_files?
-      sum_file_paths.any?
+    def mod_files?
+      mod_file_paths.any?
     end
 
-    def sum_file_paths
+    def mod_file_paths
       Dir[project_path.join(PACKAGES_FILE)]
     end
 

--- a/lib/license_finder/package_managers/go_modules.rb
+++ b/lib/license_finder/package_managers/go_modules.rb
@@ -31,6 +31,8 @@ module LicenseFinder
     def packages_info
       Dir.chdir(project_path) do
         # Explanations:
+        # * Only list dependencies (packages not listed in the project directory)
+        #   (.DepOnly)
         # * Ignore standard library packages
         #   (not .Standard)
         # * Replacement modules are respected
@@ -38,7 +40,7 @@ module LicenseFinder
         # * Module cache directory or (vendored) package directory
         #   (or $mod.Dir .Dir)
         format_str = \
-          '{{ if not .Standard }}'\
+          '{{ if and (.DepOnly) (not .Standard) }}'\
             '{{ $mod := (or .Module.Replace .Module) }}'\
             '{{ $mod.Path }},{{ $mod.Version }},{{ or $mod.Dir .Dir }}'\
           '{{ end }}'
@@ -49,8 +51,11 @@ module LicenseFinder
         #
         # Instead, the owning module is listed for each imported package. This better
         # matches the implementation of other Go package managers.
-        info_output, stderr, _status = Cmd.run("GO111MODULE=on go list -f '#{format_str}' all")
-        info_output, _stderr, _status = Cmd.run("GO111MODULE=on go list -mod=mod -f '#{format_str}' all") if stderr =~ Regexp.compile("can't compute 'all' using the vendor directory")
+        #
+        # TODO: Figure out a way to make the vendor directory work (i.e. remove the
+        # -mod=readonly flag). Each of the imported packages gets listed separatly,
+        # confusing the issue as to which package is the root of the module.
+        info_output, _stderr, _status = Cmd.run("GO111MODULE=on go list -mod=readonly -deps -f '#{format_str}' ./...")
 
         # Since many packages may belong to a single module, #uniq is used to deduplicate
         info_output.split("\n").uniq

--- a/lib/license_finder/package_managers/go_modules.rb
+++ b/lib/license_finder/package_managers/go_modules.rb
@@ -33,12 +33,14 @@ module LicenseFinder
     private
 
     def packages_info
-      info_output, stderr, _status = Cmd.run("GO111MODULE=on go list -m -f '{{.Path}},{{.Version}},{{.Dir}}' all")
-      if stderr =~ Regexp.compile("can't compute 'all' using the vendor directory")
-        info_output, _stderr, _status = Cmd.run("GO111MODULE=on go list -m -mod=mod -f '{{.Path}},{{.Version}},{{.Dir}}' all")
-      end
+      Dir.chdir(project_path) do
+        info_output, stderr, _status = Cmd.run("GO111MODULE=on go list -m -f '{{.Path}},{{.Version}},{{.Dir}}' all")
+        if stderr =~ Regexp.compile("can't compute 'all' using the vendor directory")
+          info_output, _stderr, _status = Cmd.run("GO111MODULE=on go list -m -mod=mod -f '{{.Path}},{{.Version}},{{.Dir}}' all")
+        end
 
-      info_output.split("\n")
+        info_output.split("\n")
+      end
     end
 
     def mod_files?

--- a/lib/license_finder/package_managers/go_modules.rb
+++ b/lib/license_finder/package_managers/go_modules.rb
@@ -12,10 +12,6 @@ module LicenseFinder
       end
     end
 
-    def prepare_command
-      'GO111MODULE=on go mod tidy && GO111MODULE=on go mod vendor'
-    end
-
     def active?
       mod_files?
     end

--- a/spec/fixtures/config/go.mod
+++ b/spec/fixtures/config/go.mod
@@ -1,0 +1,6 @@
+module foo
+
+require (
+	gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
+	gopkg.in/yaml.v2 v2.2.1
+)

--- a/spec/fixtures/config/go.sum
+++ b/spec/fixtures/config/go.sum
@@ -1,4 +1,0 @@
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
-gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/spec/lib/license_finder/package_managers/go_modules_spec.rb
+++ b/spec/lib/license_finder/package_managers/go_modules_spec.rb
@@ -79,12 +79,6 @@ module LicenseFinder
       end
     end
 
-    describe '.prepare_command' do
-      it 'returns the correct package management command' do
-        expect(subject.prepare_command).to eq('GO111MODULE=on go mod tidy && GO111MODULE=on go mod vendor')
-      end
-    end
-
     describe '.takes_priority_over' do
       it 'returns the package manager it takes priority over' do
         expect(described_class.takes_priority_over).to eq(Go15VendorExperiment)

--- a/spec/lib/license_finder/package_managers/go_modules_spec.rb
+++ b/spec/lib/license_finder/package_managers/go_modules_spec.rb
@@ -8,7 +8,7 @@ module LicenseFinder
     it_behaves_like 'a PackageManager'
 
     let(:src_path) { '/workspace/code' }
-    let(:sum_path) { "#{src_path}/go.sum" }
+    let(:mod_path) { "#{src_path}/go.mod" }
     let(:vendor_path) { "#{src_path}/vendor" }
     let(:go_list_string) do
       "foo,,/workspace/code/\ngopkg.in/check.v1,v0.0.0-20161208181325-20d25e280405,"\
@@ -22,7 +22,7 @@ module LicenseFinder
         FakeFS.activate!
 
         FileUtils.mkdir_p(vendor_path)
-        File.write(sum_path, content)
+        File.write(mod_path, content)
 
         allow(SharedHelpers::Cmd).to receive(:run).with("GO111MODULE=on go list -m -f '{{.Path}},{{.Version}},{{.Dir}}' all").and_return(go_list_string)
       end
@@ -33,11 +33,11 @@ module LicenseFinder
 
       let(:content) do
         FakeFS.without do
-          fixture_from('go.sum')
+          fixture_from('go.mod')
         end
       end
 
-      it 'finds all the packages all go.sum files' do
+      it 'finds all the packages all go.mod files' do
         packages = subject.current_packages
 
         expect(packages.length).to eq 2
@@ -65,7 +65,7 @@ module LicenseFinder
             .and_return(go_list_string)
         end
 
-        it 'finds all the packages all go.sum files' do
+        it 'finds all the packages all go.mod files' do
           packages = subject.current_packages
 
           expect(packages.length).to eq 2

--- a/spec/lib/license_finder/package_managers/go_modules_spec.rb
+++ b/spec/lib/license_finder/package_managers/go_modules_spec.rb
@@ -10,7 +10,7 @@ module LicenseFinder
     let(:src_path) { '/workspace/code' }
     let(:mod_path) { "#{src_path}/go.mod" }
     let(:vendor_path) { "#{src_path}/vendor" }
-    let(:go_list_format) { '{{ if not .Standard }}{{ $mod := (or .Module.Replace .Module) }}{{ $mod.Path }},{{ $mod.Version }},{{ or $mod.Dir .Dir }}{{ end }}' }
+    let(:go_list_format) { '{{ if and (.DepOnly) (not .Standard) }}{{ $mod := (or .Module.Replace .Module) }}{{ $mod.Path }},{{ $mod.Version }},{{ or $mod.Dir .Dir }}{{ end }}' }
     let(:go_list_string) do
       "foo,,/workspace/code/\ngopkg.in/check.v1,v0.0.0-20161208181325-20d25e280405,"\
 "/workspace/LicenseFinder/features/fixtures/go_modules/vendor/gopkg.in/check.v1\n"\
@@ -26,7 +26,7 @@ module LicenseFinder
         FileUtils.mkdir_p(vendor_path)
         File.write(mod_path, content)
 
-        allow(SharedHelpers::Cmd).to receive(:run).with("GO111MODULE=on go list -f '#{go_list_format}' all").and_return(go_list_string)
+        allow(SharedHelpers::Cmd).to receive(:run).with("GO111MODULE=on go list -mod=readonly -deps -f '#{go_list_format}' ./...").and_return(go_list_string)
       end
 
       after do
@@ -55,29 +55,6 @@ module LicenseFinder
         packages = subject.current_packages
 
         expect(packages.first.package_manager).to eq 'Go'
-      end
-
-      context 'when compute is not allowed on vendor' do
-        before do
-          allow(SharedHelpers::Cmd).to receive(:run)
-            .with("GO111MODULE=on go list -f '#{go_list_format}' all")
-            .and_return(['', "go list -m: can't compute 'all' using the vendor directory\n\t(Use -mod=mod or -mod=readonly to bypass.)\n", 1])
-          allow(SharedHelpers::Cmd).to receive(:run)
-            .with("GO111MODULE=on go list -mod=mod -f '#{go_list_format}' all")
-            .and_return(go_list_string)
-        end
-
-        it 'finds all the packages all go.mod files' do
-          packages = subject.current_packages
-
-          expect(packages.length).to eq 2
-
-          expect(packages.first.name).to eq 'gopkg.in/check.v1'
-          expect(packages.first.version).to eq 'v0.0.0-20161208181325-20d25e280405'
-
-          expect(packages.last.name).to eq 'gopkg.in/yaml.v2'
-          expect(packages.last.version).to eq 'v2.2.1'
-        end
       end
     end
 


### PR DESCRIPTION
While upgrading our Go project from Glide to Go modules, we noticed a number of discrepancies between the two implementations. This PR attempts to address these inconsistencies.

Each fix has been separated into its own commit for ease of review, but I am happy to separate these into individual PRs as well, if that makes things easier.

The issues discovered are as follows:

1. The `go.mod` file should be used to identify a module, not `go.sum` (667f6be716504a53ccc2824daae08af085566546)
2. The `go.mod` file is discovered based on the current working directory, so the working directory needs to be changed to the project path before invoking `go` (667f6be716504a53ccc2824daae08af085566546)
3. The `go list` command requires no preparation, tidying, nor vendoring (284cc5c821270a6e56275e32bac836a3e451f46b)
4. Only imported packages/modules should be listed (just like other Go package manager implementations) (34361fdab2dc3f197f7aec6408175018dee3b453 and dffae4ab95e34115b6a54bf681fc0966a8611f01)