### PR TITLE
Fix a bug writing to the decisions file when there is nested inheritance

### DIFF
--- a/lib/license_finder/decisions.rb
+++ b/lib/license_finder/decisions.rb
@@ -235,9 +235,10 @@ module LicenseFinder
     end
 
     def restore_inheritance(decisions)
+      previous_value = @inherited
       @inherited = true
       self.class.restore(decisions, self)
-      @inherited = false
+      @inherited = previous_value
       self
     end
 

--- a/spec/lib/license_finder/decisions_spec.rb
+++ b/spec/lib/license_finder/decisions_spec.rb
@@ -304,9 +304,9 @@ module LicenseFinder
       it 'inherits rules from nested remote decisions files with new config format' do
         grandparent_yml = YAML.dump([[:permit, 'GPL']])
         parent_yml = YAML.dump([
-          [:inherit_from, { 'url' => 'https://example.com/config/grandparent.yml' }],
-          [:permit, 'MIT']
-        ])
+                                 [:inherit_from, { 'url' => 'https://example.com/config/grandparent.yml' }],
+                                 [:permit, 'MIT']
+                               ])
 
         stub_request(:get, 'https://example.com/config/grandparent.yml').to_return(status: 200, body: grandparent_yml, headers: {})
         stub_request(:get, 'https://example.com/config/parent.yml').to_return(status: 200, body: parent_yml, headers: {})
@@ -563,9 +563,9 @@ module LicenseFinder
       it 'does not store decisions from inheritance when there is nested inheritance' do
         grandparent_yml = YAML.dump([[:permit, 'GPL']])
         parent_yml = YAML.dump([
-          [:inherit_from, { 'url' => 'https://example.com/config/grandparent.yml' }],
-          [:permit, 'MIT']
-        ])
+                                 [:inherit_from, { 'url' => 'https://example.com/config/grandparent.yml' }],
+                                 [:permit, 'MIT']
+                               ])
 
         stub_request(:get, 'https://example.com/config/grandparent.yml').to_return(status: 200, body: grandparent_yml, headers: {})
         stub_request(:get, 'https://example.com/config/parent.yml').to_return(status: 200, body: parent_yml, headers: {})


### PR DESCRIPTION
## Fixed

* Don't write decisions from the Parent to the Child when there is nested inheritance (i.e. Child inherits from Parent which inherits from Grandparent)