### PR TITLE
feat: add --yarn-options option to customize yarn behavior

### DIFF
--- a/lib/license_finder/cli/base.rb
+++ b/lib/license_finder/cli/base.rb
@@ -46,6 +46,7 @@ module LicenseFinder
           :maven_include_groups,
           :maven_options,
           :npm_options,
+          :yarn_options,
           :pip_requirements_path,
           :python_version,
           :rebar_command,

--- a/lib/license_finder/cli/main.rb
+++ b/lib/license_finder/cli/main.rb
@@ -32,6 +32,7 @@ module LicenseFinder
       class_option :maven_include_groups, desc: 'Whether dependency name should include group id. Only meaningful if used with a Java/maven project. Defaults to false.'
       class_option :maven_options, desc: 'Maven options to append to command. Defaults to empty.'
       class_option :npm_options, desc: 'npm options to append to command. Defaults to empty.'
+      class_option :yarn_options, desc: 'yarn options to append to command. Defaults to empty.'
       class_option :pip_requirements_path, desc: 'Path to python requirements file. Defaults to requirements.txt.'
       class_option :python_version, desc: 'Python version to invoke pip with. Valid versions: 2 or 3. Default: 2'
       class_option :rebar_command, desc: "Command to use when fetching rebar packages. Only meaningful if used with a Erlang/rebar project. Defaults to 'rebar'."

--- a/lib/license_finder/configuration.rb
+++ b/lib/license_finder/configuration.rb
@@ -97,6 +97,10 @@ module LicenseFinder
       get(:npm_options)
     end
 
+    def yarn_options
+      get(:yarn_options)
+    end
+
     def pip_requirements_path
       get(:pip_requirements_path)
     end

--- a/lib/license_finder/core.rb
+++ b/lib/license_finder/core.rb
@@ -101,6 +101,7 @@ module LicenseFinder
         maven_include_groups: config.maven_include_groups,
         maven_options: config.maven_options,
         npm_options: config.npm_options,
+        yarn_options: config.yarn_options,
         pip_requirements_path: config.pip_requirements_path,
         python_version: config.python_version,
         rebar_command: config.rebar_command,

--- a/lib/license_finder/package_managers/yarn.rb
+++ b/lib/license_finder/package_managers/yarn.rb
@@ -2,6 +2,11 @@
 
 module LicenseFinder
   class Yarn < PackageManager
+    def initialize(options = {})
+      super
+      @yarn_options = options[:yarn_options]
+    end
+
     SHELL_COMMAND = 'yarn licenses list --json'
 
     def possible_package_paths
@@ -14,6 +19,7 @@ module LicenseFinder
       if yarn_version == 1
         cmd += ' --no-progress'
         cmd += " --cwd #{project_path}" unless project_path.nil?
+        cmd += " #{@yarn_options}" unless @yarn_options.nil?
       end
 
       stdout, stderr, status = Cmd.run(cmd)

--- a/spec/lib/license_finder/core_spec.rb
+++ b/spec/lib/license_finder/core_spec.rb
@@ -41,6 +41,7 @@ module LicenseFinder
           maven_include_groups: nil,
           maven_options: nil,
           npm_options: nil,
+          yarn_options: nil,
           pip_requirements_path: nil,
           python_version: nil,
           rebar_command: configuration.rebar_command,


### PR DESCRIPTION
adds parameter `--yarn-options` that like the same option for npm is useful to pass a parameter to the yarn `yarn licenses list` command