### PR TITLE
[Fixed] Print subproject paths when logging

### DIFF
--- a/lib/license_finder/core.rb
+++ b/lib/license_finder/core.rb
@@ -61,9 +61,9 @@ module LicenseFinder
       clear_logs
       package_managers = @scanner.active_package_managers
       package_managers.each do |manager|
-        logger.debug manager.class, 'Running prepare on project'
+        logger.debug manager.class, "Running prepare on project '#{config.project_path}'"
         manager.prepare
-        logger.debug manager.class, 'Finished prepare on project', color: :green
+        logger.debug manager.class, "Finished prepare on project '#{config.project_path}'", color: :green
       end
     end
 

--- a/lib/license_finder/scanner.rb
+++ b/lib/license_finder/scanner.rb
@@ -50,10 +50,10 @@ module LicenseFinder
         active = pm_class.new(@config).active?
 
         if active
-          @logger.info pm_class, 'is active', color: :green
+          @logger.info pm_class, "is active for '#{@project_path}'", color: :green
           active_pm_classes << pm_class
         else
-          @logger.debug pm_class, 'is not active', color: :red
+          @logger.debug pm_class, "is not active for '#{@project_path}'", color: :red
         end
       end
 

--- a/spec/lib/license_finder/scanner_spec.rb
+++ b/spec/lib/license_finder/scanner_spec.rb
@@ -30,7 +30,7 @@ module LicenseFinder
       context 'when package manager is NOT installed' do
         it 'should log all active packages' do
           allow(bundler).to receive(:command_exists?).and_return false
-          expect(logger).to receive(:info).with(Bundler, 'is active', color: :green)
+          expect(logger).to receive(:info).with(Bundler, 'is active for \'\'', color: :green)
           expect(logger).to receive(:info).with(Bundler, 'is not installed', color: :red)
           expect(subject.active_packages).to_not be_nil
         end
@@ -47,7 +47,7 @@ module LicenseFinder
       it 'should log active states of package managers' do
         bundler = double(:bundler, active?: true)
         allow(Bundler).to receive(:new).and_return bundler
-        expect(logger).to receive(:info).with(Bundler, 'is active', color: :green)
+        expect(logger).to receive(:info).with(Bundler, 'is active for \'\'', color: :green)
 
         subject.active_package_managers
       end
@@ -55,7 +55,7 @@ module LicenseFinder
       it 'should log inactive states of package managers' do
         bundler = double(:bundler, active?: false)
         allow(Bundler).to receive(:new).and_return bundler
-        expect(logger).to receive(:debug).with(Bundler, 'is not active', color: :red)
+        expect(logger).to receive(:debug).with(Bundler, 'is not active for \'\'', color: :red)
 
         subject.active_package_managers
       end


### PR DESCRIPTION
Make it easier to see what's going on when running recursively by printing the sub-project that is currently being analysed.

e.g.
old:
```
Running prepare on project
Finished prepare on project
Running prepare on project
Finished prepare on project
Yarn is active
Yarn is active
```

new:
```
Running prepare on project 'subproj1'
Finished prepare on project 'subproj1'
Running prepare on project 'subproj2'
Finished prepare on project 'subproj2'
Yarn is active for 'subproj1'
Yarn is active for 'subproj2'
```