### PR TITLE
Fix CocoaPods path transformation

### DIFF
--- a/lib/license_finder/package_managers/cocoa_pods.rb
+++ b/lib/license_finder/package_managers/cocoa_pods.rb
@@ -53,7 +53,9 @@ module LicenseFinder
     end
 
     def read_plist(pathname)
-      JSON.parse(`plutil -convert json -o - '#{pathname.gsub!(%r{[^0-9A-Za-z.\-'/]}, '')}'`)
+      transformed_pathname = pathname.gsub!(%r{[^0-9A-Za-z. \-'/]}, '')
+      transformed_pathname = pathname if transformed_pathname.nil?
+      JSON.parse(`plutil -convert json -o - '#{transformed_pathname}'`)
     end
   end
 end


### PR DESCRIPTION
This PR fixes two issues when reading the `Pods-*-acknowledgements.plist` file:

1. Updates the regular expression to not replace whitespaces (ex. _Target Support Files_).
2. When **gsub** returns `nil` if no matches were found in the pathname, it should default to the original value.