### PR TITLE
Relax erlang version regex

### DIFF
--- a/lib/license_finder/packages/erlangmk_package.rb
+++ b/lib/license_finder/packages/erlangmk_package.rb
@@ -38,7 +38,6 @@ module LicenseFinder
 
     def dep_version
       @dep_version ||= begin
-        version_prefix_re = Regexp.new('^v')
         dep_version_unformatted.sub(version_prefix_re, '')
       end
     end
@@ -96,12 +95,20 @@ module LicenseFinder
       if dep_version =~ version_re
         Gem::Version.correct?(dep_version)
       else
-        dep_version =~ word_re
+        dep_version =~ word_dot_re
       end
     end
 
     def version_re
       @version_re ||= Regexp.new('\d+\.\d+\.\d+')
+    end
+
+    def word_dot_re
+      @word_dot_re ||= Regexp.new('^[.\w]+$')
+    end
+
+    def version_prefix_re
+      @version_prefix_re ||= Regexp.new('^v')
     end
   end
 end

--- a/lib/license_finder/packages/erlangmk_package.rb
+++ b/lib/license_finder/packages/erlangmk_package.rb
@@ -80,10 +80,6 @@ module LicenseFinder
       dep =~ word_re
     end
 
-    def word_re
-      @word_re ||= Regexp.new('^\w+$')
-    end
-
     def dep_repo_valid?
       set?(dep_repo_unformatted) &&
         URI.parse(dep_repo)
@@ -103,12 +99,16 @@ module LicenseFinder
       @version_re ||= Regexp.new('\d+\.\d+\.\d+')
     end
 
-    def word_dot_re
-      @word_dot_re ||= Regexp.new('^[.\w]+$')
-    end
-
     def version_prefix_re
       @version_prefix_re ||= Regexp.new('^v')
+    end
+
+    def word_re
+      @word_re ||= Regexp.new('^\w+$')
+    end
+
+    def word_dot_re
+      @word_dot_re ||= Regexp.new('^[.\w]+$')
     end
   end
 end

--- a/spec/lib/license_finder/package_managers/erlangmk_spec.rb
+++ b/spec/lib/license_finder/package_managers/erlangmk_spec.rb
@@ -18,8 +18,10 @@ module LicenseFinder
     # Also NOTE:
     #
     # This line was added manually to test the case where a git branch is the "version":
-    #
     # erlangmk_spec_fake_lib: another_fake_lib git https://github.com/rabbitmq/rabbitmq-fake-lib master /fake/path
+    #
+    # This line was added manually to test v3.8.x as the version:
+    # erlangmk_spec_fake_lib: another_fake_lib_two git https://github.com/rabbitmq/rabbitmq-fake-lib-two v3.8.x /fake/path-two
 
     query_deps_output = <<-QUERYDEPSOUTPUT
  DEP    rabbit_common (v3.8.6-rc.2)
@@ -2223,6 +2225,7 @@ rabbitmq_web_stomp_examples: rabbit git_rmq https://github.com/rabbitmq/rabbitmq
 rabbitmq_web_stomp_examples: rabbitmq_web_dispatch git_rmq https://github.com/rabbitmq/rabbitmq-web-dispatch v3.8.6-rc.2 /home/lbakken/workspace/rabbitmq-server-release/deps/rabbitmq_web_dispatch
 rabbitmq_web_stomp_examples: rabbitmq_web_stomp git_rmq https://github.com/rabbitmq/rabbitmq-web-stomp v3.8.6-rc.2 /home/lbakken/workspace/rabbitmq-server-release/deps/rabbitmq_web_stomp
 erlangmk_spec_fake_lib: another_fake_lib git https://github.com/rabbitmq/rabbitmq-fake-lib master /fake/path
+erlangmk_spec_fake_lib: another_fake_lib_two git https://github.com/rabbitmq/rabbitmq-fake-lib-two v3.8.x /fake/path-two
     QUERYDEPSOUTPUT
 
     describe '#package_management_command' do

--- a/spec/lib/license_finder/package_managers/erlangmk_spec.rb
+++ b/spec/lib/license_finder/package_managers/erlangmk_spec.rb
@@ -2280,7 +2280,7 @@ erlangmk_spec_fake_lib: another_fake_lib_two git https://github.com/rabbitmq/rab
           expect(
             erlangmk.current_packages.size
           ).to eql(
-            193
+            194
           )
         end
       end


### PR DESCRIPTION
This allows version strings like `v3.8.x`

cc @gerhard @dumbbell 