### PR TITLE
CSV no longer part of the stdlib

### DIFF
--- a/license_finder.gemspec
+++ b/license_finder.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency 'bundler'
+  s.add_dependency 'csv'
   s.add_dependency 'rubyzip', '>=1', '<3'
   s.add_dependency 'thor', '~> 1.2'
   s.add_dependency 'tomlrb', '>= 1.3', '< 2.1'


### PR DESCRIPTION
On Ruby 3.3 the following warning is emitted:

```
/usr/local/bundle/ruby/3.3.0/gems/license_finder-7.1.0/lib/license_finder/package_managers/sbt.rb:3: warning: csv was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of license_finder-7.1.0 to add csv into its gemspec.
```

As of Ruby 3.4 license_finder would cease to work without this explicit dependency.

See also https://github.com/pivotal/LicenseFinder/pull/1014