### PR TITLE
Do not run Composer scripts when installing dependencies

### DIFF
--- a/lib/license_finder/package_managers/composer.rb
+++ b/lib/license_finder/package_managers/composer.rb
@@ -33,7 +33,7 @@ module LicenseFinder
     end
 
     def prepare_command
-      'composer install --no-plugins --ignore-platform-reqs --no-interaction'
+      'composer install --no-plugins --no-scripts --ignore-platform-reqs --no-interaction'
     end
 
     def package_path

--- a/spec/lib/license_finder/package_managers/composer_spec.rb
+++ b/spec/lib/license_finder/package_managers/composer_spec.rb
@@ -31,8 +31,8 @@ module LicenseFinder
         FileUtils.mkdir_p(root)
       end
 
-      it 'should call composer install --no-plugins --ignore-platform-reqs --no-interaction' do
-        expect(SharedHelpers::Cmd).to receive(:run).with('composer install --no-plugins --ignore-platform-reqs --no-interaction')
+      it 'should call composer install --no-plugins --no-scripts --ignore-platform-reqs --no-interaction' do
+        expect(SharedHelpers::Cmd).to receive(:run).with('composer install --no-plugins --no-scripts --ignore-platform-reqs --no-interaction')
                                                    .and_return([composer_shell_command_output, '', cmd_success])
         subject.prepare
       end


### PR DESCRIPTION
LicenseFinder only needs the dependencies but not scripts being executed after installing the dependencies which saves some time as well as might result in less errors in case scripts are executed.