### PR TITLE
Improve CocoaPods support: multiple targets, licenses from specs, subspec inheritance

### DIFF
--- a/lib/license_finder/package_managers/cocoa_pods.rb
+++ b/lib/license_finder/package_managers/cocoa_pods.rb
@@ -11,11 +11,12 @@ module LicenseFinder
         pod = pod.keys.first if pod.is_a?(Hash)
 
         name, version = pod.scan(/(.*)\s\((.*)\)/).flatten
+        parent_name = name.split('/').first if name.include?('/')
 
         CocoaPodsPackage.new(
           name,
           version,
-          acknowledgements[name],
+          acknowledgements[name] || (parent_name && acknowledgements[parent_name]),
           logger: logger
         )
       end

--- a/lib/license_finder/packages/cocoa_pods_package.rb
+++ b/lib/license_finder/packages/cocoa_pods_package.rb
@@ -2,13 +2,20 @@
 
 module LicenseFinder
   class CocoaPodsPackage < Package
-    def initialize(name, version, license_text, options = {})
-      super(name, version, options)
-      @license = License.find_by_text(license_text.to_s)
+    def initialize(name, version, acknowledgement, options = {})
+      licenses = acknowledgement && acknowledgement['License']
+      license_text = acknowledgement && acknowledgement['FooterText']
+
+      spec_licenses = [licenses] if licenses && !licenses.empty?
+      @parsed_license = License.find_by_text(license_text.to_s) if spec_licenses.nil?
+
+      super(name, version, options.merge(spec_licenses: spec_licenses))
     end
 
     def licenses_from_spec
-      [@license].compact
+      return [@parsed_license].compact if @parsed_license
+
+      super
     end
 
     def package_manager


### PR DESCRIPTION
This addresses two issues with the existing implementation:

1. License information was only loaded from the first acknowledgements path. In projects with multiple build targets, this resulted in a failure to identify many dependencies.
2. License names provided in the acknowledgements were ignored and the license text was always used to determine a license. This refactors which data is passed to `CocoaPodPackage` to allow the license names to be read from the spec, falling back to searching by text.

It also adds fallback behavior for subspec entries, allowing them to look up their license from their parent package.

Unlike other package managers like npm where a slash in a package name denotes a namespace across multiple package like `@babel/something` in npm, CocoaPods subspecs are specified in a single podspec file.
(e.g. https://github.com/CocoaPods/Specs/blob/master/Specs/3/2/5/FlipperKit/0.104.0/FlipperKit.podspec.json)

Per https://guides.cocoapods.org/syntax/podspec.html#subspec, the intended behavior is that "a ‘sub-specification’ inherits the value of the attributes of the parents so common values for attributes can be specified in the ancestors."

I believe this means that we can safely fall back to the parent specification to look up a license value for subspecs when the subspec does not provide one of its own.