### PR TITLE
Support latest dependencies output format for conan2

### DIFF
--- a/lib/license_finder/package_managers/conan.rb
+++ b/lib/license_finder/package_managers/conan.rb
@@ -14,7 +14,13 @@ module LicenseFinder
     end
 
     def license_file(project_path, name)
-      candidates = Dir.glob("#{project_path}/licenses/#{name}/**/LICENSE*")
+      lic_file = license_file_by_mask(project_path, name, 'LICENSE*')
+      lic_file = license_file_by_mask(project_path, name, 'copy*') if lic_file.nil?
+      lic_file
+    end
+
+    def license_file_by_mask(project_path, name, file_mask)
+      candidates = Dir.glob("#{project_path}/licenses/#{name}/**/#{file_mask}")
       candidates.each do |candidate|
         return candidate if license_file_is_good?(candidate)
       end

--- a/lib/license_finder/package_utils/conan_info_parser_v2.rb
+++ b/lib/license_finder/package_utils/conan_info_parser_v2.rb
@@ -3,15 +3,12 @@
 module LicenseFinder
   class ConanInfoParserV2
     def parse(info)
-      @lines = info.lines.map(&:chomp)
+      @lines = get_dependencies_lines(info)
       @state = :project_level # state of the state machine
       @projects = [] # list of projects
       @current_project = nil # current project being populated in the SM
       @current_vals = [] # current val list being populate in the SM
       @current_key = nil # current key to be associated with the current val
-
-      line = @lines.shift
-      line = @lines.shift while line != '======== Basic graph information ========'
 
       while (line = @lines.shift)
         next if line == ''
@@ -32,6 +29,20 @@ module LicenseFinder
     end
 
     private
+
+    def get_dependencies_lines(info)
+      lines = info.lines.map(&:chomp)
+      graph_info_start = 'basic graph information'
+      if info.downcase.include?(graph_info_start)
+        loop do
+          line = lines.shift
+          break if lines.empty?
+          next if line.nil?
+          break if line.downcase.include?(graph_info_start)
+        end
+      end
+      lines
+    end
 
     def parse_key_val(line)
       key, val = key_val(line)


### PR DESCRIPTION
## Background
Recently conan2 changed dependencies graph output and writes dependencies list to stdout and additional information to stderr. Before that everything was written to stdout. Because of that there is no "Basic graph information" header in the parsed output and we fail to parse dependencies.

## Solution
Added check if there is a "Basic graph information" header, if no, we are parsing everything from the beginning