### PR TITLE
Bump rubyzip dependency to 3

### DIFF
--- a/license_finder.gemspec
+++ b/license_finder.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'bundler'
   s.add_dependency 'csv', '~> 3.2'
-  s.add_dependency 'rubyzip', '>=1', '<3'
+  s.add_dependency 'rubyzip', '>=1', '<4'
   s.add_dependency 'thor', '~> 1.2'
   s.add_dependency 'tomlrb', '>= 1.3', '< 2.1'
   s.add_dependency 'with_env', '1.1.0'

--- a/spec/lib/license_finder/package_managers/nuget_spec.rb
+++ b/spec/lib/license_finder/package_managers/nuget_spec.rb
@@ -178,7 +178,7 @@ module LicenseFinder
           XML
           File.write('app/packages/ObscureDependency.nuspec', obscure_dependency_nuspec)
           Dir.chdir 'app/packages' do
-            Zip::File.open('ObscureDependency.1.3.15.nupkg', Zip::File::CREATE) do |zipfile|
+            Zip::File.open('ObscureDependency.1.3.15.nupkg', create: true) do |zipfile|
               zipfile.add('ObscureDependency.nuspec', 'ObscureDependency.nuspec')
             end
           end


### PR DESCRIPTION
- updated call for `Zip::File#open` in `nuget_spec` to use named arguments, should still work fine with <3 
- all of the current calls to RubyZip API should work without issues with version >=3, <4
- tests pass successfully

changes:
- bump rubyzip dependency to 3
- update license_finder.gemspec
- update call for Zip::File#open at nuget spec to use named arguments
- no other changes needed to calls for original rubyzip API