### PR TITLE
fix: docker node install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ENV SBT_VERSION 1.3.3
 ENV GRADLE_VERSION 5.6.4
 ENV RUBY_VERSION 3.2.2
 ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV NODE_MAJOR=18
 
 # programs needed for building
 RUN apt -q update && apt install -y \
@@ -27,8 +28,10 @@ RUN add-apt-repository ppa:git-core/ppa && \
     apt -q update && apt install -y git && rm -rf /var/lib/apt/lists/*
 
 # install nodejs
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
-    apt -q update && apt install -y nodejs && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    apt -q update && apt install -y nodejs
 
 # install yarn
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \


### PR DESCRIPTION
Fixes an issue whereby the available version of Node is 14 even though [18 install is implied](https://github.com/pivotal/LicenseFinder/blob/46ae9f6428e403a2a2392bfbfb7a595029d270db/Dockerfile#L30).

![image](https://github.com/pivotal/LicenseFinder/assets/17315774/6152c46d-a8fd-4f3d-ad07-1e9d0dbe07e2)

After reviewing the notes at the top of the [nodesource/distributions README](https://github.com/nodesource/distributions/tree/a19918c9fb851fc036bc8e7bd1ade59868b891ae#new-update-%EF%B8%8F), it is clear that the setup script-based install is no longer supported.

Switch to the new recommended install method and verify that the installed version of node is actually 18.

![image](https://github.com/pivotal/LicenseFinder/assets/17315774/c6cdcdd7-1adb-4581-ad49-ea14f2008c24)
