### PR TITLE
Support NPM 7 and later and upgrade NodeJS in the Docker image from 14 to 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@ RUN apt -q update && apt install -y \
 RUN add-apt-repository ppa:git-core/ppa && \
     apt -q update && apt install -y git && rm -rf /var/lib/apt/lists/*
 
-# nodejs seems to be required for the one of the gems
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+# install nodejs
+RUN curl -sL https://deb.nodesource.com/setup_17.x | bash - && \
     apt -q update && apt install -y nodejs && rm -rf /var/lib/apt/lists/*
 
 # install yarn

--- a/features/features/package_managers/npm_spec.rb
+++ b/features/features/package_managers/npm_spec.rb
@@ -12,5 +12,6 @@ describe 'NPM Dependencies' do
     LicenseFinder::TestingDSL::NpmProject.create
     node_developer.run_license_finder
     expect(node_developer).to be_seeing_line 'http-server, 0.11.1, MIT'
+    expect(node_developer).to be_seeing_line 'entities, 4.4.0, "Simplified BSD"'
   end
 end

--- a/features/support/testing_dsl.rb
+++ b/features/support/testing_dsl.rb
@@ -178,7 +178,7 @@ module LicenseFinder
 
     class NpmProject < Project
       def add_dep
-        add_to_file('package.json', '{"dependencies" : {"http-server": "0.11.1"}}')
+        add_to_file('package.json', '{"dependencies" : {"http-server": "0.11.1", "entities": "4.4.0"}}')
       end
 
       def install

--- a/lib/license_finder/package_managers/npm.rb
+++ b/lib/license_finder/package_managers/npm.rb
@@ -39,7 +39,7 @@ module LicenseFinder
     private
 
     def npm_json
-      command = "#{package_management_command} list --json --long#{production_flag}"
+      command = "#{package_management_command} list --json --long#{all_flag}#{production_flag}"
       command += " #{@npm_options}" unless @npm_options.nil?
       stdout, stderr, status = Dir.chdir(project_path) { Cmd.run(command) }
       # we can try and continue if we got an exit status 1 - unmet peer dependency
@@ -52,6 +52,19 @@ module LicenseFinder
       return '' if @ignored_groups.nil?
 
       @ignored_groups.include?('devDependencies') ? ' --production' : ''
+    end
+
+    def all_flag
+      npm_version >= 7 ? ' --all' : ''
+    end
+
+    def npm_version
+      command = "#{package_management_command} -v"
+      stdout, stderr, status = Dir.chdir(project_path) { Cmd.run(command) }
+      raise "Command '#{command}' failed to execute: #{stderr}" unless status.success?
+
+      version = stdout.split('.').map(&:to_i)
+      version[0]
     end
   end
 end


### PR DESCRIPTION
Address #916:
* Update NodeJS to version 17 (the last one supported on Ubuntu 18.04 - once you upgrade to 22.04 we can bump this to 18 to be on an LTS version again)
* Add support for the `--all` flag that is needed to list transitive dependencies on NPM version 7 and later