### PR TITLE
Maven: extract LICENSE and NOTICE texts from JAR + add summary, description, url from POM

### DIFF
--- a/features/features/package_managers/maven_spec.rb
+++ b/features/features/package_managers/maven_spec.rb
@@ -21,4 +21,21 @@ describe 'Maven Dependencies' do
       expect(java_developer).to be_seeing_line 'junit:junit, 4.13.1, "Eclipse Public License 1.0"'
     end
   end
+
+  it 'extracts name/description/url from POM and license/notice from JAR' do
+    LicenseFinder::TestingDSL::MavenProject.create
+    java_developer.execute_command 'license_finder report --columns summary description homepage texts notice --format=csv'
+
+    expect(java_developer).to be_seeing_once 'Hamcrest Core,'
+    expect(java_developer).to be_seeing_once 'This is the core API of hamcrest matcher framework'
+    expect(java_developer).to be_seeing_once 'Copyright (c) 2000-2006, www.hamcrest.org'
+
+    expect(java_developer).to be_seeing_once 'JUnit,'
+    expect(java_developer).to be_seeing_once '"JUnit is a unit testing framework for Java'
+    expect(java_developer).to be_seeing_once 'http://junit.org'
+
+    expect(java_developer).to be_seeing_once 'Apache Commons Lang,"Apache Commons Lang, a package of Java utility classes'
+    expect(java_developer).to be_seeing_once 'Version 2.0, January 2004' # LICENSE
+    expect(java_developer).to be_seeing_once 'This product includes software developed at' # NOTICE
+  end
 end

--- a/features/fixtures/pom.xml
+++ b/features/fixtures/pom.xml
@@ -15,5 +15,10 @@
       <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.12.0</version>
+    </dependency>
   </dependencies>
 </project>

--- a/lib/license_finder/package_utils/license_files.rb
+++ b/lib/license_finder/package_utils/license_files.rb
@@ -27,7 +27,7 @@ module LicenseFinder
 
     def paths_of_candidate_files
       candidate_files_and_dirs
-        .flat_map { |path| path.directory? ? path.children : path }
+        .flat_map { |path| !path.is_a?(Zip::Entry) && path.directory? ? path.children : path }
         .reject(&:directory?)
         .uniq
     end
@@ -35,7 +35,17 @@ module LicenseFinder
     def candidate_files_and_dirs
       return [] if install_path.nil?
 
-      Pathname.glob(install_path.join('**', CANDIDATE_PATH_WILDCARD))
+      if !install_path.extname.casecmp('.jar').zero?
+        Pathname.glob(install_path.join('**', CANDIDATE_PATH_WILDCARD))
+      else
+        candidates_from_zip
+      end
+    end
+
+    def candidates_from_zip
+      Zip::File.open(install_path.to_s) do |zip_file|
+        zip_file.glob(CANDIDATE_PATH_WILDCARD, File::FNM_EXTGLOB)
+      end
     end
   end
 end

--- a/lib/license_finder/package_utils/maven_dependency_finder.rb
+++ b/lib/license_finder/package_utils/maven_dependency_finder.rb
@@ -2,14 +2,50 @@
 
 module LicenseFinder
   class MavenDependencyFinder
-    def initialize(project_path)
+    def initialize(project_path, m2_path)
       @project_path = project_path
+      @m2_path = m2_path
     end
 
     def dependencies
+      options = {
+        'GroupTags' => { 'licenses' => 'license', 'dependencies' => 'dependency' },
+        'ForceArray' => %w[license dependency]
+      }
+
       Pathname
         .glob(@project_path.join('**', 'target', 'generated-resources', 'licenses.xml'))
         .map(&:read)
+        .flat_map { |xml| XmlSimple.xml_in(xml, options)['dependencies'] }
+        .each { |dep| add_info_from_m2(dep) }
+    end
+
+    # Add the name of the JAR file to allow later retrieval of license and notice files,
+    # and add the name, description and URL from the POM XML file.
+    def add_info_from_m2(dep)
+      m2_artifact_dir = @m2_path
+        .join(dep['groupId'].tr('.', '/'))
+        .join(dep['artifactId'])
+        .join(dep['version'])
+      artifact_basename = "#{dep['artifactId']}-#{dep['version']}"
+
+      dep.store('jarFile', m2_artifact_dir.join("#{artifact_basename}.jar"))
+
+      add_info_from_pom(m2_artifact_dir.join("#{artifact_basename}.pom"), dep)
+    end
+
+    # Extract name, description and URL from pom.xml
+    def add_info_from_pom(pom_file, dep)
+      pom = XmlSimple.xml_in(pom_file.read, { 'ForceArray' => false })
+
+      name = pom['name']
+      dep.store('summary', name) unless name.nil?
+
+      description = pom['description']
+      dep.store('description', description) unless description.nil?
+
+      url = pom['url']
+      dep.store('homepage', url) unless url.nil?
     end
   end
 end

