### PR TITLE
Avoid using OpenStruct where Struct is enough

### DIFF
--- a/spec/lib/license_finder/decisions_spec.rb
+++ b/spec/lib/license_finder/decisions_spec.rb
@@ -418,7 +418,7 @@ module LicenseFinder
       end
 
       it 'inheritates rules from gem decision file' do
-        gem_spec = OpenStruct.new(gem_dir: 'gem-name')
+        gem_spec = Struct.new(:gem_dir).new('gem-name')
         allow(Gem::Specification).to receive(:find_by_name).with('gem-name').and_return(gem_spec)
         allow_any_instance_of(Pathname).to receive(:read).and_return(yml)
 


### PR DESCRIPTION
On PR #1036, I saw a CI failure that is unrelated to its changeset.
https://norsk.cf-app.com/builds/446820782

The error `NameError: uninitialized constant LicenseFinder::OpenStruct` implies that we should explicitly bundle "ostruct" gem, but in this case I'd suggest to simply use Struct instead of OpenStruct.