### PR TITLE
:sparkle: add a new option to use spdx identifier in reports

### DIFF
--- a/lib/license_finder/cli/base.rb
+++ b/lib/license_finder/cli/base.rb
@@ -61,7 +61,8 @@ module LicenseFinder
           :recursive,
           :sbt_include_groups,
           :conda_bash_setup_script,
-          :composer_check_require_only
+          :composer_check_require_only,
+          :use_spdx_id
         ).merge(
           logger: logger_mode
         )

--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -90,6 +90,11 @@ module LicenseFinder
         method_option :columns,
                       desc: "For text or CSV reports, which columns to print. Pick from: #{CsvReport::AVAILABLE_COLUMNS}",
                       type: :array
+
+        method_option :use_spdx_id,
+                      type: :boolean,
+                      desc: 'For reports, use the SPDX identifier instead of license name (useful to match license with other standard tools)',
+                      default: false
       end
 
       desc 'project_roots', 'List project directories to be scanned'
@@ -210,7 +215,7 @@ module LicenseFinder
       def report_of(content)
         report = FORMATS[config.format] || FORMATS['text']
         report = MergedReport if report == CsvReport && config.aggregate_paths
-        report.of(content, columns: config.columns, project_name: decisions.project_name || config.project_path.basename.to_s, write_headers: config.write_headers)
+        report.of(content, columns: config.columns, project_name: decisions.project_name || config.project_path.basename.to_s, write_headers: config.write_headers, use_spdx_id: config.use_spdx_id)
       end
 
       def save?

--- a/lib/license_finder/configuration.rb
+++ b/lib/license_finder/configuration.rb
@@ -145,6 +145,10 @@ module LicenseFinder
       get(:columns)
     end
 
+    def use_spdx_id
+      get(:use_spdx_id)
+    end
+
     def sbt_include_groups
       get(:sbt_include_groups)
     end

--- a/lib/license_finder/license.rb
+++ b/lib/license_finder/license.rb
@@ -40,6 +40,7 @@ module LicenseFinder
     def initialize(settings)
       @short_name  = settings.fetch(:short_name)
       @pretty_name = settings.fetch(:pretty_name, short_name)
+      @spdx_id     = settings.fetch(:spdx_id, '')
       @other_names = settings.fetch(:other_names, [])
       @url         = settings.fetch(:url)
       @matcher     = settings.fetch(:matcher) { Matcher.from_template(Template.named(short_name)) }
@@ -49,6 +50,10 @@ module LicenseFinder
 
     def name
       pretty_name
+    end
+
+    def standard_id
+      spdx_id
     end
 
     def stripped_name(name)
@@ -77,7 +82,7 @@ module LicenseFinder
 
     private
 
-    attr_reader :short_name, :pretty_name, :other_names
+    attr_reader :short_name, :pretty_name, :other_names, :spdx_id
     attr_reader :matcher
 
     def names
@@ -93,6 +98,7 @@ module LicenseFinder
       @short_name = name
       @pretty_name = name
       @url = nil
+      @spdx_id = nil
       @matcher = NoneMatcher.new
       # removes heading and trailing parentesis and splits
       name = name[1..-2] if name.start_with?('(')

