### PR TITLE
feat: [#180665528] upgrade conan and use https://center.conan.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -137,7 +137,7 @@ RUN apt-get install -y python-dev && \
 	    --ignore-installed requests --ignore-installed chardet \
 	    --ignore-installed urllib3 \
 	    --upgrade setuptools && \
-    pip install --no-cache-dir -Iv conan==1.11.2 && \
+    pip install --no-cache-dir -Iv conan==1.43.0 && \
     conan config install https://github.com/conan-io/conanclientcert.git
 
 

--- a/features/features/package_managers/conan_spec.rb
+++ b/features/features/package_managers/conan_spec.rb
@@ -8,6 +8,6 @@ describe 'Conan Dependencies' do
   specify 'are shown in reports for a project' do
     LicenseFinder::TestingDSL::ConanProject.create
     conan_developer.run_license_finder
-    expect(conan_developer).to be_seeing_line 'range-v3, 0.3.0, MIT'
+    expect(conan_developer).to be_seeing_line 'range-v3, 0.10.0, MIT'
   end
 end

--- a/features/fixtures/conanfile.txt
+++ b/features/fixtures/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-range-v3/0.3.0@ericniebler/stable
+range-v3/0.10.0
 
 [generators]
 txt

--- a/lib/license_finder/package_managers/conan.rb
+++ b/lib/license_finder/package_managers/conan.rb
@@ -18,10 +18,10 @@ module LicenseFinder
 
       deps = info_parser.parse(info_output)
       deps.map do |dep|
-        name, version = dep['name'].split('@').first.split('/')
+        name, version = dep['name'].split('/')
         url = dep['URL']
         license_file_path = Dir.glob("#{project_path}/licenses/#{name}/**/LICENSE*").first
-        ConanPackage.new(name, version, File.open(license_file_path).read, url) unless name == 'PROJECT'
+        ConanPackage.new(name, version, File.open(license_file_path).read, url) unless name == 'conanfile.txt'
       end.compact
     end
   end

--- a/spec/fixtures/config/conan.txt
+++ b/spec/fixtures/config/conan.txt
@@ -1,4 +1,4 @@
-PROJECT
+conanfile.txt
     ID: 4c3dfe99a9c2d5003148e0054b9bacf58ac69f66
     BuildID: None
     Requires:
@@ -8,42 +8,42 @@ PROJECT
 OpenSSL/1.0.2l@conan/stable
     ID: 0197c20e330042c026560da838f5b4c4bf094b8a
     BuildID: None
-    Remote: conan-center=https://conan.bintray.com
+    Remote: conan-center=https://center.conan.io
     URL: http://github.com/lasote/conan-openssl
     License: The current OpenSSL licence is an 'Apache style' license: https://www.openssl.org/source/license.html
     Updates: Version not checked
     Creation date: 2017-08-21 10:28:57
     Required by:
         Poco/1.7.9@pocoproject/stable
-        PROJECT
+        conanfile.txt
     Requires:
         zlib/1.2.11@conan/stable
 Poco/1.7.9@pocoproject/stable
     ID: 33fe7ea34efc04fb6d81fabd9e34f51da57f9e09
     BuildID: None
-    Remote: conan-center=https://conan.bintray.com
+    Remote: conan-center=https://center.conan.io
     URL: http://github.com/lasote/conan-poco
     License: The Boost Software License 1.0
     Updates: Version not checked
     Creation date: 2017-09-20 16:51:10
     Required by:
-        PROJECT
+        conanfile.txt
     Requires:
         OpenSSL/1.0.2l@conan/stable
 range-v3/0.3.0@ericniebler/stable
     ID: 5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9
     BuildID: None
-    Remote: conan-center=https://conan.bintray.com
+    Remote: conan-center=https://center.conan.io
     URL: https://github.com/ericniebler/range-v3
     License: Boost Software License - Version 1.0 - August 17th, 2003
     Updates: Version not checked
     Creation date: 2017-06-30 13:20:56
     Required by:
-        PROJECT
+        conanfile.txt
 zlib/1.2.11@conan/stable
     ID: 09512ff863f37e98ed748eadd9c6df3e4ea424a8
     BuildID: None
-    Remote: conan-center=https://conan.bintray.com
+    Remote: conan-center=https://center.conan.io
     URL: http://github.com/lasote/conan-zlib
     License: http://www.zlib.net/zlib_license.html
     Updates: Version not checked

--- a/spec/lib/license_finder/package_managers/conan_info_parser_spec.rb
+++ b/spec/lib/license_finder/package_managers/conan_info_parser_spec.rb
@@ -8,7 +8,7 @@ module LicenseFinder
     let(:parsed_config) do
       [
         {
-          'name' => 'PROJECT',
+          'name' => 'conanfile.txt',
           'ID' => '4c3dfe99a9c2d5003148e0054b9bacf58ac69f66',
           'BuildID' => 'None',
           'Requires' => ['Poco/1.7.9@pocoproject/stable', 'OpenSSL/1.0.2l@conan/stable', 'range-v3/0.3.0@ericniebler/stable']
@@ -17,42 +17,42 @@ module LicenseFinder
           'name' => 'OpenSSL/1.0.2l@conan/stable',
           'ID' => '0197c20e330042c026560da838f5b4c4bf094b8a',
           'BuildID' => 'None',
-          'Remote' => 'conan-center=https://conan.bintray.com',
+          'Remote' => 'conan-center=https://center.conan.io',
           'URL' => 'http://github.com/lasote/conan-openssl',
           'License' => 'The current OpenSSL licence is an \'Apache style\' license: https://www.openssl.org/source/license.html',
           'Updates' => 'Version not checked',
           'Creation date' => '2017-08-21 10:28:57',
-          'Required by' => ['Poco/1.7.9@pocoproject/stable', 'PROJECT'],
+          'Required by' => ['Poco/1.7.9@pocoproject/stable', 'conanfile.txt'],
           'Requires' => ['zlib/1.2.11@conan/stable']
         },
         {
           'name' => 'Poco/1.7.9@pocoproject/stable',
           'ID' => '33fe7ea34efc04fb6d81fabd9e34f51da57f9e09',
           'BuildID' => 'None',
-          'Remote' => 'conan-center=https://conan.bintray.com',
+          'Remote' => 'conan-center=https://center.conan.io',
           'URL' => 'http://github.com/lasote/conan-poco',
           'License' => 'The Boost Software License 1.0',
           'Updates' => 'Version not checked',
           'Creation date' => '2017-09-20 16:51:10',
-          'Required by' => ['PROJECT'],
+          'Required by' => ['conanfile.txt'],
           'Requires' => ['OpenSSL/1.0.2l@conan/stable']
         },
         {
           'name' => 'range-v3/0.3.0@ericniebler/stable',
           'ID' => '5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9',
           'BuildID' => 'None',
-          'Remote' => 'conan-center=https://conan.bintray.com',
+          'Remote' => 'conan-center=https://center.conan.io',
           'URL' => 'https://github.com/ericniebler/range-v3',
           'License' => 'Boost Software License - Version 1.0 - August 17th, 2003',
           'Updates' => 'Version not checked',
           'Creation date' => '2017-06-30 13:20:56',
-          'Required by' => ['PROJECT']
+          'Required by' => ['conanfile.txt']
         },
         {
           'name' => 'zlib/1.2.11@conan/stable',
           'ID' => '09512ff863f37e98ed748eadd9c6df3e4ea424a8',
           'BuildID' => 'None',
-          'Remote' => 'conan-center=https://conan.bintray.com',
+          'Remote' => 'conan-center=https://center.conan.io',
           'URL' => 'http://github.com/lasote/conan-zlib',
           'License' => 'http://www.zlib.net/zlib_license.html',
           'Updates' => 'Version not checked',

--- a/spec/lib/license_finder/package_managers/conan_spec.rb
+++ b/spec/lib/license_finder/package_managers/conan_spec.rb
@@ -11,7 +11,7 @@ module LicenseFinder
     describe '#current_packages' do
       let(:content) do
         '[requires]
-Poco/1.7.8p3@pocoproject/stable
+Poco/1.7.8p3
 
 [generators]
 cmake
@@ -21,48 +21,48 @@ cmake
       end
 
       let(:conaninfo) do
-        'PROJECT
+        'conanfile.txt
     ID: 4c3dfe99a9c2d5003148e0054b9bacf58ac69f66
     BuildID: None
     Requires:
-        Poco/1.7.9@pocoproject/stable
-        OpenSSL/1.0.2l@conan/stable
-        range-v3/0.3.0@ericniebler/stable
-OpenSSL/1.0.2l@conan/stable
+        Poco/1.7.9
+        OpenSSL/1.0.2l
+        range-v3/0.3.0
+OpenSSL/1.0.2l
     ID: 0197c20e330042c026560da838f5b4c4bf094b8a
     BuildID: None
-    Remote: conan-center=https://conan.bintray.com
+    Remote: conan-center=https://center.conan.io
     URL: http://github.com/lasote/conan-openssl
     License: The current OpenSSL licence is an \'Apache style\' license: https://www.openssl.org/source/license.html
     Updates: Version not checked
     Creation date: 2017-08-21 10:28:57
     Required by:
-        Poco/1.7.9@pocoproject/stable
-        PROJECT
+        Poco/1.7.9
+        conanfile.txt
     Requires:
-        zlib/1.2.11@conan/stable
-Poco/1.7.8p3@pocoproject/stable
+        zlib/1.2.11
+Poco/1.7.8p3
     ID: 33fe7ea34efc04fb6d81fabd9e34f51da57f9e09
     BuildID: None
-    Remote: conan-center=https://conan.bintray.com
+    Remote: conan-center=https://center.conan.io
     URL: http://github.com/lasote/conan-poco
     License: The Boost Software License 1.0
     Updates: Version not checked
     Creation date: 2017-09-20 16:51:10
     Required by:
-        PROJECT
+        conanfile.txt
     Requires:
-        OpenSSL/1.0.2l@conan/stable
-zlib/1.2.11@conan/stable
+        OpenSSL/1.0.2l
+zlib/1.2.11
     ID: 09512ff863f37e98ed748eadd9c6df3e4ea424a8
     BuildID: None
-    Remote: conan-center=https://conan.bintray.com
+    Remote: conan-center=https://center.conan.io
     URL: http://github.com/lasote/conan-zlib
     License: http://www.zlib.net/zlib_license.html
     Updates: Version not checked
     Creation date: 2017-09-25 14:42:53
     Required by:
-        OpenSSL/1.0.2l@conan/stable'
+        OpenSSL/1.0.2l'
       end
 
       before do


### PR DESCRIPTION
Due to conan.bintray.com being deprecated, we needed to upgrade conan to be compatible with the new conan center and use center.conan.io instead. Also update some code logic and tests due to conan changes.
Tracker story [#180665528](https://www.pivotaltracker.com/story/show/180665528)

Signed-off-by: Jason Smith <jsmith@pivotal.io>