### PR TITLE
Feature: "check-require-only" for Composer

### DIFF
--- a/lib/license_finder/cli/base.rb
+++ b/lib/license_finder/cli/base.rb
@@ -59,7 +59,8 @@ module LicenseFinder
           :aggregate_paths,
           :recursive,
           :sbt_include_groups,
-          :conda_bash_setup_script
+          :conda_bash_setup_script,
+          :composer_check_require_only
         ).merge(
           logger: logger_mode
         )

--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -39,6 +39,8 @@ module LicenseFinder
       class_option :mix_deps_dir, desc: "Path to Mix dependencies directory. Only meaningful if used with a Mix project (i.e., Elixir or Erlang). Defaults to 'deps'."
       class_option :sbt_include_groups, desc: 'Whether dependency name should include group id. Only meaningful if used with a Scala/sbt project. Defaults to false.'
       class_option :conda_bash_setup_script, desc: "Path to conda.sh script. Only meaningful if used with a Conda project. Defaults to '~/miniconda3/etc/profile.d/conda.sh'."
+      class_option :composer_check_require_only,
+                   desc: "Whether to only check for licenses from dependencies on the 'require' section. Only meaningful if used with a Composer project. Defaults to false."
 
       # Method options which are shared between report and action_item
       def self.format_option

--- a/lib/license_finder/configuration.rb
+++ b/lib/license_finder/configuration.rb
@@ -145,6 +145,10 @@ module LicenseFinder
       get(:sbt_include_groups)
     end
 
+    def composer_check_require_only
+      get(:composer_check_require_only)
+    end
+
     attr_writer :strict_matching
 
     attr_reader :strict_matching

--- a/lib/license_finder/core.rb
+++ b/lib/license_finder/core.rb
@@ -109,7 +109,8 @@ module LicenseFinder
         prepare: config.prepare,
         prepare_no_fail: config.prepare_no_fail,
         sbt_include_groups: config.sbt_include_groups,
-        conda_bash_setup_script: config.conda_bash_setup_script
+        conda_bash_setup_script: config.conda_bash_setup_script,
+        composer_check_require_only: config.composer_check_require_only
       }
     end
   end

--- a/lib/license_finder/package_managers/composer.rb
+++ b/lib/license_finder/package_managers/composer.rb
@@ -4,7 +4,10 @@ require 'json'
 
 module LicenseFinder
   class Composer < PackageManager
-    SHELL_COMMAND = 'composer licenses --format=json'
+    def initialize(options = {})
+      super
+      @check_require_only = !!options[:composer_check_require_only]
+    end
 
     def possible_package_paths
       [project_path.join('composer.lock'), project_path.join('composer.json')]
@@ -50,8 +53,9 @@ module LicenseFinder
     end
 
     def composer_json
-      stdout, stderr, status = Dir.chdir(project_path) { Cmd.run(Composer::SHELL_COMMAND) }
-      raise "Command '#{Composer::SHELL_COMMAND}' failed to execute: #{stderr}" unless status.success?
+      command = "composer licenses --format=json#{@check_require_only ? ' --no-dev' : ''}"
+      stdout, stderr, status = Dir.chdir(project_path) { Cmd.run(command) }
+      raise "Command '#{command}' failed to execute: #{stderr}" unless status.success?
 
       JSON(stdout)
     end

--- a/spec/fixtures/config/composer_license_require_only.json
+++ b/spec/fixtures/config/composer_license_require_only.json
@@ -1,0 +1,25 @@
+{
+    "name": "__root__",
+    "version": "No version set (parsed as 1.0.0)",
+    "license": [],
+    "dependencies": {
+        "phpoption/phpoption": {
+            "version": "1.5.0",
+            "license": [
+                "Apache2"
+            ]
+        },
+        "symfony/polyfill-ctype": {
+            "version": "v1.11.0",
+            "license": [
+                "MIT"
+            ]
+        },
+        "vlucas/phpdotenv": {
+            "version": "v3.3.3",
+            "license": [
+                "BSD-3-Clause"
+            ]
+        }
+    }
+}

--- a/spec/lib/license_finder/core_spec.rb
+++ b/spec/lib/license_finder/core_spec.rb
@@ -49,7 +49,8 @@ module LicenseFinder
           prepare: configuration.prepare,
           prepare_no_fail: nil,
           sbt_include_groups: nil,
-          conda_bash_setup_script: configuration.conda_bash_setup_script
+          conda_bash_setup_script: configuration.conda_bash_setup_script,
+          composer_check_require_only: nil
         }
       end
 

--- a/spec/lib/license_finder/package_managers/composer_spec.rb
+++ b/spec/lib/license_finder/package_managers/composer_spec.rb
@@ -57,6 +57,11 @@ module LicenseFinder
         fixture_from('composer_license.json')
       end
     end
+    let(:license_require_only_json) do
+      FakeFS.without do
+        fixture_from('composer_license_require_only.json')
+      end
+    end
 
     describe '.current_packages' do
       include FakeFS::SpecHelpers
@@ -71,6 +76,17 @@ module LicenseFinder
         current_packages = composer.current_packages
 
         expect(current_packages.map(&:name)).to eq(['phpoption/phpoption', 'psr/log', 'symfony/debug', 'symfony/polyfill-ctype', 'vlucas/phpdotenv'])
+      end
+
+      context 'check_require_only is set' do
+        let(:composer) { Composer.new(composer_check_require_only: true, project_path: Pathname.new(root)) }
+
+        it 'checks for require deps licenses only' do
+          allow(SharedHelpers::Cmd).to receive(:run).with('composer licenses -f json --no-dev').and_return([license_require_only_json, '', cmd_success])
+
+          current_packages = composer.current_packages
+          expect(current_packages.map(&:name)).to eq(['phpoption/phpoption', 'psr/log', 'symfony/debug', 'symfony/polyfill-ctype', 'vlucas/phpdotenv'])
+        end
       end
 
       it 'fails when command fails' do


### PR DESCRIPTION
As Composer has the ability to check for licenses from only the packages in the 'require' section, this feature will be able to use that capability on License Finder.

For example, using the `composer.json` file at `LicenseFinder/spec/fixtures/all_pms`, we know that `vlucas/phpdotenv` is the sole library on the `require` section, while `symfony/debug` is on `require-dev`.

Normally, the result obtained by running License Finder would be showing the licenses for all packages on `require` and `require-dev`:

```bash
> ./bin/license_finder                                   
LicenseFinder::Composer: is active

Dependencies that need approval:
phpoption/phpoption, 1.7.5, "Apache 2.0"
psr/log, 1.1.3, MIT
symfony/debug, v4.2.12, MIT
symfony/polyfill-ctype, v1.20.0, MIT
vlucas/phpdotenv, v3.3.3, "New BSD"
```
With this new feature, it will show the results of libraries that `vlucas/phpdotenv` pulls when used as a required dependency:
```bash
> ./bin/license_finder --composer-check-require-only=true
LicenseFinder::Composer: is active

Dependencies that need approval:
phpoption/phpoption, 1.7.5, "Apache 2.0"
symfony/polyfill-ctype, v1.20.0, MIT
vlucas/phpdotenv, v3.3.3, "New BSD"
```