### PR TITLE
Fail to detect "BSD 3-Clause"

### DIFF
--- a/lib/license_finder/license/definitions.rb
+++ b/lib/license_finder/license/definitions.rb
@@ -267,6 +267,7 @@ module LicenseFinder
             '3-clause BSD',
             '3-Clause BSD License',
             'BSD-3-Clause',
+            'BSD 3-Clause',
             'BSD 3-Clause License',
             'The 3-Clause BSD License',
             'BSD 3-clause New License',


### PR DESCRIPTION
## Issue

#927 

## What I did

- Add `'BSD 3-Clause'` in `other_names` of NewBSD license to solve a mis-recognition.
