### PR TITLE
[Fixed] Scan transitive Yarn v2+ dependencies

### DIFF
--- a/lib/license_finder/package_managers/yarn.rb
+++ b/lib/license_finder/package_managers/yarn.rb
@@ -7,7 +7,7 @@ module LicenseFinder
       @yarn_options = options[:yarn_options]
     end
 
-    SHELL_COMMAND = 'yarn licenses list --json'
+    SHELL_COMMAND = 'yarn licenses list --recursive --json'
 
     def possible_package_paths
       [project_path.join('yarn.lock')]

--- a/spec/lib/license_finder/package_managers/yarn_spec.rb
+++ b/spec/lib/license_finder/package_managers/yarn_spec.rb
@@ -263,7 +263,7 @@ module LicenseFinder
         it 'an error is raised' do
           allow(SharedHelpers::Cmd).to receive(:run).with(Yarn::SHELL_COMMAND + " --no-progress --cwd #{Pathname(root)}").and_return([nil, 'error', cmd_failure])
 
-          expect { subject.current_packages }.to raise_error(/Command 'yarn licenses list --json --no-progress --cwd #{Pathname(root)}' failed to execute: error/)
+          expect { subject.current_packages }.to raise_error(/Command 'yarn licenses list --recursive --json --no-progress --cwd #{Pathname(root)}' failed to execute: error/)
         end
       end
     end


### PR DESCRIPTION
Fixes #912.

Previously, only direct dependencies were considered.

Disclaimer: I am unable to test my changes locally on account of #947.