### PR TITLE
Use Ubuntu 22.04 (Jammy) for Docker image

### DIFF
--- a/features/features/package_managers/dep_spec.rb
+++ b/features/features/package_managers/dep_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../support/feature_helper'
 
-describe 'Dep Dependencies' do
+xdescribe 'Dep Dependencies' do
   let(:go_developer) { LicenseFinder::TestingDSL::User.new }
 
   specify 'are shown in reports for a project' do

--- a/lib/license_finder/package_managers/pip.rb
+++ b/lib/license_finder/package_managers/pip.rb
@@ -4,7 +4,7 @@ require 'json'
 
 module LicenseFinder
   class Pip < PackageManager
-    DEFAULT_VERSION = '2'
+    DEFAULT_VERSION = '3'
 
     def initialize(options = {})
       super

--- a/lib/license_finder/scanner.rb
+++ b/lib/license_finder/scanner.rb
@@ -3,7 +3,7 @@
 module LicenseFinder
   class Scanner
     PACKAGE_MANAGERS = [
-      GoModules, GoDep, GoWorkspace, Go15VendorExperiment, Glide, Gvt, Govendor, Trash, Dep, Bundler, NPM, PNPM, Pip,
+      GoModules, GoDep, GoWorkspace, Go15VendorExperiment, Glide, Gvt, Govendor, Trash, Bundler, NPM, PNPM, Pip,
       Yarn, Bower, Maven, Gradle, CocoaPods, Rebar, Erlangmk, Nuget, Carthage, Mix, Conan, Sbt, Cargo, Dotnet, Composer, Pipenv,
       Conda, Spm, Pub
     ].freeze


### PR DESCRIPTION
@xtreme-shane-lattanzio FYI, not sure if all the tests will pass.

Update:
* Python2 is no longer available. Do we need it? I changed the default in the code to use "3" and that seems to make the tests pass.
* The Go tool `dep` is deprecated since 2020 and not available on Jammy. See also https://github.com/golang/dep#dep. Do we need it?


Somewhat related:
In general, it might be worth considering not to build one gigantic Docker image that has all possible package managers and supporting tools and frameworks in it, but rather make LicenseFinder itself use smaller Docker images to perform the scans.
This way, it could use the most up-to-date, unmodified upstream images (e.g. https://hub.docker.com/_/maven, https://hub.docker.com/_/python, etc.) or even ancient ones with legacy software. Further, LicenseFinder users would only have to pull (or wait for LF to pull) the Docker images they actually need.

