### PR TITLE
Relax thor version requirement

### DIFF
--- a/lib/license_finder/cli/approvals.rb
+++ b/lib/license_finder/cli/approvals.rb
@@ -13,7 +13,7 @@ module LicenseFinder
         assert_some names
         modifying { names.each { |name| decisions.approve(name, txn) } }
 
-        say "The #{names.join(', ')} dependency has been approved!", :green
+        say! "The #{names.join(', ')} dependency has been approved!", :green
       end
 
       auditable
@@ -21,7 +21,7 @@ module LicenseFinder
       def remove(dep)
         modifying { decisions.unapprove(dep, txn) }
 
-        say "The dependency #{dep} no longer has a manual approval"
+        say! "The dependency #{dep} no longer has a manual approval"
       end
     end
   end

--- a/lib/license_finder/cli/base.rb
+++ b/lib/license_finder/cli/base.rb
@@ -29,7 +29,7 @@ module LicenseFinder
       private
 
       def fail(message)
-        say(message) && exit(1)
+        say!(message) && exit(1)
       end
 
       def license_finder_config
@@ -81,13 +81,23 @@ module LicenseFinder
         end
       end
 
+      def say!(*args)
+        @loud = true
+        say(*args)
+        @loud = false
+      end
+
+      def quiet?
+        @loud ? false : super
+      end
+
       def say_each(coll)
         if coll.any?
           coll.each do |item|
-            say(block_given? ? yield(item) : item)
+            say!(block_given? ? yield(item) : item)
           end
         else
-          say '(none)'
+          say! '(none)'
         end
       end
 

--- a/lib/license_finder/cli/dependencies.rb
+++ b/lib/license_finder/cli/dependencies.rb
@@ -20,9 +20,9 @@ module LicenseFinder
           decisions.approve(name, txn) if options[:approve]
         end
         if options[:approve]
-          say "The #{name} dependency has been added and approved!", :green
+          say! "The #{name} dependency has been added and approved!", :green
         else
-          say "The #{name} dependency has been added!", :green
+          say! "The #{name} dependency has been added!", :green
         end
       end
 
@@ -31,12 +31,12 @@ module LicenseFinder
       def remove(name)
         modifying { decisions.remove_package(name, txn) }
 
-        say "The #{name} dependency has been removed.", :green
+        say! "The #{name} dependency has been removed.", :green
       end
 
       desc 'list', 'List manually added dependencies'
       def list
-        say 'Manually Added Dependencies:', :blue
+        say! 'Manually Added Dependencies:', :blue
         say_each(decisions.packages, &:name)
       end
     end

--- a/lib/license_finder/cli/ignored_dependencies.rb
+++ b/lib/license_finder/cli/ignored_dependencies.rb
@@ -8,7 +8,7 @@ module LicenseFinder
 
       desc 'list', 'List all the ignored dependencies'
       def list
-        say 'Ignored Dependencies:', :blue
+        say! 'Ignored Dependencies:', :blue
         say_each(decisions.ignored)
       end
 
@@ -17,7 +17,7 @@ module LicenseFinder
       def add(dep)
         modifying { decisions.ignore(dep, txn) }
 
-        say "Added #{dep} to the ignored dependencies"
+        say! "Added #{dep} to the ignored dependencies"
       end
 
       auditable
@@ -25,7 +25,7 @@ module LicenseFinder
       def remove(dep)
         modifying { decisions.heed(dep, txn) }
 
-        say "Removed #{dep} from the ignored dependencies"
+        say! "Removed #{dep} from the ignored dependencies"
       end
     end
   end

--- a/lib/license_finder/cli/ignored_groups.rb
+++ b/lib/license_finder/cli/ignored_groups.rb
@@ -8,7 +8,7 @@ module LicenseFinder
 
       desc 'list', 'List all the ignored groups'
       def list
-        say 'Ignored Groups:', :blue
+        say! 'Ignored Groups:', :blue
         say_each(decisions.ignored_groups)
       end
 
@@ -17,7 +17,7 @@ module LicenseFinder
       def add(group)
         modifying { decisions.ignore_group(group, txn) }
 
-        say "Added #{group} to the ignored groups"
+        say! "Added #{group} to the ignored groups"
       end
 
       auditable
@@ -25,7 +25,7 @@ module LicenseFinder
       def remove(group)
         modifying { decisions.heed_group(group, txn) }
 