--- a/lib/license_finder/license/definitions.rb
+++ b/lib/license_finder/license/definitions.rb
@@ -46,7 +46,7 @@ module LicenseFinder
         License.new(
           short_name: 'Apache1_1',
           pretty_name: 'Apache 1.1',
-          spdx_id: 'Apache-1.0',
+          spdx_id: 'Apache-1.1',
           other_names: [
             'Apache-1.1',
             'The Apache Software License, Version 1.1'

--- a/lib/license_finder/license/definitions.rb
+++ b/lib/license_finder/license/definitions.rb
@@ -46,6 +46,7 @@ module LicenseFinder
         License.new(
           short_name: 'Apache1_1',
           pretty_name: 'Apache 1.1',
+          spdx_id: 'Apache-1.0',
           other_names: [
             'Apache-1.1',
             'The Apache Software License, Version 1.1'
@@ -58,6 +59,7 @@ module LicenseFinder
         License.new(
           short_name: 'Apache2',
           pretty_name: 'Apache 2.0',
+          spdx_id: 'Apache-2.0',
           other_names: [
             'Apache-2.0',
             'Apache Software License',
@@ -79,6 +81,7 @@ module LicenseFinder
       def bsd
         License.new(
           short_name: 'BSD',
+          spdx_id: 'BSD-4-Clause',
           other_names: ['BSD4', 'bsd-old', '4-clause BSD', 'BSD-4-Clause', 'BSD 4-Clause', 'BSD License'],
           url: 'http://en.wikipedia.org/wiki/BSD_licenses#4-clause_license_.28original_.22BSD_License.22.29'
         )
@@ -87,6 +90,7 @@ module LicenseFinder
       def cc01
         License.new(
           short_name: 'CC01',
+          spdx_id: 'CC0-1.0',
           pretty_name: 'CC0 1.0 Universal',
           other_names: ['CC0 1.0'],
           url: 'http://creativecommons.org/publicdomain/zero/1.0'
@@ -96,6 +100,7 @@ module LicenseFinder
       def cddl1
         License.new(
           short_name: 'CDDL1',
+          spdx_id: 'CDDL-1.0',
           pretty_name: 'Common Development and Distribution License 1.0',
           other_names: [
             'CDDL-1.0',
@@ -109,6 +114,7 @@ module LicenseFinder
       def eclipse1
         License.new(
           short_name: 'EPL1',
+          spdx_id: 'EPL-1.0',
           pretty_name: 'Eclipse Public License 1.0',
           other_names: [
             'EPL-1.0',
@@ -122,6 +128,7 @@ module LicenseFinder
       def gplv2
         License.new(
           short_name: 'GPLv2',
+          spdx_id: 'GPL-2.0-only',
           other_names: ['GPL V2', 'gpl-v2', 'GNU GENERAL PUBLIC LICENSE Version 2'],
           url: 'http://www.gnu.org/licenses/gpl-2.0.txt'
         )
@@ -130,6 +137,7 @@ module LicenseFinder
       def gplv3
         License.new(
           short_name: 'GPLv3',
+          spdx_id: 'GPL-3.0-only',
           other_names: ['GPL V3', 'gpl-v3', 'GNU GENERAL PUBLIC LICENSE Version 3'],
           url: 'http://www.gnu.org/licenses/gpl-3.0.txt'
         )
@@ -138,6 +146,7 @@ module LicenseFinder
       def isc
         License.new(
           short_name: 'ISC',
+          spdx_id: 'ISC',
           url: 'http://en.wikipedia.org/wiki/ISC_license'
         )
       end
@@ -145,6 +154,7 @@ module LicenseFinder
       def lgpl
         License.new(
           short_name: 'LGPL',
+          spdx_id: 'LGPL-3.0-only',
           other_names: ['LGPL-3', 'LGPLv3', 'LGPL-3.0'],
           url: 'http://www.gnu.org/licenses/lgpl.txt'
         )
@@ -153,6 +163,7 @@ module LicenseFinder
       def lgpl2_1
         License.new(
           short_name: 'LGPL2_1',
+          spdx_id: 'LGPL-2.1-only',
           pretty_name: 'GNU Lesser General Public License version 2.1',
           other_names: [
             'LGPL-2.1-only',
@@ -178,6 +189,7 @@ module LicenseFinder
 
         License.new(
           short_name: 'MIT',
+          spdx_id: 'MIT',
           other_names: ['Expat', 'MIT license', 'MIT License', 'The MIT License (MIT)'],
           url: 'http://opensource.org/licenses/mit-license',
           matcher: matcher
@@ -197,6 +209,7 @@ module LicenseFinder
 
         License.new(
           short_name: 'MPL1_1',
+          spdx_id: 'MPL-1.1',
           pretty_name: 'Mozilla Public License 1.1',
           other_names: [
             'MPL-1.1',
@@ -218,6 +231,7 @@ module LicenseFinder
 
         License.new(
           short_name: 'MPL2',
+          spdx_id: 'MPL-2.0',
           pretty_name: 'Mozilla Public License 2.0',
           other_names: [
             'MPL-2.0',
@@ -243,6 +257,7 @@ module LicenseFinder
 
         License.new(
           short_name: 'NewBSD',
+          spdx_id: 'BSD-3-Clause',
           pretty_name: 'New BSD',
           other_names: [
             'Modified BSD',
@@ -266,6 +281,7 @@ module LicenseFinder
       def ofl
         License.new(
           short_name: 'OFL',
+          spdx_id: 'OFL-1.1',
           pretty_name: 'SIL OPEN FONT LICENSE Version 1.1',
           other_names: [
             'OPEN FONT LICENSE Version 1.1'
@@ -277,6 +293,7 @@ module LicenseFinder
       def python
         License.new(
           short_name: 'Python',
+          spdx_id: 'PSF-2.0',
           pretty_name: 'Python Software Foundation License',
           other_names: [
             'PSF',
@@ -297,6 +314,7 @@ module LicenseFinder
 
         License.new(
           short_name: 'Ruby',
+          spdx_id: 'Ruby',
           pretty_name: 'ruby',
           url: url,
           matcher: matcher
@@ -306,6 +324,7 @@ module LicenseFinder
       def simplifiedbsd
         License.new(
           short_name: 'SimplifiedBSD',
+          spdx_id: 'BSD-2-Clause',
           pretty_name: 'Simplified BSD',
           other_names: [
             'FreeBSD',
@@ -321,6 +340,7 @@ module LicenseFinder
       def wtfpl
         License.new(
           short_name: 'WTFPL',
+          spdx_id: 'WTFPL',
           pretty_name: 'WTFPL',
           other_names: [
             'WTFPL V2',
@@ -337,6 +357,7 @@ module LicenseFinder
 
         License.new(
           short_name: '0BSD',
+          spdx_id: '0BSD',
           pretty_name: 'BSD Zero Clause License',
           other_names: [
             '0-Clause BSD',
@@ -354,6 +375,7 @@ module LicenseFinder
       def zlib
         License.new(
           short_name: 'Zlib',
+          spdx_id: 'Zlib',
           pretty_name: 'zlib/libpng license',
           other_names: [
             'zlib License'

--- a/lib/license_finder/report.rb
+++ b/lib/license_finder/report.rb
@@ -9,11 +9,12 @@ module LicenseFinder
     def initialize(dependencies, options)
       @dependencies = dependencies
       @project_name = options[:project_name]
+      @use_spdx_id = options[:use_spdx_id]
     end
 
     private
 
-    attr_reader :dependencies, :project_name
+    attr_reader :dependencies, :project_name, :use_spdx_id
 
     def sorted_dependencies
       dependencies.sort

--- a/lib/license_finder/reports/csv_report.rb
+++ b/lib/license_finder/reports/csv_report.rb
@@ -60,7 +60,7 @@ module LicenseFinder
       if dep.missing?
         MISSING_DEPENDENCY_TEXT
       else
-        dep.licenses.map(&:name).join(self.class::COMMA_SEP)
+        dep.licenses.map(&@use_spdx_id ? :standard_id : :name).join(self.class::COMMA_SEP)
       end
     end
 

--- a/lib/license_finder/reports/erb_report.rb
+++ b/lib/license_finder/reports/erb_report.rb
@@ -22,7 +22,7 @@ module LicenseFinder
     end
 
     def link_to_license(license)
-      link_to_maybe license.name, license.url
+      link_to_maybe (@use_spdx_id ? license.standard_id : license.name), license.url
     end
 
     def link_to_dependency(dependency)
@@ -42,7 +42,7 @@ module LicenseFinder
     end
 
     def license_names(dependency)
-      dependency.licenses.map(&:name).sort.join ', '
+      dependency.licenses.map(&@use_spdx_id? :standard_id : :name).sort.join ', '
     end
 
     def license_links(dependency)

--- a/lib/license_finder/reports/json_report.rb
+++ b/lib/license_finder/reports/json_report.rb
@@ -24,7 +24,8 @@ module LicenseFinder
     end
 
     def format_licenses(dep)
-      dep.missing? ? [] : dep.licenses.map(&:name)
+      dep.missing? ? [] :
+       dep.licenses.map(&(@use_spdx_id ? :standard_id : :name))
     end
   end
 end

--- a/spec/lib/license_finder/cli/main_spec.rb
+++ b/spec/lib/license_finder/cli/main_spec.rb
@@ -95,7 +95,8 @@ module LicenseFinder
 
         it 'passes the config options to the new LicenseFinder::LicenseAggregator instance' do
           stubs = { valid_project_path?: true, project_path: Pathname('../other_project'),
-                    decisions_file_path: Pathname('../other_project'), aggregate_paths: nil, recursive: false, format: nil, columns: nil, strict_matching: false, write_headers: false }
+                    decisions_file_path: Pathname('. ./other_project'), aggregate_paths: nil, recursive: false,
+                    format: nil, columns: nil, strict_matching: false, write_headers: false, use_spdx_id: false }
           configuration = double(:configuration, stubs)
           allow(LicenseFinder::Configuration).to receive(:with_optional_saved_config).and_return(configuration)
           expect(LicenseFinder::LicenseAggregator).to receive(:new).with(configuration, anything).and_return(license_finder_instance)

--- a/spec/lib/license_finder/license_spec.rb
+++ b/spec/lib/license_finder/license_spec.rb
@@ -17,7 +17,7 @@ module LicenseFinder
       end
     end
   end
-  describe AndLicense do
+  describe OrLicense do
     describe '.find_by_name' do
       # sub licenses case already tested on and, since this is subclass
       it 'should create a compound OR license' do

--- a/spec/lib/license_finder/reports/csv_report_spec.rb
+++ b/spec/lib/license_finder/reports/csv_report_spec.rb
@@ -65,6 +65,14 @@ module LicenseFinder
       expect(subject.to_s).to eq("gem_a,MIT,#{mit.url}\n")
     end
 
+    it 'use license spdx identifier instead of name' do
+      dep = Package.new('gem_a', '1.0')
+      license = License.find_by_name('Apache 2.0')
+      dep.decide_on_license(license)
+      subject = described_class.new([dep], use_spdx_id: true)
+      expect(subject.to_s).to eq("gem_a,1.0,Apache-2.0\n")
+    end
+
     it 'does not include columns that should only be in merged reports' do
       dep = Package.new('gem_a', '1.0')
       subject = described_class.new([dep], columns: %w[aggregate_paths])


### PR DESCRIPTION
 - SPDX identifier is essential to make license match between CI tools.
 - Using the proper --use_spdx_licenses, the user can get those licenses
in the proper format to use reports in tools such as Sonar License Check plugins