### PR TITLE
fix: For Ruby 3.3 compatibility, specify racc dependency in gemspec

### DIFF
--- a/license_finder.gemspec
+++ b/license_finder.gemspec
@@ -49,6 +49,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'tomlrb', '>= 1.3', '< 2.1'
   s.add_dependency 'with_env', '1.1.0'
   s.add_dependency 'xml-simple', '~> 1.1.9'
+  s.add_dependency 'racc'
 
   s.add_development_dependency 'addressable', '2.8.4'
   s.add_development_dependency 'capybara', '~> 3.36.0'


### PR DESCRIPTION
This PR adds racc to the gemspec, because [Ruby 3.3 changes](https://bugs.ruby-lang.org/issues/19702) mean that without it we get:

```
~/test (+main) $ cat Gemfile 
# frozen_string_literal: true

source "https://rubygems.org"
~/test (+main) $ license_finder
<internal:/opt/homebrew/Cellar/ruby/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require': cannot load such file -- racc/parser.rb (LoadError)
	from <internal:/opt/homebrew/Cellar/ruby/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
	from /opt/homebrew/lib/ruby/gems/3.3.0/gems/tomlrb-2.0.3/lib/tomlrb/generated_parser.rb:7:in `<top (required)>'
	from <internal:/opt/homebrew/Cellar/ruby/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
	from <internal:/opt/homebrew/Cellar/ruby/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
	from /opt/homebrew/lib/ruby/gems/3.3.0/gems/tomlrb-2.0.3/lib/tomlrb/parser.rb:1:in `<top (required)>'
	from <internal:/opt/homebrew/Cellar/ruby/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
	from <internal:/opt/homebrew/Cellar/ruby/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
	from /opt/homebrew/lib/ruby/gems/3.3.0/gems/tomlrb-2.0.3/lib/tomlrb.rb:9:in `<top (required)>'
	from <internal:/opt/homebrew/Cellar/ruby/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
	from <internal:/opt/homebrew/Cellar/ruby/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
	from /opt/homebrew/lib/ruby/gems/3.3.0/gems/license_finder-7.1.0/lib/license_finder/package_managers/dep.rb:3:in `<top (required)>'
	from <internal:/opt/homebrew/Cellar/ruby/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
	from <internal:/opt/homebrew/Cellar/ruby/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
	from /opt/homebrew/lib/ruby/gems/3.3.0/gems/license_finder-7.1.0/lib/license_finder/package_manager.rb:175:in `<top (required)>'
	from <internal:/opt/homebrew/Cellar/ruby/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
	from <internal:/opt/homebrew/Cellar/ruby/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
	from /opt/homebrew/lib/ruby/gems/3.3.0/gems/license_finder-7.1.0/lib/license_finder/core.rb:9:in `<top (required)>'
	from <internal:/opt/homebrew/Cellar/ruby/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
	from <internal:/opt/homebrew/Cellar/ruby/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
	from /opt/homebrew/lib/ruby/gems/3.3.0/gems/license_finder-7.1.0/lib/license_finder.rb:13:in `<top (required)>'
	from <internal:/opt/homebrew/Cellar/ruby/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
	from <internal:/opt/homebrew/Cellar/ruby/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
	from /opt/homebrew/lib/ruby/gems/3.3.0/gems/license_finder-7.1.0/bin/license_finder:4:in `<top (required)>'
	from /opt/homebrew/lib/ruby/gems/3.3.0/bin/license_finder:25:in `load'
	from /opt/homebrew/lib/ruby/gems/3.3.0/bin/license_finder:25:in `<main>'
~/test (+main) $ 
```

@pivotal-cla This is an Obvious Fix