### PR TITLE
Speed up Cargo license finder

### DIFF
--- a/lib/license_finder/package_managers/cargo.rb
+++ b/lib/license_finder/package_managers/cargo.rb
@@ -6,7 +6,7 @@ module LicenseFinder
   class Cargo < PackageManager
     def current_packages
       cargo_output.map do |package|
-        path = Dir.glob("#{Dir.home}/.cargo/registry/src/**/#{package['name']}-#{package['version']}").first
+        path = Dir.glob("#{Dir.home}/.cargo/registry/src/*/#{package['name']}-#{package['version']}").first
         CargoPackage.new(package, logger: logger, install_path: path)
       end
     end


### PR DESCRIPTION
The current implementation uses a recursive `**` glob, which is very slow on our application. `time ls ~/.cargo/registry/src/**/ahash-0.8.6` for example takes 1.8 seconds for a single package.

Changing it to use `*` improves `bundle exec license_finder` runtime from several minutes (at least) to 28 seconds.

I don't think the `**` was needed: the path includes a folder for every Cargo registry, immediately followed by a folder for each crate.