### PR TITLE
Support of Conan v1.6 and v2

### DIFF
--- a/lib/license_finder/package_managers/conan.rb
+++ b/lib/license_finder/package_managers/conan.rb
@@ -25,6 +25,7 @@ module LicenseFinder
       info_command = 'conan info .'
       info_output, _stderr, _status = Dir.chdir(project_path) { Cmd.run(info_command) }
       return nil if info_output.empty?
+
       info_parser = ConanInfoParser.new
       info_parser.parse(info_output)
     end
@@ -34,6 +35,7 @@ module LicenseFinder
       info_output, stderr, _status = Dir.chdir(project_path) { Cmd.run(info_command) }
       if info_output.empty?
         return if stderr.empty?
+
         info_output = stderr
       end
       info_parser = ConanInfoParserV2.new
@@ -42,9 +44,7 @@ module LicenseFinder
 
     def deps_list(project_path)
       deps = deps_list_conan_v1(project_path)
-      if deps.nil? || deps.empty?
-        deps = deps_list_conan_v2(project_path)
-      end
+      deps = deps_list_conan_v2(project_path) if deps.nil? || deps.empty?
       deps
     end
 
@@ -53,9 +53,7 @@ module LicenseFinder
       Dir.chdir(project_path) { Cmd.run(install_command) }
 
       deps = deps_list(project_path)
-      if deps.nil?
-        return []
-      end
+      return [] if deps.nil?
 
       deps.map do |dep|
         name, version = dep['name'].split('/')

--- a/lib/license_finder/package_managers/conan.rb
+++ b/lib/license_finder/package_managers/conan.rb
@@ -62,6 +62,7 @@ module LicenseFinder
         next unless license_file_is_good?(license_file_path)
 
         url = dep['homepage']
+        url = dep['url'] if url.nil?
         ConanPackage.new(name, version, File.open(license_file_path).read, url)
       end.compact
     end

--- a/lib/license_finder/package_utils/conan_info_parser_v2.rb
+++ b/lib/license_finder/package_utils/conan_info_parser_v2.rb
@@ -11,9 +11,7 @@ module LicenseFinder
       @current_key = nil # current key to be associated with the current val
 
       line = @lines.shift
-      while line != '======== Basic graph information ========'
-        line = @lines.shift
-      end
+      line = @lines.shift while line != '======== Basic graph information ========'
 
       while (line = @lines.shift)
         next if line == ''
@@ -21,7 +19,7 @@ module LicenseFinder
         case @state
         when :project_level
           @current_project = {}
-          name, _ = line.strip.split('#')
+          name, _id = line.strip.split('#')
           @current_project['name'] = name
           @state = :key_val
         when :key_val

