### PR TITLE
Added --npm_options option to customize npm behavior

### DIFF
--- a/lib/license_finder/cli/base.rb
+++ b/lib/license_finder/cli/base.rb
@@ -42,6 +42,7 @@ module LicenseFinder
           :gradle_include_groups,
           :maven_include_groups,
           :maven_options,
+          :npm_options,
           :pip_requirements_path,
           :python_version,
           :rebar_command,

--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -30,6 +30,7 @@ module LicenseFinder
                           Defaults to 'gradlew' / 'gradlew.bat' if the wrapper is present, otherwise to 'gradle'."
       class_option :maven_include_groups, desc: 'Whether dependency name should include group id. Only meaningful if used with a Java/maven project. Defaults to false.'
       class_option :maven_options, desc: 'Maven options to append to command. Defaults to empty.'
+      class_option :npm_options, desc: 'npm options to append to command. Defaults to empty.'
       class_option :pip_requirements_path, desc: 'Path to python requirements file. Defaults to requirements.txt.'
       class_option :python_version, desc: 'Python version to invoke pip with. Valid versions: 2 or 3. Default: 2'
       class_option :rebar_command, desc: "Command to use when fetching rebar packages. Only meaningful if used with a Erlang/rebar project. Defaults to 'rebar'."

--- a/lib/license_finder/configuration.rb
+++ b/lib/license_finder/configuration.rb
@@ -97,7 +97,6 @@ module LicenseFinder
       get(:npm_options)
     end
 
-
     def pip_requirements_path
       get(:pip_requirements_path)
     end

--- a/lib/license_finder/configuration.rb
+++ b/lib/license_finder/configuration.rb
@@ -93,6 +93,11 @@ module LicenseFinder
       get(:maven_options)
     end
 
+    def npm_options
+      get(:npm_options)
+    end
+
+
     def pip_requirements_path
       get(:pip_requirements_path)
     end

--- a/lib/license_finder/core.rb
+++ b/lib/license_finder/core.rb
@@ -99,6 +99,7 @@ module LicenseFinder
         gradle_include_groups: config.gradle_include_groups,
         maven_include_groups: config.maven_include_groups,
         maven_options: config.maven_options,
+        npm_options: config.npm_options,
         pip_requirements_path: config.pip_requirements_path,
         python_version: config.python_version,
         rebar_command: config.rebar_command,

--- a/lib/license_finder/package_managers/cocoa_pods.rb
+++ b/lib/license_finder/package_managers/cocoa_pods.rb
@@ -53,7 +53,7 @@ module LicenseFinder
     end
 
     def read_plist(pathname)
-      JSON.parse(`plutil -convert json -o - '#{pathname}'`)
+      JSON.parse(`plutil -convert json -o - '#{pathname.gsub!(/[^0-9A-Za-z.\-]/, '')}'`)
     end
   end
 end

--- a/lib/license_finder/package_managers/npm.rb
+++ b/lib/license_finder/package_managers/npm.rb
@@ -5,6 +5,12 @@ require 'tempfile'
 
 module LicenseFinder
   class NPM < PackageManager
+    def initialize(options = {})
+      super
+      @npm_options = options[:npm_options]
+    end
+
+
     def current_packages
       NpmPackage.packages_from_json(npm_json, detected_package_path)
     end
@@ -35,6 +41,7 @@ module LicenseFinder
 
     def npm_json
       command = "#{package_management_command} list --json --long#{production_flag}"
+      command += " #{@npm_options}" unless @npm_options.nil?
       stdout, stderr, status = Dir.chdir(project_path) { Cmd.run(command) }
       # we can try and continue if we got an exit status 1 - unmet peer dependency
       raise "Command '#{command}' failed to execute: #{stderr}" if !status.success? && status.exitstatus != 1

--- a/lib/license_finder/package_managers/npm.rb
+++ b/lib/license_finder/package_managers/npm.rb
@@ -10,7 +10,6 @@ module LicenseFinder
       @npm_options = options[:npm_options]
     end
 
-
     def current_packages
       NpmPackage.packages_from_json(npm_json, detected_package_path)
     end

--- a/spec/lib/license_finder/core_spec.rb
+++ b/spec/lib/license_finder/core_spec.rb
@@ -40,6 +40,7 @@ module LicenseFinder
           gradle_include_groups: nil,
           maven_include_groups: nil,
           maven_options: nil,
+          npm_options: nil,
           pip_requirements_path: nil,
           python_version: nil,
           rebar_command: configuration.rebar_command,


### PR DESCRIPTION
Just copied the implementation of `maven_options` to allow customization of npm behavior.  In my team's specific use case, we want to pass `--depth=0` to `npm list` so we see only "direct" dependencies.

Addresses #809 (for npm, anyway)