### PR TITLE
Fix inability to run license_finder with Ruby 3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .bundle
 .gradle/
 .idea/
+*.iml
 .pairs
 .rvmrc
 Gemfile.lock

--- a/lib/license_finder/decisions.rb
+++ b/lib/license_finder/decisions.rb
@@ -280,7 +280,11 @@ module LicenseFinder
     def self.restore(persisted, result = new)
       return result unless persisted
 
-      actions = YAML.load(persisted)
+      actions = if Psych::VERSION < '3.1.0'
+                  YAML.safe_load(persisted, %i[Symbol Time], [], true)
+                else
+                  YAML.safe_load(persisted, permitted_classes: %i[Symbol Time], aliases: true)
+                end
 
       list_of_actions = (actions || []).map(&:first)
 


### PR DESCRIPTION
Ruby 3.1 uses Psych 4 which requires safe_load to be called
with a list of permitted classes to load