-        say "Removed #{group} from the ignored groups"
+        say! "Removed #{group} from the ignored groups"
       end
     end
   end

--- a/lib/license_finder/cli/inherited_decisions.rb
+++ b/lib/license_finder/cli/inherited_decisions.rb
@@ -8,7 +8,7 @@ module LicenseFinder
 
       desc 'list', 'List all the inherited decision files'
       def list
-        say 'Inherited Decision Files:', :blue
+        say! 'Inherited Decision Files:', :blue
         say_each(decisions.inherited_decisions)
       end
 
@@ -17,7 +17,7 @@ module LicenseFinder
       def add(*decision_files)
         assert_some decision_files
         modifying { decision_files.each { |filepath| decisions.inherit_from(filepath) } }
-        say "Added #{decision_files.join(', ')} to the inherited decisions"
+        say! "Added #{decision_files.join(', ')} to the inherited decisions"
       end
 
       auditable
@@ -26,7 +26,7 @@ module LicenseFinder
         url, auth_type, token_or_env = params
         auth_info = { 'url' => url, 'authorization' => "#{auth_type} #{token_or_env}" }
         modifying { decisions.add_decision [:inherit_from, auth_info] }
-        say "Added #{url} to the inherited decisions"
+        say! "Added #{url} to the inherited decisions"
       end
 
       auditable
@@ -34,7 +34,7 @@ module LicenseFinder
       def remove(*decision_files)
         assert_some decision_files
         modifying { decision_files.each { |filepath| decisions.remove_inheritance(filepath) } }
-        say "Removed #{decision_files.join(', ')} from the inherited decisions"
+        say! "Removed #{decision_files.join(', ')} from the inherited decisions"
       end
 
       auditable
@@ -43,7 +43,7 @@ module LicenseFinder
         url, auth_type, token_or_env = params
         auth_info = { 'url' => url, 'authorization' => "#{auth_type} #{token_or_env}" }
         modifying { decisions.remove_inheritance(auth_info) }
-        say "Removed #{url} from the inherited decisions"
+        say! "Removed #{url} from the inherited decisions"
       end
     end
   end

--- a/lib/license_finder/cli/licenses.rb
+++ b/lib/license_finder/cli/licenses.rb
@@ -11,7 +11,7 @@ module LicenseFinder
       def add(name, license)
         modifying { decisions.license(name, license, txn) }
 
-        say "The #{name} dependency has been marked as using #{license} license!", :green
+        say! "The #{name} dependency has been marked as using #{license} license!", :green
       end
 
       auditable
@@ -19,7 +19,7 @@ module LicenseFinder
       def remove(dep, lic)
         modifying { decisions.unlicense(dep, lic, txn) }
 
-        say "The dependency #{dep} no longer has a manual license"
+        say! "The dependency #{dep} no longer has a manual license"
       end
     end
   end

--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -102,7 +102,7 @@ module LicenseFinder
 
         filtered_project_roots << project_path if aggregate_paths.include?(project_path) && !filtered_project_roots.include?(project_path)
 
-        say(filtered_project_roots)
+        say!(filtered_project_roots)
       end
 
       desc 'action_items', 'List unapproved dependencies (the default action for `license_finder`)'
@@ -115,25 +115,25 @@ module LicenseFinder
         restricted = finder.restricted
 
         # Ensure to start output on a new line even with dot progress indicators.
-        say "\n"
+        say! "\n"
 
         unless any_packages
-          say 'No dependencies recognized!', :red
+          say! 'No dependencies recognized!', :red
           exit 0
         end
 
         if unapproved.empty?
-          say 'All dependencies are approved for use', :green
+          say! 'All dependencies are approved for use', :green
         else
           unless restricted.empty?
-            say 'Restricted dependencies:', :red
-            say report_of(restricted)
+            say! 'Restricted dependencies:', :red
+            say! report_of(restricted)
           end
 
           other_unapproved = unapproved - restricted
           unless other_unapproved.empty?
-            say 'Dependencies that need approval:', :yellow
-            say report_of(other_unapproved)
+            say! 'Dependencies that need approval:', :yellow
+            say! report_of(other_unapproved)
           end
 
           exit 1
@@ -151,7 +151,7 @@ module LicenseFinder
       def report
         finder = LicenseAggregator.new(config, aggregate_paths)
         report = report_of(finder.dependencies)
