### PR TITLE
lazy loading licensing

### DIFF
--- a/lib/license_finder/package.rb
+++ b/lib/license_finder/package.rb
@@ -18,7 +18,7 @@ module LicenseFinder
   #   the constructor options
   # - otherwise, override #licenses_from_spec or #license_files
   class Package
-    attr_reader :logger, :name, :version, :authors, :summary, :description, :children, :parents, :groups, :manual_approval, :license_names_from_spec, :install_path, :decided_licenses
+    attr_reader :logger, :name, :version, :authors, :summary, :description, :children, :parents, :groups, :manual_approval, :license_names_from_spec, :install_path
 
     def self.license_names_from_standard_spec(spec)
       licenses = spec['licenses'] || [spec['license']].compact
@@ -127,7 +127,12 @@ module LicenseFinder
     end
 
     def licensing
-      Licensing.new(self)
+      Licensing.new(
+        self,
+        @decided_licenses,
+        -> { licenses_from_spec },
+        -> { license_files }
+      )
     end
 
     def decide_on_license(license)

--- a/lib/license_finder/package.rb
+++ b/lib/license_finder/package.rb
@@ -18,7 +18,7 @@ module LicenseFinder
   #   the constructor options
   # - otherwise, override #licenses_from_spec or #license_files
   class Package
-    attr_reader :logger, :name, :version, :authors, :summary, :description, :children, :parents, :groups, :manual_approval, :license_names_from_spec, :install_path
+    attr_reader :logger, :name, :version, :authors, :summary, :description, :children, :parents, :groups, :manual_approval, :license_names_from_spec, :install_path, :decided_licenses
 
     def self.license_names_from_standard_spec(spec)
       licenses = spec['licenses'] || [spec['license']].compact
@@ -127,7 +127,7 @@ module LicenseFinder
     end
 
     def licensing
-      Licensing.new(self, @decided_licenses, licenses_from_spec, license_files)
+      Licensing.new(self)
     end
 
     def decide_on_license(license)

--- a/lib/license_finder/package_utils/licensing.rb
+++ b/lib/license_finder/package_utils/licensing.rb
@@ -3,7 +3,7 @@
 require 'license_finder/package_utils/activation'
 
 module LicenseFinder
-  Licensing = Struct.new(:package, :decided_licenses, :licenses_from_spec, :license_files) do
+  Licensing = Struct.new(:package) do
     # Implements the algorithm for choosing the right set of licenses from
     # among the various sources of licenses we know about.  In order of
     # priority, licenses come from decisions, package specs, or package files.
@@ -17,17 +17,17 @@ module LicenseFinder
     end
 
     def activations_from_decisions
-      @activations_from_decisions ||= decided_licenses
+      @activations_from_decisions ||= package.decided_licenses
                .map { |license| Activation::FromDecision.new(package, license) }
     end
 
     def activations_from_spec
-      @activations_from_spec ||= licenses_from_spec
+      @activations_from_spec ||= package.licenses_from_spec
                .map { |license| Activation::FromSpec.new(package, license) }
     end
 
     def activations_from_files
-      @activations_from_files ||= license_files
+      @activations_from_files ||= package.license_files
                .group_by(&:license)
                .map { |license, files| Activation::FromFiles.new(package, license, files) }
     end

--- a/lib/license_finder/package_utils/licensing.rb
+++ b/lib/license_finder/package_utils/licensing.rb
@@ -3,7 +3,7 @@
 require 'license_finder/package_utils/activation'
 
 module LicenseFinder
-  Licensing = Struct.new(:package) do
+  Licensing = Struct.new(:package, :decided_licenses, :licenses_from_spec_proc, :license_files_proc) do
     # Implements the algorithm for choosing the right set of licenses from
     # among the various sources of licenses we know about.  In order of
     # priority, licenses come from decisions, package specs, or package files.
@@ -17,17 +17,17 @@ module LicenseFinder
     end
 
     def activations_from_decisions
-      @activations_from_decisions ||= package.decided_licenses
+      @activations_from_decisions ||= decided_licenses
                .map { |license| Activation::FromDecision.new(package, license) }
     end
 
     def activations_from_spec
-      @activations_from_spec ||= package.licenses_from_spec
+      @activations_from_spec ||= licenses_from_spec_proc.call
                .map { |license| Activation::FromSpec.new(package, license) }
     end
 
     def activations_from_files
-      @activations_from_files ||= package.license_files
+      @activations_from_files ||= license_files_proc.call
                .group_by(&:license)
                .map { |license, files| Activation::FromFiles.new(package, license, files) }
     end


### PR DESCRIPTION
Optimize license_finder behavior for package by skipping unnecessary activations when license info is already resolved via decisions or spec

### Motivation
In Yarn v1, packages often include numerous transitive dependencies that get placed within the node_modules folder.  license_finder attempts a deep scan of the file system, looking for license-related files (e.g., LICENSE, COPYING, README) in these nested folders.

This scanning process is especially expensive for deeply nested packages and can take up to 10 seconds per package in the worst case. By skipping the activation step when license information has already been resolved via decisions or spec metadata, we significantly reduce unnecessary file system traversal and improve overall performance.