### PR TITLE
Add examples for extracting custom data or generating custom reports

### DIFF
--- a/examples/Gemfile
+++ b/examples/Gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+gem 'license_finder', path: '..'

--- a/examples/custom_erb_template.rb
+++ b/examples/custom_erb_template.rb
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+
+# frozen_string_literal: true
+
+require 'rubygems'
+require 'bundler/setup'
+
+# This is an example of how to programatically generate a report using a custom
+# ERB template. Run with
+# > bundle install
+# > ./custom_erb_template.rb
+
+require 'license_finder'
+
+# See lib/license_finder/core.rb for more configuration options.
+# A quiet logger is required when running reports...
+lf = LicenseFinder::Core.new(LicenseFinder::Configuration.with_optional_saved_config(logger: :quiet))
+
+# Find many more examples of complex ERB templates in
+# lib/license_finder/reports/templates/
+template = Pathname.new('./sample_template.erb')
+print LicenseFinder::ErbReport
+  .new(lf.acknowledged, project_name: lf.project_name)
+  .to_s(template)

--- a/examples/extract_license_data.rb
+++ b/examples/extract_license_data.rb
@@ -1,0 +1,63 @@
+#!/usr/bin/env ruby
+
+# frozen_string_literal: true
+
+require 'rubygems'
+require 'bundler/setup'
+
+# This is an example of how to programatically extract the information that
+# LicenseFinder has about packages and their licenses.
+# > bundle install
+# > ./extract_license_data.rb
+
+require 'license_finder'
+
+# See lib/license_finder/core.rb for more configuration options.
+# A quiet logger is required when running reports...
+lf = LicenseFinder::Core.new(LicenseFinder::Configuration.with_optional_saved_config(logger: :quiet))
+
+# Groups of packages
+lf.acknowledged # All (non-ignored) packages license_finder is tracking
+lf.unapproved # The packages which have not been approved or permitted
+lf.restricted # The packages which have been restricted
+
+# Package details
+lf.acknowledged.each do |package|
+  # Approvals
+  package.approved? # Whether the package has been approved manually or permitted
+  package.approved_manually?
+  package.permitted?
+  package.restricted?
+
+  # Licensing
+  # The set of licenses, each of which has a name and url, which
+  # license_finder will report for this package.
+  package.licenses
+  # Additional information about how these licenses were chosen
+  # (from decision, from spec, from files, or none-found).  See
+  # LicenseFinder::Licensing and LicenseFinder::Activation
+  package.activations
+  # The files that look like licenses, found in the package's
+  # directory.  Caveat: if a package's licenses were specified by a decision or
+  # by the package's spec, the license_files will be ignored.  That means,
+  # package.licenses may report different licenses than those found in
+  # license_files.
+  package.license_files
+  package.license_files.each do |file|
+    # The license found in this file.
+    file.license
+    # The text of the file.  Sometimes this will be an entire README file,
+    # because license_finder has found the phrase "is released under the
+    # MIT license" in it.
+    file.text
+  end
+  package.licensing.activations_from_decisions # If license_finder only knew about decisions, what licenses would it report?
+  package.licensing.activations_from_spec      # If license_finder only knew about package specs, what licenses would it report?
+  package.licensing.activations_from_files     # If license_finder only knew about package files, what licenses would it report?
+  package.licensing.activations_from_files.each do |activation|
+    # Each activation groups together all files that point to the same license.
+    # Each file contains its #license and #text.
+    activation.license
+    activation.files
+  end
+end

--- a/examples/sample_template.erb
+++ b/examples/sample_template.erb
@@ -1,0 +1,7 @@
+Licenses
+
+<%= dependencies.size %> total
+
+<% grouped_dependencies.each do |license_name, group| -%>
+* <%= group.size %> <%= license_name %>
+<% end %>

--- a/lib/license_finder/core.rb
+++ b/lib/license_finder/core.rb
@@ -24,7 +24,7 @@ module LicenseFinder
     # Default +options+:
     # {
     #   project_path: Pathname.pwd
-    #   logger: {},   # can include quiet: true or debug: true
+    #   logger: nil,   # can be :quiet or :debug
     #   decisions_file: "doc/dependency_decisions.yml",
     #   gradle_command: "gradle",
     #   rebar_command: "rebar",


### PR DESCRIPTION
This contributes examples of using LicenseFinder outside of the CLI. 

As suggested by #786, the hope is that by including these files in the repo they will be updated as the API changes, as opposed to when they were in my personal gists where they languished. To ensure that they do indeed stay up-to-date, they would need tests, but I'll leave that decision to the LF maintainers.

Note that this creates a new `examples/` directory. Please move if necessary.