### PR TITLE
npm packages: do not crash if an array is given for author

### DIFF
--- a/lib/license_finder/packages/npm_package.rb
+++ b/lib/license_finder/packages/npm_package.rb
@@ -80,16 +80,22 @@ module LicenseFinder
 
     def author_names
       names = []
-      names.push(author_name(@json['author'])) unless @json['author'].nil?
+      if @json['author'].is_a?(Array)
+        # "author":["foo","bar"] isn't valid according to the NPM package.json schema, but can be found in the wild.
+        names += @json['author'].map { |a| author_name(a) }
+      else
+        names << author_name(@json['author']) unless @json['author'].nil?
+      end
       names += @json['contributors'].map { |c| author_name(c) } if @json['contributors'].is_a?(Array)
-      names.join(', ')
+      names.compact.join(', ')
+    rescue TypeError
+      puts "Warning: Invalid author and/or contributors metadata found in package.json for #{@identifier}"
+      nil
     end
 
     def author_name(author)
       if author.instance_of?(String)
         author_name_from_combined(author)
-      elsif author.instance_of?(Array)
-        author.join(', ')
       else
         author['name']
       end

--- a/lib/license_finder/packages/npm_package.rb
+++ b/lib/license_finder/packages/npm_package.rb
@@ -88,6 +88,8 @@ module LicenseFinder
     def author_name(author)
       if author.instance_of?(String)
         author_name_from_combined(author)
+      elsif author.instance_of?(Array)
+        author.join(', ')
       else
         author['name']
       end


### PR DESCRIPTION
I encountered a crash 
```
lib/license_finder/packages/npm_package.rb:92:in `author_name': no implicit conversion of String into Integer (TypeError)
```
which was caused by author being an array instead of string or dictionary in the following package.json:
https://github.com/romulomachado/ember-cli-string-helpers/blob/master/package.json#L55-L59

This PR makes sure we do not crash on such cases.