### PR TITLE
PyPI: Raise on error 

### DIFF
--- a/dlf
+++ b/dlf
@@ -1,7 +1,7 @@
 #!/bin/bash
 if `which docker > /dev/null`; then
   if [ $# -eq 0 ]; then
-    docker run --platform linux/amd64 -v $PWD:/scan -it licensefinder/license_finder
+    docker run -v $PWD:/scan -it licensefinder/license_finder
   else
     escaped_params=""
     for p in "$@"; do
@@ -12,7 +12,7 @@ if `which docker > /dev/null`; then
     else
       command=$escaped_params
     fi
-    docker run --platform linux/amd64 -v $PWD:/scan -it licensefinder/license_finder /bin/bash -lc "cd /scan && $command"
+    docker run -v $PWD:/scan -it licensefinder/license_finder /bin/bash -lc "cd /scan && $command"
   fi
 else
   echo "You do not have docker installed. Please install it:"

--- a/dlf
+++ b/dlf
@@ -1,7 +1,7 @@
 #!/bin/bash
 if `which docker > /dev/null`; then
   if [ $# -eq 0 ]; then
-    docker run -v $PWD:/scan -it licensefinder/license_finder
+    docker run --platform linux/amd64 -v $PWD:/scan -it licensefinder/license_finder
   else
     escaped_params=""
     for p in "$@"; do
@@ -12,7 +12,7 @@ if `which docker > /dev/null`; then
     else
       command=$escaped_params
     fi
-    docker run -v $PWD:/scan -it licensefinder/license_finder /bin/bash -lc "cd /scan && $command"
+    docker run --platform linux/amd64 -v $PWD:/scan -it licensefinder/license_finder /bin/bash -lc "cd /scan && $command"
   fi
 else
   echo "You do not have docker installed. Please install it:"

--- a/lib/license_finder/package_utils/pypi.rb
+++ b/lib/license_finder/package_utils/pypi.rb
@@ -28,6 +28,7 @@ module LicenseFinder
         response.is_a?(Net::HTTPSuccess) ? JSON.parse(response.body).fetch('info', {}) : {}
       rescue *CONNECTION_ERRORS => e
         raise e, "Unable to read package from pypi.org #{name} #{version}: #{e}" unless @prepare_no_fail
+        
         {}
       end
 

--- a/lib/license_finder/package_utils/pypi.rb
+++ b/lib/license_finder/package_utils/pypi.rb
@@ -2,6 +2,7 @@
 
 require 'net/http'
 require 'openssl'
+require 'license_finder/logger'
 
 module LicenseFinder
   class PyPI
@@ -25,8 +26,12 @@ module LicenseFinder
       def definition(name, version)
         response = request("https://pypi.org/pypi/#{name}/#{version}/json")
         response.is_a?(Net::HTTPSuccess) ? JSON.parse(response.body).fetch('info', {}) : {}
-      rescue *CONNECTION_ERRORS
-        {}
+      rescue *CONNECTION_ERRORS => e
+        if @prepare_no_fail
+          {}
+        else
+          raise e, "Unable to read package from pypi.org #{name} #{version}: #{e}"
+        end
       end
 
       def request(location, limit = 10)

--- a/lib/license_finder/package_utils/pypi.rb
+++ b/lib/license_finder/package_utils/pypi.rb
@@ -27,11 +27,8 @@ module LicenseFinder
         response = request("https://pypi.org/pypi/#{name}/#{version}/json")
         response.is_a?(Net::HTTPSuccess) ? JSON.parse(response.body).fetch('info', {}) : {}
       rescue *CONNECTION_ERRORS => e
-        if @prepare_no_fail
-          {}
-        else
-          raise e, "Unable to read package from pypi.org #{name} #{version}: #{e}"
-        end
+        raise e, "Unable to read package from pypi.org #{name} #{version}: #{e}" unless @prepare_no_fail
+        {}
       end
 
       def request(location, limit = 10)

--- a/lib/license_finder/package_utils/pypi.rb
+++ b/lib/license_finder/package_utils/pypi.rb
@@ -28,7 +28,7 @@ module LicenseFinder
         response.is_a?(Net::HTTPSuccess) ? JSON.parse(response.body).fetch('info', {}) : {}
       rescue *CONNECTION_ERRORS => e
         raise e, "Unable to read package from pypi.org #{name} #{version}: #{e}" unless @prepare_no_fail
-        
+
         {}
       end
 

--- a/lib/license_finder/package_utils/pypi.rb
+++ b/lib/license_finder/package_utils/pypi.rb
@@ -2,7 +2,6 @@
 
 require 'net/http'
 require 'openssl'
-require 'license_finder/logger'
 
 module LicenseFinder
   class PyPI

--- a/spec/lib/license_finder/package_utils/pypi_spec.rb
+++ b/spec/lib/license_finder/package_utils/pypi_spec.rb
@@ -70,7 +70,6 @@ RSpec.describe LicenseFinder::PyPI do
     end
 
     context 'when the source is not reachable and --prepare_no_fail is not set' do
-
       before do
         stub_request(:get, "https://#{source}/pypi/#{package}/#{version}/json")
           .to_timeout
@@ -92,6 +91,5 @@ RSpec.describe LicenseFinder::PyPI do
         expect(subject.definition(package, version)).to be_empty
       end
     end
-
   end
 end

--- a/spec/lib/license_finder/package_utils/pypi_spec.rb
+++ b/spec/lib/license_finder/package_utils/pypi_spec.rb
@@ -69,15 +69,29 @@ RSpec.describe LicenseFinder::PyPI do
       end
     end
 
-    context 'when the source is not reachable' do
+    context 'when the source is not reachable and --prepare_no_fail is not set' do
+
       before do
         stub_request(:get, "https://#{source}/pypi/#{package}/#{version}/json")
           .to_timeout
+      end
+
+      it 'raises error' do
+        expect { subject.definition(package, version) }.to raise_error(Net::OpenTimeout)
+      end
+    end
+
+    context 'when the source is not reachable and --prepare_no_fail is set' do
+      before do
+        stub_request(:get, "https://#{source}/pypi/#{package}/#{version}/json")
+          .to_timeout
+        subject.instance_variable_set(:@prepare_no_fail, true)
       end
 
       it 'fails gracefully' do
         expect(subject.definition(package, version)).to be_empty
       end
     end
+
   end
 end


### PR DESCRIPTION

### Changed
 - When `--prepare_no_fail` isn't set, raise errors from PyPi rather than suppressing them.