### PR TITLE
Use Maven 3.6.3 instead of 3.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /tmp
 # Versioning
 ENV PIP3_INSTALL_VERSION 20.0.2
 ENV GO_LANG_VERSION 1.17.13
-ENV MAVEN_VERSION 3.6.0
 ENV SBT_VERSION 1.3.3
 ENV GRADLE_VERSION 5.6.4
 ENV RUBY_VERSION 3.2.2
@@ -64,10 +63,8 @@ RUN apt -q update && apt install -y python3-pip && \
     python3 -m pip install pip==$PIP3_INSTALL_VERSION --upgrade
 
 # install maven
-RUN curl -O https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz && \
-    tar -xf apache-maven-$MAVEN_VERSION-bin.tar.gz; rm -rf apache-maven-$MAVEN_VERSION-bin.tar.gz && \
-    mv apache-maven-$MAVEN_VERSION /usr/local/lib/maven && \
-    ln -s /usr/local/lib/maven/bin/mvn /usr/local/bin/mvn
+RUN apt -q update && apt install -y maven && \
+    rm -rf /var/lib/apt/lists/*
 
 # install sbt
 RUN mkdir -p /usr/local/share/sbt-launcher-packaging && \


### PR DESCRIPTION
Use Maven 3.6.3 instead of 3.6.0 which now throws an error when we run
```
mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout
```

Error:
> [ERROR] Failed to execute goal org.apache.maven.plugins:maven-help-plugin:3.4.0:evaluate (default-cli) on project IVION: The plugin org.apache.maven.plugins:maven-help-plugin:3.4.0 requires Maven version 3.6.3.

I suspect it's downloading the `maven-help-plugin` as needed, and it seems like it's downloading one that is incompatible.