### PR TITLE
SPM: Fix a crash with PDF files

### DIFF
--- a/lib/license_finder/package_managers/spm.rb
+++ b/lib/license_finder/package_managers/spm.rb
@@ -83,7 +83,7 @@ module LicenseFinder
 
     def license_pattern(subpath)
       checkout_path = project_checkout(subpath)
-      Dir.glob(checkout_path.join('LICENSE*'), File::FNM_CASEFOLD)
+      Dir.glob(checkout_path.join('LICENSE.*(?<!\.pdf)$'), File::FNM_CASEFOLD)
     end
 
     def name_version_from_line(cartfile_line)


### PR DESCRIPTION
Whenever the PDF file contains phrase "LICENSE" exists in package repository license_finder crashes

```
LicenseFinder::Bundler: is active
LicenseFinder::Spm: is active
Traceback (most recent call last):
	32: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/bin/ruby_executable_hooks:22:in `<main>'
	31: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/bin/ruby_executable_hooks:22:in `eval'
	30: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/bin/license_finder:23:in `<main>'
	29: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/bin/license_finder:23:in `load'
	28: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/license_finder-7.1.0/bin/license_finder:6:in `<top (required)>'
	27: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/thor-1.2.2/lib/thor/base.rb:485:in `start'
	26: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/thor-1.2.2/lib/thor.rb:392:in `dispatch'
	25: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/thor-1.2.2/lib/thor/invocation.rb:127:in `invoke_command'
	24: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/thor-1.2.2/lib/thor/command.rb:27:in `run'
	23: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/license_finder-7.1.0/lib/license_finder/cli/main.rb:161:in `report'
	22: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/license_finder-7.1.0/lib/license_finder/license_aggregator.rb:11:in `dependencies'
	21: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/license_finder-7.1.0/lib/license_finder/license_aggregator.rb:49:in `aggregate_packages'
	20: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/license_finder-7.1.0/lib/license_finder/license_aggregator.rb:49:in `flat_map'
	19: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/license_finder-7.1.0/lib/license_finder/license_aggregator.rb:49:in `each'
	18: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/license_finder-7.1.0/lib/license_finder/license_aggregator.rb:51:in `block in aggregate_packages'
	17: from /Users/dzwoneke/.rvm/rubies/ruby-2.7.2/lib/ruby/2.7.0/forwardable.rb:229:in `acknowledged'
	16: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/license_finder-7.1.0/lib/license_finder/core.rb:79:in `decision_applier'
	15: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/license_finder-7.1.0/lib/license_finder/core.rb:84:in `current_packages'
	14: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/license_finder-7.1.0/lib/license_finder/scanner.rb:42:in `active_packages'
	13: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/license_finder-7.1.0/lib/license_finder/scanner.rb:42:in `flat_map'
	12: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/license_finder-7.1.0/lib/license_finder/scanner.rb:42:in `each'
	11: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/license_finder-7.1.0/lib/license_finder/package_manager.rb:105:in `current_packages_with_relations'
	10: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/license_finder-7.1.0/lib/license_finder/package_managers/spm.rb:16:in `current_packages'
	 9: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/license_finder-7.1.0/lib/license_finder/package_managers/spm.rb:16:in `map'
	 8: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/license_finder-7.1.0/lib/license_finder/package_managers/spm.rb:25:in `block in current_packages'
	 7: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/license_finder-7.1.0/lib/license_finder/package_managers/spm.rb:25:in `new'
	 6: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/license_finder-7.1.0/lib/license_finder/packages/spm_package.rb:7:in `initialize'
	 5: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/license_finder-7.1.0/lib/license_finder/license.rb:36:in `find_by_text'
	 4: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/license_finder-7.1.0/lib/license_finder/license.rb:36:in `detect'
	 3: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/license_finder-7.1.0/lib/license_finder/license.rb:36:in `each'
	 2: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/license_finder-7.1.0/lib/license_finder/license.rb:36:in `block in find_by_text'
	 1: from /Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/license_finder-7.1.0/lib/license_finder/license.rb:68:in `matches_text?'
/Users/dzwoneke/.rvm/gems/ruby-2.7.2/gems/license_finder-7.1.0/lib/license_finder/license/matcher.rb:20:in `matches_text?': invalid byte sequence in UTF-8 (ArgumentError)
```

Such a repository is for example https://github.com/comScore/ComScore-iOS-watchOS-tvOS containing LicenseAgreement.pdf file

This PR introduces a REGEX pattern that ensures that PDF files aren't taken into consideration