### PR TITLE
Support new versions of pip

### DIFF
--- a/bin/license_finder_pip.py
+++ b/bin/license_finder_pip.py
@@ -18,7 +18,6 @@ except ImportError:
         from pip.download import PipSession
 
 from pip._vendor import pkg_resources
-from pip._vendor.six import print_
 
 
 reqs = []
@@ -40,4 +39,4 @@ transform = lambda dist: {
 
 
 packages = [transform(dist) for dist in pkg_resources.working_set.resolve(reqs)]
-print_(json.dumps(packages))
+print(json.dumps(packages))


### PR DESCRIPTION
Pip stopped vendoring the six package in May 2024, https://github.com/pypa/pip/commit/692b7f00440ca6e225f94cb665696c20d27bfea9

Fixes: #1046