### PR TITLE
Maven jakarta classifier

### DIFF
--- a/features/features/package_managers/maven_spec.rb
+++ b/features/features/package_managers/maven_spec.rb
@@ -39,6 +39,14 @@ describe 'Maven Dependencies' do
     expect(java_developer).to be_seeing_once 'This product includes software developed at' # NOTICE
   end
 
+  it 'extracts name for a package that is using the "jakarta" classifier' do
+    LicenseFinder::TestingDSL::MavenProject.create
+    java_developer.execute_command 'license_finder report --columns summary description homepage texts notice --format=csv'
+
+    # the JAR file is named like "querydsl-jpa-5.0.0-jakarta.jar"
+    expect(java_developer).to be_seeing_once 'Querydsl - JPA support'
+  end
+
   it 'handles an empty dependencies section gracefully' do
     LicenseFinder::TestingDSL::MavenProjectNoDeps.create
     java_developer.run_license_finder

--- a/features/fixtures/pom.xml
+++ b/features/fixtures/pom.xml
@@ -20,5 +20,11 @@
       <artifactId>commons-lang3</artifactId>
       <version>3.12.0</version>
     </dependency>
+	<dependency>
+      <groupId>com.querydsl</groupId>
+      <artifactId>querydsl-jpa</artifactId>
+      <version>5.0.0</version>
+      <classifier>jakarta</classifier>
+    </dependency>
   </dependencies>
 </project>

--- a/lib/license_finder/package_utils/maven_dependency_finder.rb
+++ b/lib/license_finder/package_utils/maven_dependency_finder.rb
@@ -30,7 +30,12 @@ module LicenseFinder
         .join(dep['version'])
       artifact_basename = "#{dep['artifactId']}-#{dep['version']}"
 
-      dep.store('jarFile', m2_artifact_dir.join("#{artifact_basename}.jar"))
+      # Basic support for Maven classifiers. So far, only "jakarta" is supported. Unfortunately,
+      # we do not have access to the "classifier" field here (licenses.xml does not have it).
+      jar_file = m2_artifact_dir.join("#{artifact_basename}.jar")
+      jar_file = m2_artifact_dir.join("#{artifact_basename}-jakarta.jar") unless File.exist?(jar_file)
+
+      dep.store('jarFile', jar_file)
 
       add_info_from_pom(m2_artifact_dir.join("#{artifact_basename}.pom"), dep)
     end


### PR DESCRIPTION
For a dependency that includes a `classifier` like this:
```xml
<dependency>
      <groupId>com.querydsl</groupId>
      <artifactId>querydsl-jpa</artifactId>
      <version>5.0.0</version>
      <classifier>jakarta</classifier>
</dependency>
```

We crash:
```
/usr/share/rvm/gems/ruby-3.2.2/gems/rubyzip-2.3.2/lib/zip/file.rb:106:in `initialize': File /root/.m2/repository/com/querydsl/querydsl-jpa/5.0.0/querydsl-jpa-5.0.0.jar not found (Zip::Error)
	from /usr/share/rvm/gems/ruby-3.2.2/gems/rubyzip-2.3.2/lib/zip/file.rb:121:in `new'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/rubyzip-2.3.2/lib/zip/file.rb:121:in `open'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/license_finder-7.1.0/lib/license_finder/package_utils/license_files.rb:46:in `candidates_from_zip'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/license_finder-7.1.0/lib/license_finder/package_utils/license_files.rb:41:in `candidate_files_and_dirs'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/license_finder-7.1.0/lib/license_finder/package_utils/license_files.rb:29:in `paths_of_candidate_files'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/license_finder-7.1.0/lib/license_finder/package_utils/license_files.rb:19:in `find'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/license_finder-7.1.0/lib/license_finder/package_utils/license_files.rb:11:in `find'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/license_finder-7.1.0/lib/license_finder/packages/maven_package.rb:32:in `license_files'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/license_finder-7.1.0/lib/license_finder/package.rb:130:in `licensing'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/license_finder-7.1.0/lib/license_finder/package.rb:124:in `activations'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/license_finder-7.1.0/lib/license_finder/package.rb:120:in `licenses'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/license_finder-7.1.0/lib/license_finder/decision_applier.rb:60:in `with_approval'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/license_finder-7.1.0/lib/license_finder/decision_applier.rb:34:in `block in apply_decisions'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/license_finder-7.1.0/lib/license_finder/decision_applier.rb:32:in `map'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/license_finder-7.1.0/lib/license_finder/decision_applier.rb:32:in `apply_decisions'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/license_finder-7.1.0/lib/license_finder/decision_applier.rb:8:in `initialize'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/license_finder-7.1.0/lib/license_finder/core.rb:79:in `new'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/license_finder-7.1.0/lib/license_finder/core.rb:79:in `decision_applier'
	from /usr/share/rvm/rubies/ruby-3.2.2/lib/ruby/3.2.0/forwardable.rb:234:in `acknowledged'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/license_finder-7.1.0/lib/license_finder/license_aggregator.rb:51:in `block in aggregate_packages'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/license_finder-7.1.0/lib/license_finder/license_aggregator.rb:49:in `each'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/license_finder-7.1.0/lib/license_finder/license_aggregator.rb:49:in `flat_map'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/license_finder-7.1.0/lib/license_finder/license_aggregator.rb:49:in `aggregate_packages'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/license_finder-7.1.0/lib/license_finder/license_aggregator.rb:11:in `dependencies'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/license_finder-7.1.0/lib/license_finder/cli/main.rb:161:in `report'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/thor-1.2.2/lib/thor/command.rb:27:in `run'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/thor-1.2.2/lib/thor/invocation.rb:127:in `invoke_command'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/thor-1.2.2/lib/thor.rb:392:in `dispatch'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/thor-1.2.2/lib/thor/base.rb:485:in `start'
	from /usr/share/rvm/gems/ruby-3.2.2/gems/license_finder-7.1.0/bin/license_finder:6:in `<top (required)>'
	from /usr/share/rvm/gems/ruby-3.2.2/bin/license_finder:25:in `load'
	from /usr/share/rvm/gems/ruby-3.2.2/bin/license_finder:25:in `<main>'
	from /usr/share/rvm/gems/ruby-3.2.2/bin/ruby_executable_hooks:22:in `eval'
	from /usr/share/rvm/gems/ruby-3.2.2/bin/ruby_executable_hooks:22:in `<main>'
```

This PR is an attempt to fix this issue, at least for when the classifier is `jakarta`.