### PR TITLE
Added the `who` and `why` of manually approved licenses to the CSV report

### DIFF
--- a/lib/license_finder/reports/csv_report.rb
+++ b/lib/license_finder/reports/csv_report.rb
@@ -4,7 +4,7 @@ module LicenseFinder
   class CsvReport < Report
     COMMA_SEP = ','.freeze
     NEWLINE_SEP = '\@NL'.freeze
-    AVAILABLE_COLUMNS = %w[name version authors licenses license_links approved summary description homepage install_path package_manager groups texts notice].freeze
+    AVAILABLE_COLUMNS = %w[name version authors licenses license_links approved summary description homepage install_path package_manager groups texts notice approved_by approved_reason].freeze
     MISSING_DEPENDENCY_TEXT = 'This package is not installed. Please install to determine licenses.'.freeze
 
     def initialize(dependencies, options)
@@ -95,5 +95,14 @@ module LicenseFinder
         dep.groups.join(self.class::COMMA_SEP)
       end
     end
+
+    def format_approved_by(dep)
+      dep.approved_manually? ? dep.manual_approval.who : ''
+    end
+
+    def format_approved_reason(dep)
+      dep.approved_manually? ? dep.manual_approval.why : ''
+    end
+
   end
 end

--- a/spec/lib/license_finder/reports/csv_report_spec.rb
+++ b/spec/lib/license_finder/reports/csv_report_spec.rb
@@ -57,6 +57,13 @@ module LicenseFinder
       expect(subject.to_s).to eq("gem_a,1.0,Nuget\n")
     end
 
+    it 'supports why and who column' do
+      dep = Package.new('gem_a', '1.0')
+      dep.approved_manually!(Decisions::TXN.new('the-approver', 'the-approval-note', Time.now.utc))
+      subject = described_class.new([dep], columns: %w[name version approved_reason approved_by])
+      expect(subject.to_s).to eq("gem_a,1.0,the-approval-note,the-approver\n")
+    end
+
     it 'supports license_links column' do
       dep = Package.new('gem_a', '1.0')
       mit = License.find_by_name('MIT')


### PR DESCRIPTION
The `who` is represented by the `approved_by` column and the `why` by the `approved_reason`.