### PR TITLE
Also supports the name "Python-2.0"

### DIFF
--- a/lib/license_finder/license/definitions.rb
+++ b/lib/license_finder/license/definitions.rb
@@ -399,6 +399,7 @@ module LicenseFinder
             'PSF 2.0',
             'PSFL',
             'Python 2.0',
+            'Python-2.0',
             'PSF License',
             'PSF License 2.0'
           ],


### PR DESCRIPTION
I would also like to see support for the name `Python-2.0`.

This format is used in argparse v2.0.1 (latest).
https://github.com/nodeca/argparse/blob/2.0.1/package.json#L17

I considered submitting a pull request to argparse, but I couldn't figure out why Python-2.0 should be changed to Python 2.0, so I made a pull request to LicenseFinder.
