### PR TITLE
escape parameters before handing over to bash

### DIFF
--- a/dlf
+++ b/dlf
@@ -1,10 +1,14 @@
 #!/bin/bash
 if `which docker > /dev/null`; then
-	if [ $# -eq 0 ]; then
-  		docker run -v $PWD:/scan -it licensefinder/license_finder
-	else
-  		docker run -v $PWD:/scan -it licensefinder/license_finder /bin/bash -lc "cd /scan && `echo $@`"
-	fi
+  if [ $# -eq 0 ]; then
+    docker run -v $PWD:/scan -it licensefinder/license_finder
+  else
+    escaped_params=""
+    for p in "$@"; do
+      escaped_params="$escaped_params \"$p\""
+    done
+    docker run -v $PWD:/scan -it licensefinder/license_finder /bin/bash -lc "cd /scan && $escaped_params"
+  fi
 else
   echo "You do not have docker installed. Please install it:"
   echo "    https://docs.docker.com/engine/installation/"


### PR DESCRIPTION
The ```dlf``` for running LicenseFinder in Docker is quite handy but has issues with missing escaping of parameters.

Actual:
```shell
➜   ./dlf license_finder permitted_licenses add "A License 1.0"   
Added A, License, 1.0 to the permitted licenses
```
As you see by the commas indicating, actually 3 licenses are added, namely "A", "License", "1.0".
The problem in real life, one can't add e.g. "New BSD" as a permitted license. 

Expected
```shell
➜   ./dlf license_finder permitted_licenses add "A License 1.0"    
Added A License 1.0 to the permitted licenses
```

This PR does escape the given parameter, before handing over to the bash script,
and the above command behaves as expected.

Any feedback welcome.