### PR TITLE
Add --enabled-package-managers option to narrow down package managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,15 @@ If you store rebar dependencies in a custom directory (by setting `deps_dir` in
 You can also invoke a custom Mix script `remix` with `--mix_command remix` and
 set `--mix_deps_dir` to fetch Mix dependencies from a custom directory.
 
+### Narrow down Package Manager
+
+By default, license_finder will check for all supported package managers,
+but you can narrow it down to use only those you pass to `--enabled-package-manager`.
+For example,
+
+```
+$ license_finder --enabled-package-manager bundler npm
+```
 
 ### Saving Configuration
 
@@ -437,6 +446,11 @@ rebar_command: './rebarw'
 rebar_deps_dir: './rebar_deps'
 mix_command: './mixw'
 mix_deps_dir: './mix_deps'
+enabled_package_managers:
+  - bundler
+  - gradle
+  - rebar
+  - mix
 ```
 
 ### Gradle Projects

--- a/lib/license_finder/cli/base.rb
+++ b/lib/license_finder/cli/base.rb
@@ -11,6 +11,10 @@ module LicenseFinder
                    desc: 'Where decisions are saved. Defaults to doc/dependency_decisions.yml.'
       class_option :log_directory,
                    desc: 'Where logs are saved. Defaults to ./lf_logs/$PROJECT/prepare_$PACKAGE_MANAGER.log'
+      class_option :enabled_package_managers,
+                   desc: 'List of package managers to be enabled. Defaults to all supported package managers.',
+                   type: :array,
+                   enum: LicenseFinder::Scanner.supported_package_manager_ids
 
       no_commands do
         def decisions
@@ -32,6 +36,7 @@ module LicenseFinder
         extract_options(
           :project_path,
           :decisions_file,
+          :enabled_package_managers,
           :go_full_version,
           :gradle_command,
           :gradle_include_groups,

--- a/lib/license_finder/configuration.rb
+++ b/lib/license_finder/configuration.rb
@@ -65,6 +65,10 @@ module LicenseFinder
       Pathname(path_prefix).expand_path
     end
 
+    def enabled_package_manager_ids
+      get(:enabled_package_managers)
+    end
+
     def logger_mode
       get(:logger)
     end

--- a/lib/license_finder/core.rb
+++ b/lib/license_finder/core.rb
@@ -93,6 +93,7 @@ module LicenseFinder
         project_path: config.project_path,
         log_directory: File.join(config.log_directory, project_name),
         ignored_groups: decisions.ignored_groups,
+        enabled_package_manager_ids: config.enabled_package_manager_ids,
         go_full_version: config.go_full_version,
         gradle_command: config.gradle_command,
         gradle_include_groups: config.gradle_include_groups,

--- a/lib/license_finder/package_manager.rb
+++ b/lib/license_finder/package_manager.rb
@@ -22,6 +22,10 @@ module LicenseFinder
       def takes_priority_over
         nil
       end
+
+      def id
+        name.split('::').last.downcase
+      end
     end
 
     def installed?(logger = Core.default_logger)

--- a/spec/lib/license_finder/cli/main_spec.rb
+++ b/spec/lib/license_finder/cli/main_spec.rb
@@ -65,7 +65,8 @@ module LicenseFinder
             '--mix_command=surprise_me',
             '--mix_deps_dir=mix_dir',
             '--prepare',
-            '--log_directory=some_logs'
+            '--log_directory=some_logs',
+            '--enabled_package_managers=package_manager'
           ]
         end
 
@@ -87,7 +88,8 @@ module LicenseFinder
             mix_deps_dir: 'mix_dir',
             prepare: true,
             log_directory: 'some_logs',
-            logger: { mode: LicenseFinder::Logger::MODE_INFO }
+            logger: { mode: LicenseFinder::Logger::MODE_INFO },
+            enabled_package_managers: ['package_manager']
           }
         end
 

--- a/spec/lib/license_finder/configuration_spec.rb
+++ b/spec/lib/license_finder/configuration_spec.rb
@@ -33,6 +33,24 @@ module LicenseFinder
       end
     end
 
+    describe 'enabled_package_managers' do
+      it 'prefers primary values' do
+        subject = described_class.new(
+          { enabled_package_managers: ['primary'] },
+          'enabled_package_managers' => ['secondary']
+        )
+        expect(subject.enabled_package_manager_ids).to contain_exactly('primary')
+      end
+
+      it 'accepts saved value' do
+        subject = described_class.new(
+          { enabled_package_managers: nil },
+          'enabled_package_managers' => ['secondary']
+        )
+        expect(subject.enabled_package_manager_ids).to contain_exactly('secondary')
+      end
+    end
+
     describe 'gradle_command' do
       it 'prefers primary value' do
         subject = described_class.new(

--- a/spec/lib/license_finder/package_manager_spec.rb
+++ b/spec/lib/license_finder/package_manager_spec.rb
@@ -7,6 +7,12 @@ module LicenseFinder
   describe PackageManager do
     let(:logger) { double(:logger, debug: true, info: true) }
 
+    describe '.id' do
+      it 'returns the lowercase class name' do
+        expect(described_class.id).to eq('packagemanager')
+      end
+    end
+
     describe '#current_packages_with_relations' do
       it "sets packages' parents" do
         grandparent = Package.new('grandparent', nil, children: ['parent'])


### PR DESCRIPTION
I added support for specifying a package manager to be enabled.
This feature is intended for the following purposes:

- Switch the decisions file for each package manager
  (e.g. Separate licenses to be allowed on the server-side and front-end)
- Exclude specific package managers from the license check
  (e.g. Skip checking package managers that only resolve dependencies on development tools that do not affect the production code)