--- a/spec/lib/license_finder/package_managers/conan_info_parser_spec.rb
+++ b/spec/lib/license_finder/package_managers/conan_info_parser_spec.rb
@@ -9,55 +9,55 @@ module LicenseFinder
       [
         {
           'name' => 'conanfile.txt',
-          'ID' => '4c3dfe99a9c2d5003148e0054b9bacf58ac69f66',
-          'BuildID' => 'None',
-          'Requires' => ['Poco/1.7.9@pocoproject/stable', 'OpenSSL/1.0.2l@conan/stable', 'range-v3/0.3.0@ericniebler/stable']
+          'id' => '4c3dfe99a9c2d5003148e0054b9bacf58ac69f66',
+          'buildid' => 'None',
+          'requires' => ['Poco/1.7.9@pocoproject/stable', 'OpenSSL/1.0.2l@conan/stable', 'range-v3/0.3.0@ericniebler/stable']
         },
         {
           'name' => 'OpenSSL/1.0.2l@conan/stable',
-          'ID' => '0197c20e330042c026560da838f5b4c4bf094b8a',
-          'BuildID' => 'None',
-          'Remote' => 'conan-center=https://center.conan.io',
-          'URL' => 'http://github.com/lasote/conan-openssl',
-          'License' => 'The current OpenSSL licence is an \'Apache style\' license: https://www.openssl.org/source/license.html',
-          'Updates' => 'Version not checked',
-          'Creation date' => '2017-08-21 10:28:57',
-          'Required by' => ['Poco/1.7.9@pocoproject/stable', 'conanfile.txt'],
-          'Requires' => ['zlib/1.2.11@conan/stable']
+          'id' => '0197c20e330042c026560da838f5b4c4bf094b8a',
+          'buildid' => 'None',
+          'remote' => 'conan-center=https://center.conan.io',
+          'url' => 'http://github.com/lasote/conan-openssl',
+          'license' => 'The current OpenSSL licence is an \'Apache style\' license: https://www.openssl.org/source/license.html',
+          'updates' => 'Version not checked',
+          'creation date' => '2017-08-21 10:28:57',
+          'required by' => ['Poco/1.7.9@pocoproject/stable', 'conanfile.txt'],
+          'requires' => ['zlib/1.2.11@conan/stable']
         },
         {
           'name' => 'Poco/1.7.9@pocoproject/stable',
-          'ID' => '33fe7ea34efc04fb6d81fabd9e34f51da57f9e09',
-          'BuildID' => 'None',
-          'Remote' => 'conan-center=https://center.conan.io',
-          'URL' => 'http://github.com/lasote/conan-poco',
-          'License' => 'The Boost Software License 1.0',
-          'Updates' => 'Version not checked',
-          'Creation date' => '2017-09-20 16:51:10',
-          'Required by' => ['conanfile.txt'],
-          'Requires' => ['OpenSSL/1.0.2l@conan/stable']
+          'id' => '33fe7ea34efc04fb6d81fabd9e34f51da57f9e09',
+          'buildid' => 'None',
+          'remote' => 'conan-center=https://center.conan.io',
+          'url' => 'http://github.com/lasote/conan-poco',
+          'license' => 'The Boost Software License 1.0',
+          'updates' => 'Version not checked',
+          'creation date' => '2017-09-20 16:51:10',
+          'required by' => ['conanfile.txt'],
+          'requires' => ['OpenSSL/1.0.2l@conan/stable']
         },
         {
           'name' => 'range-v3/0.3.0@ericniebler/stable',
-          'ID' => '5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9',
-          'BuildID' => 'None',
-          'Remote' => 'conan-center=https://center.conan.io',
-          'URL' => 'https://github.com/ericniebler/range-v3',
-          'License' => 'Boost Software License - Version 1.0 - August 17th, 2003',
-          'Updates' => 'Version not checked',
-          'Creation date' => '2017-06-30 13:20:56',
-          'Required by' => ['conanfile.txt']
+          'id' => '5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9',
+          'buildid' => 'None',
+          'remote' => 'conan-center=https://center.conan.io',
+          'url' => 'https://github.com/ericniebler/range-v3',
+          'license' => 'Boost Software License - Version 1.0 - August 17th, 2003',
+          'updates' => 'Version not checked',
+          'creation date' => '2017-06-30 13:20:56',
+          'required by' => ['conanfile.txt']
         },
         {
           'name' => 'zlib/1.2.11@conan/stable',
-          'ID' => '09512ff863f37e98ed748eadd9c6df3e4ea424a8',
-          'BuildID' => 'None',
-          'Remote' => 'conan-center=https://center.conan.io',
-          'URL' => 'http://github.com/lasote/conan-zlib',
-          'License' => 'http://www.zlib.net/zlib_license.html',
-          'Updates' => 'Version not checked',
-          'Creation date' => '2017-09-25 14:42:53',
-          'Required by' => ['OpenSSL/1.0.2l@conan/stable']
+          'id' => '09512ff863f37e98ed748eadd9c6df3e4ea424a8',
+          'buildid' => 'None',
+          'remote' => 'conan-center=https://center.conan.io',
+          'url' => 'http://github.com/lasote/conan-zlib',
+          'license' => 'http://www.zlib.net/zlib_license.html',
+          'updates' => 'Version not checked',
+          'creation date' => '2017-09-25 14:42:53',
+          'required by' => ['OpenSSL/1.0.2l@conan/stable']
         }
       ]
     end


### PR DESCRIPTION
## Motivation
Conan 1.6 extracts licenses to different path than expected which causes License Finder to crash.

### Reason
File mask that is used to search licenses looks as follows:

`#{project_path}/licenses/#{name}/**/LICENSE*`

Conan 1.6 creates license files under `#{project_path}/licenses/#{name}/licenses/LICENSE*` and first file that suites is directory

### Solution

Iterate over the files that suite mentioned above mask until we find not directory
