### PR TITLE
:wrench: allow to specify cocoadpods acknowledgment through ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ languages, as long as that language has a package definition in the project dire
 * `build.gradle` (for `gradle`)
 * `settings.gradle` that specifies `rootProject.buildFileName` (for `gradle`)
 * `bower.json` (for `bower`)
-* `Podfile` (for `pod`)
+* `Podfile` (for `pod`) (set `ACKNOWLEDGEMENTS_PATH` variable if you want to target a particular `Pods-acknowledgements-<TARGET>.plist`. Can be useful in multi-target pods projects.)
 * `Cartfile` (for `carthage`)
 * `workspace-state.json` under build directory (provided as enviroment variable `SPM_DERIVED_DATA` for Xcode, or default `.build` for non-Xcode projects), (for `spm`)
 * `rebar.config` (for `rebar`)

--- a/lib/license_finder/package_managers/cocoa_pods.rb
+++ b/lib/license_finder/package_managers/cocoa_pods.rb
@@ -45,7 +45,7 @@ module LicenseFinder
 
       if !ENV['ACKNOWLEDGEMENTS_PATH'].nil?
         result = Dir[*ENV['ACKNOWLEDGEMENTS_PATH']].first
-      else  
+      else
         search_paths = ['Pods/Pods-acknowledgements.plist',
                         'Pods/Target Support Files/Pods/Pods-acknowledgements.plist',
                         'Pods/Target Support Files/Pods-*/Pods-*-acknowledgements.plist']

--- a/lib/license_finder/package_managers/cocoa_pods.rb
+++ b/lib/license_finder/package_managers/cocoa_pods.rb
@@ -42,13 +42,17 @@ module LicenseFinder
     end
 
     def acknowledgements_path
-      search_paths = ['Pods/Pods-acknowledgements.plist',
-                      'Pods/Target Support Files/Pods/Pods-acknowledgements.plist',
-                      'Pods/Target Support Files/Pods-*/Pods-*-acknowledgements.plist']
 
-      result = Dir[*search_paths.map { |path| File.join(project_path, path) }].first
-      raise "Found a Podfile but no Pods directory in #{project_path}. Try running pod install before running license_finder." if result.nil?
+      if !ENV['ACKNOWLEDGEMENTS_PATH'].nil?
+        result = Dir[*ENV['ACKNOWLEDGEMENTS_PATH']].first
+      else  
+        search_paths = ['Pods/Pods-acknowledgements.plist',
+                        'Pods/Target Support Files/Pods/Pods-acknowledgements.plist',
+                        'Pods/Target Support Files/Pods-*/Pods-*-acknowledgements.plist']
 
+        result = Dir[*search_paths.map { |path| File.join(project_path, path) }].first
+        raise "Found a Podfile but no Pods directory in #{project_path}. Try running pod install before running license_finder." if result.nil?
+      end
       result
     end
 

--- a/lib/license_finder/package_managers/cocoa_pods.rb
+++ b/lib/license_finder/package_managers/cocoa_pods.rb
@@ -42,7 +42,6 @@ module LicenseFinder
     end
 
     def acknowledgements_path
-
       if !ENV['ACKNOWLEDGEMENTS_PATH'].nil?
         result = Dir[*ENV['ACKNOWLEDGEMENTS_PATH']].first
       else


### PR DESCRIPTION
 > in multi projects folder of iOS projects, it looks like the cocoapods plugin is unable
to find the proper Pods-...-acknowledgments.plist file. As it takes only the 1st item of the dir,
We should be able to also specify the one we want trought an environment variable ACKNOWLEDGEMENT_PATH
just like what it is done in the SPM plugin where we do need to specify the environment variables for
DerivedDatas & Package.resolved files.