### PR TITLE
Do not execute scripts with Npm/Yarn Package-Managers

### DIFF
--- a/lib/license_finder/package_managers/npm.rb
+++ b/lib/license_finder/package_managers/npm.rb
@@ -14,7 +14,7 @@ module LicenseFinder
     end
 
     def prepare_command
-      'npm install --no-save'
+      'npm install --no-save --ignore-scripts'
     end
 
     def possible_package_paths

--- a/lib/license_finder/package_managers/yarn.rb
+++ b/lib/license_finder/package_managers/yarn.rb
@@ -56,7 +56,7 @@ module LicenseFinder
     end
 
     def prepare_command
-      'yarn install --ignore-engines'
+      'yarn install --ignore-engines --ignore-scripts'
     end
 
     private

--- a/spec/lib/license_finder/package_managers/npm_spec.rb
+++ b/spec/lib/license_finder/package_managers/npm_spec.rb
@@ -42,7 +42,7 @@ module LicenseFinder
       end
 
       it 'should call npm install' do
-        expect(SharedHelpers::Cmd).to receive(:run).with('npm install --no-save')
+        expect(SharedHelpers::Cmd).to receive(:run).with('npm install --no-save --ignore-scripts')
                                                    .and_return([dependency_json, '', cmd_success])
         npm.prepare
       end
@@ -50,7 +50,7 @@ module LicenseFinder
       context 'ignored_groups contains devDependencies' do
         let(:npm) { NPM.new project_path: Pathname.new(root), ignored_groups: 'devDependencies' }
         it 'should include a production flag' do
-          expect(SharedHelpers::Cmd).to receive(:run).with('npm install --no-save --production')
+          expect(SharedHelpers::Cmd).to receive(:run).with('npm install --no-save --ignore-scripts --production')
                                                      .and_return([dependency_json, '', cmd_success])
           npm.prepare
         end

--- a/spec/lib/license_finder/package_managers/yarn_spec.rb
+++ b/spec/lib/license_finder/package_managers/yarn_spec.rb
@@ -29,14 +29,14 @@ module LicenseFinder
       end
 
       it 'should call yarn install' do
-        expect(SharedHelpers::Cmd).to receive(:run).with('yarn install --ignore-engines')
+        expect(SharedHelpers::Cmd).to receive(:run).with('yarn install --ignore-engines --ignore-scripts')
                                                    .and_return([yarn_shell_command_output, '', cmd_success])
         subject.prepare
       end
       context 'ignored_groups contains devDependencies' do
         subject { Yarn.new(project_path: Pathname(root), ignored_groups: 'devDependencies') }
         it 'should include a production flag' do
-          expect(SharedHelpers::Cmd).to receive(:run).with('yarn install --ignore-engines --production')
+          expect(SharedHelpers::Cmd).to receive(:run).with('yarn install --ignore-engines --ignore-scripts --production')
                                                      .and_return([yarn_shell_command_output, '', cmd_success])
           subject.prepare
         end
@@ -146,7 +146,7 @@ module LicenseFinder
     describe '.prepare_command' do
       subject { Yarn.new(project_path: Pathname(root), logger: double(:logger, active: nil)) }
       it 'returns the correct prepare method' do
-        expect(subject.prepare_command).to eq('yarn install --ignore-engines')
+        expect(subject.prepare_command).to eq('yarn install --ignore-engines --ignore-scripts')
       end
     end
 


### PR DESCRIPTION
Following up on PR #790 this change is for Npm & Yarn to skip script execution.