--- a/lib/license_finder/package_utils/notice_files.rb
+++ b/lib/license_finder/package_utils/notice_files.rb
@@ -5,7 +5,8 @@ require 'license_finder/package_utils/possible_license_file'
 module LicenseFinder
   class NoticeFiles
     CANDIDATE_FILE_NAMES = %w[NOTICE Notice].freeze
-    CANDIDATE_PATH_WILDCARD = "*{#{CANDIDATE_FILE_NAMES.join(',')}}*"
+    CANDIDATE_PATH_WILDCARD_STRICT = "{#{CANDIDATE_FILE_NAMES.join(',')}}*"
+    CANDIDATE_PATH_WILDCARD = "*#{CANDIDATE_PATH_WILDCARD_STRICT}"
 
     def self.find(install_path, options = {})
       new(install_path).find(options)
@@ -26,7 +27,7 @@ module LicenseFinder
 
     def paths_of_candidate_files
       candidate_files_and_dirs
-        .flat_map { |path| path.directory? ? path.children : path }
+        .flat_map { |path| !path.is_a?(Zip::Entry) && path.directory? ? path.children : path }
         .reject(&:directory?)
         .uniq
     end
@@ -34,7 +35,17 @@ module LicenseFinder
     def candidate_files_and_dirs
       return [] if install_path.nil?
 
-      Pathname.glob(install_path.join('**', CANDIDATE_PATH_WILDCARD))
+      if !install_path.extname.casecmp('.jar').zero?
+        Pathname.glob(install_path.join('**', CANDIDATE_PATH_WILDCARD))
+      else
+        candidates_from_zip
+      end
+    end
+
+    def candidates_from_zip
+      Zip::File.open(install_path.to_s) do |zip_file|
+        zip_file.glob("*/#{CANDIDATE_PATH_WILDCARD_STRICT}", File::FNM_EXTGLOB)
+      end
     end
   end
 end

--- a/lib/license_finder/package_utils/possible_license_file.rb
+++ b/lib/license_finder/package_utils/possible_license_file.rb
@@ -3,7 +3,11 @@
 module LicenseFinder
   class PossibleLicenseFile
     def initialize(path, options = {})
-      @path = Pathname(path)
+      if !path.is_a?(Zip::Entry)
+        @path = Pathname(path)
+      else
+        @zip_entry = path
+      end
       @logger = options[:logger]
     end
 
@@ -16,7 +20,9 @@ module LicenseFinder
     end
 
     def text
-      if @path.exist?
+      if @zip_entry
+        @zip_entry.get_input_stream.read
+      elsif @path.exist?
         @text ||= (@path.respond_to?(:binread) ? @path.binread : @path.read)
       else
         @logger.info('ERROR', "#{@path} does not exists", color: :red)

--- a/lib/license_finder/packages/maven_package.rb
+++ b/lib/license_finder/packages/maven_package.rb
@@ -5,13 +5,17 @@ module LicenseFinder
     def initialize(spec, options = {})
       name = spec['artifactId']
       name = "#{spec['groupId']}:#{name}" if options[:include_groups]
+      @jar_file = spec['jarFile']
 
       super(
         name,
         spec['version'],
         options.merge(
           spec_licenses: Array(spec['licenses']).map { |l| l['name'] },
-          groups: Array(spec['groupId'])
+          groups: Array(spec['groupId']),
+          summary: spec['summary'],
+          description: spec['description'],
+          homepage: spec['homepage']
         )
       )
     end
@@ -22,6 +26,14 @@ module LicenseFinder
 
     def package_url
       "https://search.maven.org/artifact/#{CGI.escape(groups.first)}/#{CGI.escape(name.split(':').last)}/#{CGI.escape(version)}/jar"
+    end
+
+    def license_files
+      LicenseFiles.find(@jar_file, logger: logger)
+    end
+
+    def notice_files
+      NoticeFiles.find(@jar_file, logger: logger)
     end
   end
 end


### PR DESCRIPTION
I'd like to propose this change to the Maven extraction. It adds support for extracting the `texts` and `notice` for Maven. This resolves #822.

Further, we will now extract the following fields from the POM file to the respective LicenseFinder fields: `name` => `summary`, `description` => `description`, `url` => `homepage`.

It extracts the license and notice texts from the JAR files which are downloaded by Maven into `~/.m2`. I found this to be the only way how we can get the license texts (the files downloaded by the Maven plugin are just the license templates, with no author names). I had to make the filename matching for notice files a bit stricter (`notice*`) than your default (`*notice*`) because we do not verify them further as we do for the license files and I got wrong files included (like `.class` files).

If we want to extend the test suite to cover this new functionality, I'd be happy for any hints. Do we actually run Maven somewhere in the test suite already for an end-to-end test? The existing tests seem to stub out Maven, and I'm not sure how well I can cover this code that way.