### PR TITLE
Maven: skip the nil elements that occur when the dependencies section is empty

### DIFF
--- a/lib/license_finder/package_utils/maven_dependency_finder.rb
+++ b/lib/license_finder/package_utils/maven_dependency_finder.rb
@@ -17,6 +17,7 @@ module LicenseFinder
         .glob(@project_path.join('**', 'target', 'generated-resources', 'licenses.xml'))
         .map(&:read)
         .flat_map { |xml| XmlSimple.xml_in(xml, options)['dependencies'] }
+        .reject(&:empty?)
         .each { |dep| add_info_from_m2(dep) }
     end
 


### PR DESCRIPTION
Follow-up fix for empty `dependencies` #907.
