### PR TITLE
fix: Update install steps for LicenseFinder to work with Gem 3.3.6+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -242,7 +242,7 @@ RUN set -e; \
 
 # install license_finder
 COPY . /LicenseFinder
-RUN bash -lc "cd /LicenseFinder && bundle config set no-cache 'true' && bundle install -j4 && rake install"
+RUN bash -lc "cd /LicenseFinder && bundle config set no-cache 'true' && bundle install -j4 && bundle pristine && rake install"
 
 WORKDIR /
 

--- a/ci/scripts/run-tests.sh
+++ b/ci/scripts/run-tests.sh
@@ -7,22 +7,18 @@ PROJECT_ROOT="$( dirname "$( dirname $DIR )" )"
 
 pushd "$PROJECT_ROOT"
 
-  gem update --system
-  # Since we update the system gem, we need to ensure that RVM
-  # re-installs requested ruby version to ensure it is
-  # installed correctly again. If the ruby version is does not exist,
-  # re-install will install it.
-  rvm reinstall --default $RUBY_VERSION_UNDER_TEST
+  rvm install --default $RUBY_VERSION_UNDER_TEST
   ruby --version
 
   export GOPATH=$HOME/go
   export RUBYOPT='-E utf-8'
 
+  gem update --system
   gem install bundler
-  bundle install
+  bundle pristine
 
-  bundle exec rake install
-  bundle exec rake spec
+  rake install
+  rake spec
 
-  bundle exec rake features
+  rake features
 popd


### PR DESCRIPTION
The way LicenseFinder is installed as part of the docker image does not work
when using Gem version 3.3.6 or later. As such, the install steps have been
updated so License Finder can work with that gem version.