### PR TITLE
Add other characters as possible representation of list bullets

### DIFF
--- a/features/features/package_managers/erlangmk_spec.rb
+++ b/features/features/package_managers/erlangmk_spec.rb
@@ -19,7 +19,7 @@ describe 'Erlangmk Dependencies' do
     expect(erlang_developer).to be_seeing_line 'credentials_obfuscation, 2.0.0, "Apache 2.0, Mozilla Public License 1.1"'
     expect(erlang_developer).to be_seeing_line 'cuttlefish, 2.2.0, unknown'
     expect(erlang_developer).to be_seeing_line 'gen_batch_server, 0.8.2, "Apache 2.0, Mozilla Public License 1.1"'
-    expect(erlang_developer).to be_seeing_line 'getopt, 1.0.1, unknown'
+    expect(erlang_developer).to be_seeing_line 'getopt, 1.0.1, "New BSD"'
     expect(erlang_developer).to be_seeing_line 'goldrush, 0.1.9, ISC'
     expect(erlang_developer).to be_seeing_line 'jsx, 2.9.0, MIT'
     expect(erlang_developer).to be_seeing_line 'lager, 3.7.0, "Apache 2.0"'

--- a/lib/license_finder/license/text.rb
+++ b/lib/license_finder/license/text.rb
@@ -10,8 +10,8 @@ module LicenseFinder
       SPECIAL_DOUBLE_QUOTES = /[“”„«»]/.freeze
       ALPHABET_ORDERED_LIST = /\\\([a-z]\\\)\\\s/.freeze
       ALPHABET_ORDERED_LIST_OPTIONAL = '(\([a-z]\)\s)?'
-      LIST_BULLETS = /(\d{1,2}\\\.|\\\*)\\\s/.freeze
-      LIST_BULLETS_OPTIONAL = '(\d{1,2}.|\*)?\s*'
+      LIST_BULLETS = /(\d{1,2}\\\.|\\\*|\\\-)\\\s/.freeze
+      LIST_BULLETS_OPTIONAL = '(\d{1,2}.|\*|\-)?\s*'
       NEWLINE_CHARACTER = /\n+/.freeze
       QUOTE_COMMENT_CHARACTER = /^\s*\>+/.freeze
       ESCAPED_QUOTES = /\\\"/.freeze

--- a/spec/lib/license_finder/license/text_spec.rb
+++ b/spec/lib/license_finder/license/text_spec.rb
@@ -118,14 +118,16 @@ describe LicenseFinder::License::Text do
         text = <<~TEXT
           1. for an apple
           * for a loaf of bread
+          - for a hat
         TEXT
 
-        expected_regex = Regexp.new('(\d{1,2}.|\*)?\s*for\ an\ apple\ (\d{1,2}.|\*)?\s*for\ a\ loaf\ of\ bread')
+        expected_regex = Regexp.new('(\d{1,2}.|\*|\-)?\s*for\ an\ apple\ (\d{1,2}.|\*|\-)?\s*for\ a\ loaf\ of\ bread\ (\d{1,2}.|\*|\-)?\s*for\ a\ hat')
 
         expect(described_class.compile_to_regex(text)).to eq(expected_regex)
-        expect(described_class.compile_to_regex(text)).to match('1. for an apple * for a loaf of bread')
-        expect(described_class.compile_to_regex(text)).to match('* for an apple 1. for a loaf of bread')
-        expect(described_class.compile_to_regex(text)).to match('for an apple for a loaf of bread')
+        expect(described_class.compile_to_regex(text)).to match('1. for an apple 1. for a loaf of bread 1. for a hat')
+        expect(described_class.compile_to_regex(text)).to match('* for an apple * for a loaf of bread * for a hat')
+        expect(described_class.compile_to_regex(text)).to match('- for an apple - for a loaf of bread - for a hat')
+        expect(described_class.compile_to_regex(text)).to match('for an apple for a loaf of bread for a hat')
       end
 
       context 'when the text contains brackets near the unordered bullets' do
@@ -136,7 +138,7 @@ describe LicenseFinder::License::Text do
             **
           TEXT
 
-          expected_regex = Regexp.new('\*(\d{1,2}.|\*)?\s*(\d{1,2}.|\*)?\s*\(banana\ bread\)\ \*\*')
+          expected_regex = Regexp.new('\*(\d{1,2}.|\*|\-)?\s*(\d{1,2}.|\*|\-)?\s*\(banana\ bread\)\ \*\*')
 
           expect(described_class.compile_to_regex(text)).to eq(expected_regex)
           expect(described_class.compile_to_regex(text)).to match('** (banana bread) **')


### PR DESCRIPTION
To address [this issue](https://github.com/pivotal/LicenseFinder/issues/768)