-        save? ? save_report(report, config.save_file) : say(report)
+        save? ? save_report(report, config.save_file) : say!(report)
       end
 
       desc 'version', 'Print the version of LicenseFinder'
@@ -166,7 +166,7 @@ module LicenseFinder
         f1 = IO.read(file1)
         f2 = IO.read(file2)
         report = DiffReport.new(Diff.compare(f1, f2))
-        save? ? save_report(report, config.save_file) : say(report)
+        save? ? save_report(report, config.save_file) : say!(report)
       end
 
       subcommand 'dependencies', Dependencies, 'Add or remove dependencies that your package managers are not aware of'

--- a/lib/license_finder/cli/permitted_licenses.rb
+++ b/lib/license_finder/cli/permitted_licenses.rb
@@ -8,7 +8,7 @@ module LicenseFinder
 
       desc 'list', 'List all the permitted licenses'
       def list
-        say 'Permitted Licenses:', :blue
+        say! 'Permitted Licenses:', :blue
         say_each(decisions.permitted, &:name)
       end
 
@@ -17,7 +17,7 @@ module LicenseFinder
       def add(*licenses)
         assert_some licenses
         modifying { licenses.each { |l| decisions.permit(l, txn) } }
-        say "Added #{licenses.join(', ')} to the permitted licenses"
+        say! "Added #{licenses.join(', ')} to the permitted licenses"
       end
 
       auditable
@@ -25,7 +25,7 @@ module LicenseFinder
       def remove(*licenses)
         assert_some licenses
         modifying { licenses.each { |l| decisions.unpermit(l, txn) } }
-        say "Removed #{licenses.join(', ')} from the license permitted licenses"
+        say! "Removed #{licenses.join(', ')} from the license permitted licenses"
       end
     end
   end

--- a/lib/license_finder/cli/project_name.rb
+++ b/lib/license_finder/cli/project_name.rb
@@ -8,8 +8,8 @@ module LicenseFinder
 
       desc 'show', 'Show the project name'
       def show
-        say 'Project Name:', :blue
-        say decisions.project_name
+        say! 'Project Name:', :blue
+        say! decisions.project_name
       end
 
       auditable
@@ -17,7 +17,7 @@ module LicenseFinder
       def add(name)
         modifying { decisions.name_project(name, txn) }
 
-        say "Set the project name to #{name}", :green
+        say! "Set the project name to #{name}", :green
       end
 
       auditable
@@ -25,7 +25,7 @@ module LicenseFinder
       def remove
         modifying { decisions.unname_project(txn) }
 
-        say 'Removed the project name'
+        say! 'Removed the project name'
       end
     end
   end

--- a/lib/license_finder/cli/restricted_licenses.rb
+++ b/lib/license_finder/cli/restricted_licenses.rb
@@ -8,7 +8,7 @@ module LicenseFinder
 
       desc 'list', 'List all the restricted licenses'
       def list
-        say 'Restricted Licenses:', :blue
+        say! 'Restricted Licenses:', :blue
         say_each(decisions.restricted, &:name)
       end
 
@@ -17,7 +17,7 @@ module LicenseFinder
       def add(*licenses)
         assert_some licenses
         modifying { licenses.each { |l| decisions.restrict(l, txn) } }
-        say "Added #{licenses.join(', ')} to the restricted licenses"
+        say! "Added #{licenses.join(', ')} to the restricted licenses"
       end
 
       auditable
@@ -25,7 +25,7 @@ module LicenseFinder
       def remove(*licenses)
         assert_some licenses
         modifying { licenses.each { |l| decisions.unrestrict(l, txn) } }
-        say "Removed #{licenses.join(', ')} from the restricted licenses"
+        say! "Removed #{licenses.join(', ')} from the restricted licenses"
       end
     end
   end

--- a/license_finder.gemspec
+++ b/license_finder.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'bundler'
   s.add_dependency 'rubyzip', '>=1', '<3'
-  s.add_dependency 'thor', '~> 1.0.1'
+  s.add_dependency 'thor', '~> 1.0'
   s.add_dependency 'tomlrb', '>= 1.3', '< 2.1'
   s.add_dependency 'with_env', '1.1.0'
   s.add_dependency 'xml-simple', '~> 1.1.5'


### PR DESCRIPTION
I use license finder on some Ruby projects that also use thor.

I want to be able to upgrade to thor 1.1 on my project, but license finder has a strict 1.0.x version requirement. This relaxes the requirement to 1.x.