### PR TITLE
[Changed] Raise an error if the yarn licenses list command fails

### DIFF
--- a/lib/license_finder/package_managers/yarn.rb
+++ b/lib/license_finder/package_managers/yarn.rb
@@ -13,8 +13,8 @@ module LicenseFinder
       suffix = " --cwd #{project_path}" unless project_path.nil?
       cmd += suffix unless suffix.nil?
 
-      stdout, _stderr, status = Cmd.run(cmd)
-      return [] unless status.success?
+      stdout, stderr, status = Cmd.run(cmd)
+      raise "Command '#{cmd}' failed to execute: #{stderr}" unless status.success?
 
       packages = []
       incompatible_packages = []

--- a/spec/lib/license_finder/package_managers/yarn_spec.rb
+++ b/spec/lib/license_finder/package_managers/yarn_spec.rb
@@ -171,11 +171,11 @@ module LicenseFinder
         end
       end
 
-      context "when the shell command raises an error" do
-        it "raises" do
+      context 'when the shell command fails' do
+        it 'an error is raised' do
           allow(SharedHelpers::Cmd).to receive(:run).with(Yarn::SHELL_COMMAND + " --cwd #{Pathname(root)}").and_return([nil, 'error', cmd_failure])
 
-          expect { subject.current_packages }.to raise_error(%r{Command 'yarn licenses list --no-progress --json --cwd #{Pathname(root)}' failed to execute: error})
+          expect { subject.current_packages }.to raise_error(/Command 'yarn licenses list --no-progress --json --cwd #{Pathname(root)}' failed to execute: error/)
         end
       end
     end

--- a/spec/lib/license_finder/package_managers/yarn_spec.rb
+++ b/spec/lib/license_finder/package_managers/yarn_spec.rb
@@ -170,6 +170,14 @@ module LicenseFinder
           expect(subject.current_packages.first.homepage).to eq 'https://github.com/felixg?/node-stack-trace'
         end
       end
+
+      context "when the shell command raises an error" do
+        it "raises" do
+          allow(SharedHelpers::Cmd).to receive(:run).with(Yarn::SHELL_COMMAND + " --cwd #{Pathname(root)}").and_return([nil, 'error', cmd_failure])
+
+          expect { subject.current_packages }.to raise_error(%r{Command 'yarn licenses list --no-progress --json --cwd #{Pathname(root)}' failed to execute: error})
+        end
+      end
     end
 
     describe '.prepare_command' do


### PR DESCRIPTION
Previously, LicenseFinder::Yarn.new.current_packages silently returned an empty array when `yarn licenses list` failed, resulting in no license violations being detected.
This is dangerous as it can lead to thinking there are no license issues present.

Missing or incorrectly configured environment variables can lead to
`yarn licenses list` failing.

The change does break backwards compatibility, but I'm struggling to think of a case where you'd want silent failures.