### PR TITLE
Add CHANGELOG notes for v6.6.2 Go modules changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,18 @@
 
 ### Added
 * support for rebar3 [Removed] support for rebar2 [#173637980] - [b20e7444](https://github.com/pivotal/LicenseFinder/commit/b20e7444c147d8dbfa46eb4e8e549e03be751e02) - Jeff Jun
+* Support for Go modules projects outside of the current working directory - [56b3bec6](https://github.com/pivotal/LicenseFinder/commit/56b3bec632b3884ce4cad538742b4a13c55fd7c5)
+
+### Changed
+* Change Go modules to only report imported packages (as with other Go package managers) - [34361fda](https://github.com/pivotal/LicenseFinder/commit/34361fdab2dc3f197f7aec6408175018dee3b453) and [dffae4ab](https://github.com/pivotal/LicenseFinder/commit/dffae4ab95e34115b6a54bf681fc0966a8611f01)
+* Detect Go modules based on `go.mod` (instead of `go.sum`) - [667f6be7](https://github.com/pivotal/LicenseFinder/commit/667f6be716504a53ccc2824daae08af085566546)
 
 ### Fixed
 * handle empty case for mix dependencies [#173637843] - [fc34b281](https://github.com/pivotal/LicenseFinder/commit/fc34b2813925a709addde675849e199b05fc4a23) - Jeff Jun
 
 ### Removed
 [Added] support for rebar3 * support for rebar2 [#173637980] - [b20e7444](https://github.com/pivotal/LicenseFinder/commit/b20e7444c147d8dbfa46eb4e8e549e03be751e02) - Jeff Jun
+* Removed the unnecessary prepare command for Go modules - [284cc5c8](https://github.com/pivotal/LicenseFinder/commit/284cc5c821270a6e56275e32bac836a3e451f46b)
 
 # [6.6.1] / 2020-06-30
 


### PR DESCRIPTION
This simply adds missing CHANGELOG notes for the Go modules changes that went into v6.6.2, as mentioned [here](https://github.com/pivotal/LicenseFinder/pull/764#issuecomment-656240927).