### PR TITLE
Safely load dependency decisions with any version of Psych

### DIFF
--- a/lib/license_finder/decisions.rb
+++ b/lib/license_finder/decisions.rb
@@ -280,7 +280,11 @@ module LicenseFinder
     def self.restore(persisted, result = new)
       return result unless persisted
 
-      actions = YAML.load(persisted)
+      actions = if Psych::VERSION < '3.1.0'
+                  YAML.safe_load(persisted, %i[Symbol Time], [], true)
+                else
+                  YAML.safe_load(persisted, permitted_classes: %i[Symbol Time], aliases: true)
+                end
 
       list_of_actions = (actions || []).map(&:first)
 


### PR DESCRIPTION
Psych 4 no longer loads YAML unsafely with `Psych.load`. This change switches to `Psych.safe_load`. Since the calling convention for `Psych.safe_load` was changed, and the old convention is no longer supported in Psych 4, either the old or the new convention is used based on the loaded version of Psych.

Fixes #841.