### PR TITLE
Fix CocoaPods plutil argument escaping

### DIFF
--- a/lib/license_finder/package_managers/cocoa_pods.rb
+++ b/lib/license_finder/package_managers/cocoa_pods.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'open3'
 
 module LicenseFinder
   class CocoaPods < PackageManager
@@ -53,9 +54,10 @@ module LicenseFinder
     end
 
     def read_plist(pathname)
-      transformed_pathname = pathname.gsub!(%r{[^0-9A-Za-z. \-'/]}, '')
-      transformed_pathname = pathname if transformed_pathname.nil?
-      JSON.parse(`plutil -convert json -o - '#{transformed_pathname}'`)
+      out, err, status = Open3.capture3('plutil', '-convert', 'json', '-o', '-', pathname)
+      raise "#{out}\n\n#{err}" unless status.success?
+
+      JSON.parse(out)
     end
   end
 end


### PR DESCRIPTION
An attempt was made to fix a command injection vector in https://github.com/pivotal/LicenseFinder/commit/b0a61a2d833921c714cc39cdda8ba80af3f33d04 when passing pathnames to the `plutil` tool in the CocoaPods provider.

This method of whitelisting specific characters that can be allowed in a path is prone to failures (https://github.com/pivotal/LicenseFinder/issues/846), especially in non-english locales.

Instead of trying to work around this by blocking usage of certain characters, we can use one of Ruby's parameterized methods of command execution which will properly handle shell escaping.

```ruby
# Define a pathname containing a command injection

irb(main):001:0> injection = "'; echo 'hello world"
=> "'; echo 'hello world"

# When executing this using backticks, the injection is executed

irb(main):002:0> `plutil convert -o - '#{injection}'`
-o is not used with -lint.
=> "hello world\n"

# When executing using `Open3.capture3`, the injection string is passed as a properly-escaped
# argument to `plutil`, which exists with a non-zero status and an error as expected

irb(main):004:0> out, err, status = Open3.capture3('plutil', '-convert', 'json', '-o', '-', injection)
=> ["'; echo 'hello world: file does not exist or is not readable or is not a regular file (Error Domain=NSCocoaErrorDomain Code=260 \"The file “'; echo 'hello worl...
irb(main):005:0> out
=> "'; echo 'hello world: file does not exist or is not readable or is not a regular file (Error Domain=NSCocoaErrorDomain Code=260 \"The file “'; echo 'hello world” couldn’t be opened because there is no such file.\" UserInfo={NSFilePath='; echo 'hello world, NSUnderlyingError=0x7fb3a1c0b100 {Error Domain=NSPOSIXErrorDomain Code=2 \"No such file or directory\"}})\n"
irb(main):006:0> err
=> ""
irb(main):007:0> status
=> #<Process::Status: pid 23030 exit 1>
```

Fixes https://github.com/pivotal/LicenseFinder/issues/846